### PR TITLE
add all current theme's css to the generated one

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A WordPress plugin to create Blockbase child themes
 Find out more about Blockbase at [blockbasetheme.com](https://blockbasetheme.com)
 
 ### Step 1 – Setup
-Install and activate [Blockbase](https://github.com/Automattic/themes/tree/trunk/blockbase), and the [Create Blockbase Theme](https://github.com/Automattic/create-blockbase-theme) plugin.
+Install and activate [Blockbase](https://github.com/Automattic/themes/tree/trunk/blockbase) (or a Blockbase child theme if you want your new theme based on it instead), and the [Create Blockbase Theme](https://github.com/Automattic/create-blockbase-theme) plugin.
 
 ### Step 2 – Style Customizations
 Make changes to your site design using the Customizer and Site Editor. 

--- a/index.php
+++ b/index.php
@@ -98,12 +98,11 @@ function {$slug}_scripts() {
 add_action( 'wp_enqueue_scripts', '{$slug}_scripts' );";
 }
 
-function get_current_theme_css( $theme ){
+function blockbase_get_theme_css( $theme ){
 
 	$current_theme_css = '';
 	$current_theme = wp_get_theme( );
-
-	if ( $current_theme->exists() ){
+	if ( $current_theme->exists() && $current_theme->get( 'TextDomain' ) !== 'blockbase' ){
 		foreach ($current_theme->get_files('css', -1) as $key => $value) {
 			if (strpos($key, '.css') !== false ) {
 				if ( file_exists( $value ) ) {
@@ -119,15 +118,8 @@ function get_current_theme_css( $theme ){
 			}
 		}
 	}
-
 	return $current_theme_css;
 
-}
-
-function blockbase_get_theme_css( $theme ) {
-	if ( file_exists( get_stylesheet_directory() . '/assets/theme.css' ) ) {
-		return file_get_contents( get_stylesheet_directory() . '/assets/theme.css' );
-	}
 }
 
 function blockbase_get_readme_txt( $theme ) {
@@ -224,11 +216,10 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 		blockbase_get_style_css( $theme )
 	);
 
-	// Add theme.css combining the current theme's css and Blockbase's.
-	$new_theme_css = blockbase_get_theme_css( $theme ) . get_current_theme_css( $theme );
+	// Add theme.css combining all the current theme's css files.
 	$zip->addFromString(
 		$theme['slug'] . '/theme.css',
-		$new_theme_css
+		blockbase_get_theme_css( $theme )
 	);
 
 	// Add functions.php.

--- a/index.php
+++ b/index.php
@@ -104,17 +104,15 @@ function blockbase_get_theme_css( $theme ){
 	$current_theme = wp_get_theme( );
 	if ( $current_theme->exists() && $current_theme->get( 'TextDomain' ) !== 'blockbase' ){
 		foreach ($current_theme->get_files('css', -1) as $key => $value) {
-			if (strpos($key, '.css') !== false ) {
-				if ( file_exists( $value ) ) {
-					$current_theme_css .= "
+			if (strpos($key, '.css') !== false && file_exists( $value ) ) {
+				$current_theme_css .= "
 /*
 *
 * Styles from " . $current_theme->get_stylesheet() . "/" . $key . "
 *
 */
 ";
-					$current_theme_css .= file_get_contents( $value );
-				}
+				$current_theme_css .= file_get_contents( $value );
 			}
 		}
 	}


### PR DESCRIPTION
This PR gets the parent theme's CSS dynamically rather than assuming that it lives under `assets/theme.css` and adds any other .css files to it that are present on the theme we are building from.

To test this, try building a child of Quadrat. The generated CSS should contain both Blockbase's and Quadrat's CSS. I've added some comments so that the user can discern where everything is coming from.

Test this with Blockbase active and check that the theme.css file is empty (Blockbase's CSS is already being inherited)