### PR TITLE
Removes an errant var_dump call

### DIFF
--- a/index.php
+++ b/index.php
@@ -31,7 +31,6 @@ function flatten_theme_json( $data ) {
 			return $data['user'];
 		}
 		if ( array_key_exists( 'custom', $data ) ) {
-			var_dump( $data['custom'] );
 			return $data['custom'];
 		}
 


### PR DESCRIPTION
Ran into issues with this plugin and realized that there's a `var_dump` in the code that was outputting before the headers were sent. This PR removes that line.