### PR TITLE
Only get templates from the child theme not from Blockbase

### DIFF
--- a/index.php
+++ b/index.php
@@ -138,6 +138,11 @@ GNU General Public License for more details.
 ";
 }
 
+// Switches the template directory to the stylesheet directory.
+function create_blockbase_theme_reset_template_directory() {
+	return get_stylesheet_directory();
+}
+
 /**
  * Creates an export of the current templates and
  * template parts from the site editor at the

--- a/index.php
+++ b/index.php
@@ -150,6 +150,11 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 		return new WP_Error( 'Zip Export not supported.' );
 	}
 
+	// The gutenberg_get_block_templates function will get the parent theme templates too
+	// By filtering get_template_directory and setting it to be the same as get_stylesheet_directory
+	// We ensure that only the child theme templates are exported
+	add_filter( 'template_directory', 'create_blockbase_theme_reset_template_directory' );
+
 	$zip = new ZipArchive();
 	$zip->open( $filename, ZipArchive::OVERWRITE );
 	$zip->addEmptyDir( $theme['slug'] );
@@ -176,9 +181,10 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 		);
 	}
 
-	// Add theme.json.
+	// Remove the filter we applied above.
+	remove_filter( 'template_directory', 'create_blockbase_theme_reset_template_directory' );
 
-	// TODO only get child theme settings not the parent.
+	// Add theme.json.
 	$zip->addFromString(
 		$theme['slug'] . '/theme.json',
 		wp_json_encode( gutenberg_edit_site_get_theme_json_for_export(), JSON_PRETTY_PRINT )


### PR DESCRIPTION
Previously, when creating a child Blockbase theme, all of the templates from Blockbase would be exported. Since the child theme inherits these already we only need to export any changes.

To test this, you will need to use the empty blockbase child theme in this PR: https://github.com/Automattic/themes/pull/4999

To test
- Switch to the Empty Blockbase Child
- Make changes to the templates
- Export a new theme using the Create Blockbase Child form
- Your theme should only contain the modified templates.