### PR TITLE
Fix gutenberg function fatal

### DIFF
--- a/index.php
+++ b/index.php
@@ -190,8 +190,8 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 			continue;
 		}
 
-		// _remove_theme_attribute_from_content is provided by Gutenberg in the Site Editor's template export workflow.
-		$template->content = _remove_theme_attribute_from_content( $template->content );
+		// _remove_theme_attribute_in_block_template_content is provided by Gutenberg in the Site Editor's template export workflow.
+		$template->content = _remove_theme_attribute_in_block_template_content( $template->content );
 		$zip->addFromString(
 			$theme['slug'] . '/block-templates/' . $template->slug . '.html',
 			$template->content


### PR DESCRIPTION
After https://github.com/WordPress/gutenberg/pull/36559 the function `_remove_theme_attribute_from_content` has been renamed to `_remove_theme_attribute_in_block_template_content` and I think it's going to stay that way when backported to core. This PR resolves fatals related to this rename happening on GB 12.0.0