### PR TITLE
Remove the absolute path for the form

### DIFF
--- a/index.php
+++ b/index.php
@@ -190,8 +190,8 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 			continue;
 		}
 
-		// _remove_theme_attribute_from_content is provided by Gutenberg in the Site Editor's template export workflow.
-		$template->content = _remove_theme_attribute_from_content( $template->content );
+		// _remove_theme_attribute_in_block_template_content is provided by Gutenberg in the Site Editor's template export workflow.
+		$template->content = _remove_theme_attribute_in_block_template_content( $template->content );
 		$zip->addFromString(
 			$theme['slug'] . '/block-templates/' . $template->slug . '.html',
 			$template->content
@@ -292,7 +292,7 @@ function create_blockbase_theme_page() {
 		<div class="wrap">
 			<h2><?php _e('Create Blockbase Theme', 'create-blockbase-theme'); ?></h2>
 			<p><?php _e('Save your current block templates and theme.json settings as a new theme.', 'create-blockbase-theme'); ?></p>
-			<form method="get" action="/wp-admin/themes.php">
+			<form method="get">
 				<label><?php _e('Theme name', 'create-blockbase-theme'); ?><br /><input placeholder="<?php _e('Blockbase', 'create-blockbase-theme'); ?>" type="text" name="theme[name]" class="regular-text" /></label><br /><br />
 				<label><?php _e('Theme description', 'create-blockbase-theme'); ?><br /><textarea placeholder="<?php _e('Blockbase is a simple theme that supports full-site editing. Use it to build something beautiful.', 'create-blockbase-theme'); ?>" rows="4" cols="50" name="theme[description]" class="regular-text"></textarea></label><br /><br />
 				<label><?php _e('Theme URI', 'create-blockbase-theme'); ?><br /><input placeholder="https://github.com/automattic/themes/tree/trunk/blockbase" type="text" name="theme[uri]" class="regular-text code" /></label><br /><br />

--- a/index.php
+++ b/index.php
@@ -190,8 +190,8 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 			continue;
 		}
 
-		// _remove_theme_attribute_in_block_template_content is provided by Gutenberg in the Site Editor's template export workflow.
-		$template->content = _remove_theme_attribute_in_block_template_content( $template->content );
+		// _remove_theme_attribute_from_content is provided by Gutenberg in the Site Editor's template export workflow.
+		$template->content = _remove_theme_attribute_from_content( $template->content );
 		$zip->addFromString(
 			$theme['slug'] . '/block-templates/' . $template->slug . '.html',
 			$template->content


### PR DESCRIPTION
This fixes #12.

It also changes a function name to align with the latest version of Gutenberg.