### PR TITLE
Fixed 404 on theme.css file for generated children

### DIFF
--- a/index.php
+++ b/index.php
@@ -216,7 +216,7 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 
 	// Add theme.css combining all the current theme's css files.
 	$zip->addFromString(
-		$theme['slug'] . '/theme.css',
+		$theme['slug'] . '/assets/theme.css',
 		blockbase_get_theme_css( $theme )
 	);
 


### PR DESCRIPTION
The path where the theme.css file was being saved was wrong and it was causing a 404 don't he stylesheet. This PR fixes that.

To test it try a Quadrat child, before the patch you wouldn't see the header polygon, with it, it's back.