### PR TITLE
Remove the code to replace - with _

### DIFF
--- a/index.php
+++ b/index.php
@@ -262,7 +262,7 @@ function gutenberg_edit_site_export_theme( $theme ) {
 	$theme['author'] = sanitize_text_field( $theme['author'] );
 	$theme['author_uri'] = sanitize_text_field( $theme['author_uri'] );
 
-	$theme['slug'] = str_replace( '-', '_', sanitize_title( $theme['name'] ) ); // Slugs can't contain -.
+	$theme['slug'] = sanitize_title( $theme['name'] );
 	// Create ZIP file in the temporary directory.
 	$filename = tempnam( get_temp_dir(), $theme['slug'] );
 	gutenberg_edit_site_export_theme_create_zip( $filename, $theme );


### PR DESCRIPTION
When we were using the theme name in function calls we needed it to have _s not -s. Now we don't do that we can use - according to themes convention.