### PR TITLE
Generate themes from any block theme

### DIFF
--- a/index.php
+++ b/index.php
@@ -145,8 +145,8 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 	$zip = new ZipArchive();
 	$zip->open( $filename, ZipArchive::OVERWRITE );
 	$zip->addEmptyDir( $theme['slug'] );
-	$zip->addEmptyDir( $theme['slug'] . '/block-templates' );
-	$zip->addEmptyDir( $theme['slug'] . '/block-template-parts' );
+	$zip->addEmptyDir( $theme['slug'] . '/templates' );
+	$zip->addEmptyDir( $theme['slug'] . '/parts' );
 
 	// Load templates into the zip file.
 	$templates = gutenberg_get_block_templates();
@@ -166,7 +166,7 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 			$template->content = _remove_theme_attribute_from_content( $template->content );
 		}
 		$zip->addFromString(
-			$theme['slug'] . '/block-templates/' . $template->slug . '.html',
+			$theme['slug'] . '/templates/' . $template->slug . '.html',
 			$template->content
 		);
 	}
@@ -182,7 +182,7 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 		}
 
 		$zip->addFromString(
-			$theme['slug'] . '/block-template-parts/' . $template_part->slug . '.html',
+			$theme['slug'] . '/parts/' . $template_part->slug . '.html',
 			$template_part->content
 		);
 	}

--- a/index.php
+++ b/index.php
@@ -150,7 +150,7 @@ function blockbase_get_style_css( $theme ) {
 	"Author URI: {$author_uri}\n" .
 	"Description: {$description}\n" .
 	"Requires at least: 5.8\n" .
-	"Tested up to: 5.8\n" .
+	"Tested up to: 5.9\n" .
 	"Requires PHP: 5.7\n" .
 	"Version: 0.0.1\n" .
 	"License: GNU General Public License v2 or later\n" .

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ function augment_gutenberg_with_utilities() {
 									$sluglist[] = $item['slug'];
 									$filtered[] = $item;
 								}
-							} 
+							}
 							else {
 								$filtered[] = $item;
 							}
@@ -58,7 +58,7 @@ function augment_gutenberg_with_utilities() {
 						return MY_Theme_JSON_Resolver::flatten_theme_json($data['custom'], $name);
 					}
 
-					// When there is THEME but no CUSTOM return theme 
+					// When there is THEME but no CUSTOM return theme
 					if ( array_key_exists( 'theme', $data ) ) {
 						return MY_Theme_JSON_Resolver::flatten_theme_json($data['theme'], $name);
 					}
@@ -75,9 +75,9 @@ function augment_gutenberg_with_utilities() {
 
 		/**
 		 * Export the combined (and flattened) THEME and CUSTOM data.
-		 * 
+		 *
 		 * @param string $content ['all', 'current', 'user'] Determines which settings content to include in the export.
-		 * All options include user settings.  
+		 * All options include user settings.
 		 * 'current' will include settings from the currently installed theme but NOT from the parent theme.
 		 * 'all' will include settings from the current theme as well as the parent theme (if it has one)
 		 */
@@ -137,13 +137,13 @@ function gutenberg_edit_site_get_theme_json_for_export( $theme ) {
 function create_block_theme_get_theme_css( $theme ) {
 	// NOTE: Themes that keep their CSS in a structure other than Blockbase's will need something different...
 
-	// if we are building a STANDALONE theme we need the CURRENT theme's CSS OR ponyfill.css (if our theme is Blockbase)	
+	// if we are building a STANDALONE theme we need the CURRENT theme's CSS OR ponyfill.css (if our theme is Blockbase)
 	// if we are building a GRANDCHILD theme we need the CURRENT theme's CSS
 	if ($theme['type'] == 'block' || is_child_theme()) {
 		if ( get_stylesheet() === 'blockbase' ) {
 			//return Blockbase's /assets/ponyfill.css
 			return file_get_contents(get_stylesheet_directory() . '/assets/ponyfill.css');
-		} 
+		}
 		else if (file_exists(get_stylesheet_directory() . '/assets/theme.css')) {
 			//return the current theme's /assets/theme.css
 			return file_get_contents(get_stylesheet_directory() . '/assets/theme.css');
@@ -375,45 +375,26 @@ add_action(
 function create_blockbase_theme_page() {
 	?>
 		<div class="wrap">
-<<<<<<< HEAD
 			<h2><?php _e('Create Block Theme', 'create-block-theme'); ?></h2>
 			<p><?php _e('Save your current block templates and theme.json settings as a new theme.', 'create-block-theme'); ?></p>
+			<p><?php wp_kses_post( _e( 'The new theme will be based on whatever theme you have active at the moment. <br />If you want a fresh start, try using <a href="https://github.com/WordPress/theme-experiments/tree/master/emptytheme">Empty Theme</a> as a base.', 'create-block-theme' ) ); ?></p>
+			<p><?php _e('The current active theme is:', 'create-block-theme'); ?> <?php echo wp_get_theme()->get('Name'); ?></p>
 			<form method="get">
-			<label><?php _e('Theme name', 'create-block-theme'); ?><br /><input placeholder="<?php _e('Blockbase', 'create-block-theme'); ?>" type="text" name="theme[name]" class="regular-text" required /></label><br /><br />
+				<label><?php _e('Theme name', 'create-block-theme'); ?><br /><input placeholder="<?php _e('Blockbase', 'create-block-theme'); ?>" type="text" name="theme[name]" class="regular-text" required /></label><br /><br />
 				<label><?php _e('Theme description', 'create-block-theme'); ?><br /><textarea placeholder="<?php _e('Blockbase is a simple theme that supports full-site editing. Use it to build something beautiful.', 'create-block-theme'); ?>" rows="4" cols="50" name="theme[description]" class="regular-text"></textarea></label><br /><br />
-				<p>The new theme will be based on whatever theme you have active at the moment. <br />If you want a fresh start, try using <a href="https://github.com/WordPress/theme-experiments/tree/master/emptytheme">Empty Theme</a> as a base.</p>
-				<label><input checked value="block" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Standalone theme', 'create-blockbase-theme'); ?></label><br /><br />
-				<label><input value="child" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Child theme of the current active theme', 'create-blockbase-theme'); ?></label><br /><br />
-				<label><input checked value="block" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Standalone theme', 'create-block-theme'); ?></label><br /><br />
-				<label><input value="child" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Child theme (make sure the parent theme is currently active)', 'create-blockbase-theme'); ?></label><br /><br />
-				<label><?php _e('Theme URI', 'create-block-theme'); ?><br /><input placeholder="https://github.com/automattic/themes/tree/trunk/blockbase" type="text" name="theme[uri]" class="regular-text code" /></label><br /><br />
-				<label><?php _e('Author', 'create-block-theme'); ?><br /><input placeholder="<?php _e('Automattic', 'create-block-theme'); ?>" type="text" name="theme[author]" class="regular-text" /></label><br /><br />
-				<label><?php _e('Author URI', 'create-block-theme'); ?><br /><input placeholder="<?php _e('https://automattic.com/', 'create-block-theme'); ?>" type="text" name="theme[author_uri]" class="regular-text code" /></label><br /><br />
-				<input type="hidden" name="page" value="create-block-theme" />
-				<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_block_theme' ); ?>" />
-				<input type="submit" value="<?php _e('Create block theme', 'create-block-theme'); ?>" class="button button-primary" />
-=======
-			<h2><?php _e('Create Block Theme', 'create-blockbase-theme'); ?></h2>
-			<p><?php _e('Save your current block templates and theme.json settings as a new theme.', 'create-blockbase-theme'); ?></p>
-			<p><?php wp_kses_post( _e( 'The new theme will be based on whatever theme you have active at the moment. <br />If you want a fresh start, try using <a href="https://github.com/WordPress/theme-experiments/tree/master/emptytheme">Empty Theme</a> as a base.', 'create-blockbase-theme' ) ); ?></p>
-			<p><?php _e('The current active theme is:', 'create-blockbase-theme'); ?> <?php echo wp_get_theme()->get('Name'); ?></p>
-			<form method="get">
-				<label><?php _e('Theme name', 'create-blockbase-theme'); ?><br /><input placeholder="<?php _e('Blockbase', 'create-blockbase-theme'); ?>" type="text" name="theme[name]" class="regular-text" required /></label><br /><br />
-				<label><?php _e('Theme description', 'create-blockbase-theme'); ?><br /><textarea placeholder="<?php _e('Blockbase is a simple theme that supports full-site editing. Use it to build something beautiful.', 'create-blockbase-theme'); ?>" rows="4" cols="50" name="theme[description]" class="regular-text"></textarea></label><br /><br />
 				<?php if ( ! is_child_theme() ): ?>
 				<label><input checked value="block" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Standalone theme', 'create-blockbase-theme'); ?></label><br /><br />
 				<label><input value="child" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Child theme of the current active theme', 'create-blockbase-theme'); ?></label><br /><br />
 				<?php else: ?>
 				<input type="hidden" name="theme[type]" value="child" />
 				<?php endif; ?>
-				<label><?php _e('Theme URI', 'create-blockbase-theme'); ?><br /><input placeholder="https://github.com/automattic/themes/tree/trunk/blockbase" type="text" name="theme[uri]" class="regular-text code" /></label><br /><br />
-				<label><?php _e('Author', 'create-blockbase-theme'); ?><br /><input placeholder="<?php _e('Automattic', 'create-blockbase-theme'); ?>" type="text" name="theme[author]" class="regular-text" /></label><br /><br />
-				<label><?php _e('Author URI', 'create-blockbase-theme'); ?><br /><input placeholder="<?php _e('https://automattic.com/', 'create-blockbase-theme'); ?>" type="text" name="theme[author_uri]" class="regular-text code" /></label><br /><br />
-				<input type="hidden" name="page" value="create-blockbase-theme" />
+				<label><?php _e('Theme URI', 'create-block-theme'); ?><br /><input placeholder="https://github.com/automattic/themes/tree/trunk/blockbase" type="text" name="theme[uri]" class="regular-text code" /></label><br /><br />
+				<label><?php _e('Author', 'create-block-theme'); ?><br /><input placeholder="<?php _e('Automattic', 'create-block-theme'); ?>" type="text" name="theme[author]" class="regular-text" /></label><br /><br />
+				<label><?php _e('Author URI', 'create-block-theme'); ?><br /><input placeholder="<?php _e('https://automattic.com/', 'create-block-theme'); ?>" type="text" name="theme[author_uri]" class="regular-text code" /></label><br /><br />
+				<input type="hidden" name="page" value="create-block-theme" />
 				<input type="hidden" name="theme[grandchild]" value="<?php echo is_child_theme(); ?>" />
-				<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_blockbase_theme' ); ?>" />
-				<input type="submit" value="<?php _e('Create Block theme', 'create-blockbase-theme'); ?>" class="button button-primary" />
->>>>>>> d5ea34f (hide options when active theme is a child theme)
+				<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_block_theme' ); ?>" />
+				<input type="submit" value="<?php _e('Create block theme', 'create-block-theme'); ?>" class="button button-primary" />
 			</form>
 		</div>
 	<?php

--- a/index.php
+++ b/index.php
@@ -274,6 +274,9 @@ function create_blockbase_theme_page() {
 			<form method="get">
 			<label><?php _e('Theme name', 'create-block-theme'); ?><br /><input placeholder="<?php _e('Blockbase', 'create-block-theme'); ?>" type="text" name="theme[name]" class="regular-text" required /></label><br /><br />
 				<label><?php _e('Theme description', 'create-block-theme'); ?><br /><textarea placeholder="<?php _e('Blockbase is a simple theme that supports full-site editing. Use it to build something beautiful.', 'create-block-theme'); ?>" rows="4" cols="50" name="theme[description]" class="regular-text"></textarea></label><br /><br />
+				<p>The new theme will be based on whatever theme you have active at the moment. <br />If you want a fresh start, try using <a href="https://github.com/WordPress/theme-experiments/tree/master/emptytheme">Empty Theme</a> as a base.</p>
+				<label><input checked value="block" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Standalone theme', 'create-blockbase-theme'); ?></label><br /><br />
+				<label><input value="child" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Child theme of the current active theme', 'create-blockbase-theme'); ?></label><br /><br />
 				<label><input checked value="block" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Standalone theme', 'create-block-theme'); ?></label><br /><br />
 				<label><input value="child" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Child theme (make sure the parent theme is currently active)', 'create-blockbase-theme'); ?></label><br /><br />
 				<label><?php _e('Theme URI', 'create-block-theme'); ?><br /><input placeholder="https://github.com/automattic/themes/tree/trunk/blockbase" type="text" name="theme[uri]" class="regular-text code" /></label><br /><br />

--- a/index.php
+++ b/index.php
@@ -53,14 +53,9 @@ function flatten_theme_json( $data ) {
 	return $data;
 }
 
-function gutenberg_edit_site_get_theme_json_for_export() {
-
-	$base_theme = wp_get_theme()->get('TextDomain');
+function gutenberg_edit_site_get_theme_json_for_export($theme) {
 	$user_theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_user_data();
-
-	if ( $base_theme === 'blockbase' ) {
-		return flatten_theme_json( $user_theme_json->get_raw_data() );
-	}
+	return flatten_theme_json( $user_theme_json->get_raw_data() );
 }
 
 function blockbase_get_style_css( $theme ) {
@@ -197,7 +192,7 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 	// TODO only get child theme settings not the parent.
 	$zip->addFromString(
 		$theme['slug'] . '/theme.json',
-		wp_json_encode( gutenberg_edit_site_get_theme_json_for_export(), JSON_PRETTY_PRINT )
+		wp_json_encode( gutenberg_edit_site_get_theme_json_for_export($theme), JSON_PRETTY_PRINT )
 	);
 
 	// Add style.css.

--- a/index.php
+++ b/index.php
@@ -277,8 +277,10 @@ function create_blockbase_theme_page() {
 			<h2><?php _e('Create Block Theme', 'create-block-theme'); ?></h2>
 			<p><?php _e('Save your current block templates and theme.json settings as a new theme.', 'create-block-theme'); ?></p>
 			<form method="get">
-				<label><?php _e('Theme name', 'create-block-theme'); ?><br /><input placeholder="<?php _e('Blockbase', 'create-block-theme'); ?>" type="text" name="theme[name]" class="regular-text" required /></label><br /><br />
+			<label><?php _e('Theme name', 'create-block-theme'); ?><br /><input placeholder="<?php _e('Blockbase', 'create-block-theme'); ?>" type="text" name="theme[name]" class="regular-text" required /></label><br /><br />
 				<label><?php _e('Theme description', 'create-block-theme'); ?><br /><textarea placeholder="<?php _e('Blockbase is a simple theme that supports full-site editing. Use it to build something beautiful.', 'create-block-theme'); ?>" rows="4" cols="50" name="theme[description]" class="regular-text"></textarea></label><br /><br />
+				<label><input checked value="block" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Standalone theme', 'create-block-theme'); ?></label><br /><br />
+				<label><input value="child" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Child theme (make sure the parent theme is currently active)', 'create-blockbase-theme'); ?></label><br /><br />
 				<label><?php _e('Theme URI', 'create-block-theme'); ?><br /><input placeholder="https://github.com/automattic/themes/tree/trunk/blockbase" type="text" name="theme[uri]" class="regular-text code" /></label><br /><br />
 				<label><?php _e('Author', 'create-block-theme'); ?><br /><input placeholder="<?php _e('Automattic', 'create-block-theme'); ?>" type="text" name="theme[author]" class="regular-text" /></label><br /><br />
 				<label><?php _e('Author URI', 'create-block-theme'); ?><br /><input placeholder="<?php _e('https://automattic.com/', 'create-block-theme'); ?>" type="text" name="theme[author_uri]" class="regular-text code" /></label><br /><br />

--- a/index.php
+++ b/index.php
@@ -70,6 +70,7 @@ function blockbase_get_style_css( $theme ) {
 	$uri = $theme['uri'];
 	$author = $theme['author'];
 	$author_uri = $theme['author_uri'];
+	$template = $theme['type'] == 'child' ? 'Template: '. wp_get_theme()->get( 'Name' ) : '';
 
 	return "/*
 Theme Name: {$name}
@@ -83,7 +84,7 @@ Requires PHP: 5.7
 Version: 0.0.1
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
-Template: blockbase
+{$template}
 Text Domain: {$slug}
 Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 */";
@@ -319,15 +320,19 @@ function blockbase_save_theme() {
 			return add_action( 'admin_notices', 'create_blockbase_child_admin_notice_error' );
 		}
 
+		if( $_GET['theme']['type'] === 'child' && !wp_is_block_theme() ) {
+			return add_action( 'admin_notices', 'create_blockbase_child_admin_notice_error_wrong_parent' );
+		}
+
 		add_action( 'admin_notices', 'create_blockbase_child_admin_notice_success' );
 		gutenberg_edit_site_export_theme( $_GET['theme'] );
 	}
 }
 add_action( 'admin_init', 'blockbase_save_theme');
 
-function create_blockbase_child_admin_notice_error_wrong_theme() {
+function create_blockbase_child_admin_notice_error_wrong_parent() {
 	$class = 'notice notice-error';
-	$message = __( 'You can only create a Blockbase child theme from Blockbase. Please switch your theme to Blockbase.', 'create-block-theme' );
+	$message = __( 'You can only create a child theme from a Block theme. Please switch your theme to a Block theme.', 'create-blockbase-theme' );
 
 	printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
 }

--- a/index.php
+++ b/index.php
@@ -12,56 +12,125 @@
  * Text Domain: create-block-theme
  */
 
-/**
- * REST endpoint for exporting the contents of the Edit Site Page editor.
- *
- * @package gutenberg
- */
+function augment_gutenberg_with_utilities() {
 
+	//Ultimately it is desireable for Gutenberg to have this functionality natively.
+	// In the meantime we are patching the functionality we are expecting into the Theme JSON Resolver here
 
-/*
-	'Flatten' theme data that expresses both theme and user data.
-	change property.[user|theme].value to property.value
-	Uses user value if available, otherwise theme value
-	I feel like there should be a function to do this in Gutenberg but I couldn't find it
-*/
-function flatten_theme_json( $data ) {
-	if ( is_array( $data ) ) {
-		if ( array_key_exists( 'user', $data ) ) {
-			return $data['user'];
-		}
-		if ( array_key_exists( 'custom', $data ) ) {
-			return $data['custom'];
-		}
+	class MY_Theme_JSON_Resolver extends WP_Theme_JSON_Resolver_Gutenberg {
 
-		if ( array_key_exists( 'theme', $data ) ) {
-			if ( array_key_exists( 'user', $data ) ) {
-				return $data['user'];
+		/**
+		 * 'Flatten' theme data that expresses both theme and user data.
+		 * change property.[custom|theme].value to property.value
+		 * Uses custom value if available, otherwise theme value
+		 * I feel like there should be a function to do this in Gutenberg but I couldn't find it
+		 */
+		private static function flatten_theme_json( $data, $name ) {
+			if ( is_array( $data ) ) {
+
+				// 'settings' can have a 'custom' object that is different and should not be processed in the same way
+				// as values that could be represented as both theme and user (user data being 'custom')
+				if ( $name !== 'settings' ) {
+
+					// When there is BOTH custom AND THEME combine the two
+					if ( array_key_exists( 'custom', $data ) && array_key_exists( 'theme', $data ) ) {
+						$merged = array_merge( $data['custom'], $data['theme'] );
+						// eliminate values with duplicate slugs
+						// TODO: This could probably be done better...
+						$filtered = array();
+						$sluglist = array();
+						foreach ( $merged as $item ) {
+							if( array_key_exists('slug', $item) ) {
+								if( ! in_array($item['slug'], $sluglist) ) {
+									$sluglist[] = $item['slug'];
+									$filtered[] = $item;
+								}
+							} 
+							else {
+								$filtered[] = $item;
+							}
+						}
+						return MY_Theme_JSON_Resolver::flatten_theme_json($filtered, $name);
+					}
+
+					// When there is CUSTOM but no THEME return custom
+					if ( array_key_exists( 'custom', $data ) ) {
+						return MY_Theme_JSON_Resolver::flatten_theme_json($data['custom'], $name);
+					}
+
+					// When there is THEME but no CUSTOM return theme 
+					if ( array_key_exists( 'theme', $data ) ) {
+						return MY_Theme_JSON_Resolver::flatten_theme_json($data['theme'], $name);
+					}
+
+				}
+
+				foreach( $data as $node_name => $node_value  ) {
+					$data[ $node_name ] = MY_Theme_JSON_Resolver::flatten_theme_json( $node_value, $node_name );
+				}
 			}
-			if ( array_key_exists( 'custom', $data ) ) {
-				return $data['custom'];
+
+			return $data;
+		}
+
+		/**
+		 * Export the combined (and flattened) THEME and CUSTOM data.
+		 * 
+		 * @param string $content ['all', 'current', 'user'] Determines which settings content to include in the export.
+		 * All options include user settings.  
+		 * 'current' will include settings from the currently installed theme but NOT from the parent theme.
+		 * 'all' will include settings from the current theme as well as the parent theme (if it has one)
+		 */
+		public static function export_theme_data( $content ) {
+
+	        	$theme = new WP_Theme_JSON_Gutenberg();
+
+			if ( $content === 'all' && wp_get_theme()->parent() ) {
+				// Get parent theme.json.
+				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
+				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
+				$parent_theme           = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
+				$theme->merge ($parent_theme);
 			}
 
-			return $data['theme'];
+			if ( $content === 'all' || $content === 'current' ) {
+	        		$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
+	        		$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
+				$theme_theme     = new WP_Theme_JSON_Gutenberg( $theme_json_data );
+ 				$theme->merge( $theme_theme );
+			}
+
+	        	$theme->merge( static::get_user_data() );
+
+			$data = MY_Theme_JSON_Resolver::flatten_theme_json($theme->get_raw_data(), null);
+
+			// die(json_encode($data));
+
+			return $data;
+
 		}
 
-		foreach( $data as $node_name => $node_value  ) {
-			$data[ $node_name ] = flatten_theme_json( $node_value );
-		}
 	}
-
-	return $data;
 }
 
-function gutenberg_edit_site_get_theme_json_for_export( $theme ) {
-	$user_theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_user_data();
-	$theme_theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data();
+add_action( 'plugins_loaded', 'augment_gutenberg_with_utilities' );
 
-	//for grand children or standalone themes we want to copy the user data + the active theme data too
-	if(  $theme['grandchild'] || $theme['type'] == 'block' ) {
-		return $theme_theme_json->get_raw_data();
+function gutenberg_edit_site_get_theme_json_for_export( $theme ) {
+
+	// For STANDALONE themes we want all of the user and theme settings (including current and parent)
+	if ($theme['type'] == 'block') {
+		return MY_Theme_JSON_Resolver::export_theme_data('all');
 	}
-	return flatten_theme_json( $user_theme_json->get_raw_data() );
+
+	// For GRANDCHILDREN themes we want all of the CURRENT theme settings, the USER theme settings but NOT the PARENT settings
+	// (since those will continue to be provided by the parent)
+	if ( $theme['grandchild']) {
+		return MY_Theme_JSON_Resolver::export_theme_data('current');
+	}
+
+	// For CHILD themes we only want the USER settings
+	return MY_Theme_JSON_Resolver::export_theme_data('user');
+
 }
 
 function blockbase_get_style_css( $theme ) {

--- a/index.php
+++ b/index.php
@@ -65,24 +65,24 @@ function blockbase_get_style_css( $theme ) {
 	$uri = $theme['uri'];
 	$author = $theme['author'];
 	$author_uri = $theme['author_uri'];
-	$template = $theme['type'] == 'child' ? 'Template: '. wp_get_theme()->get( 'Name' ) : '';
+	$template = $theme['type'] == 'child' ? "Template: ". wp_get_theme()->get( 'Name' ) ."\n" : "";
 
-	return "/*
-Theme Name: {$name}
-Theme URI: {$uri}
-Author: {$author}
-Author URI: {$author_uri}
-Description: {$description}
-Requires at least: 5.8
-Tested up to: 5.8
-Requires PHP: 5.7
-Version: 0.0.1
-License: GNU General Public License v2 or later
-License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
-{$template}
-Text Domain: {$slug}
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
-*/";
+	return "/*\n" .
+	"Theme Name: {$name}\n" .
+	"Theme URI: {$uri}\n" .
+	"Author: {$author}\n" .
+	"Author URI: {$author_uri}\n" .
+	"Description: {$description}\n" .
+	"Requires at least: 5.8\n" .
+	"Tested up to: 5.8\n" .
+	"Requires PHP: 5.7\n" .
+	"Version: 0.0.1\n" .
+	"License: GNU General Public License v2 or later\n" .
+	"License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE\n" .
+	$template .
+	"Text Domain: {$slug}\n" .
+	"Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks\n" .
+	"*/";
 }
 
 function blockbase_get_readme_txt( $theme ) {

--- a/index.php
+++ b/index.php
@@ -124,7 +124,8 @@ function gutenberg_edit_site_get_theme_json_for_export( $theme ) {
 
 	// For GRANDCHILDREN themes we want all of the CURRENT theme settings, the USER theme settings but NOT the PARENT settings
 	// (since those will continue to be provided by the parent)
-	if ( $theme['grandchild']) {
+	// If the theme we are building from is a child theme then we are building a grandchild theme
+	if ( is_child_theme() ) {
 		return MY_Theme_JSON_Resolver::export_theme_data('current');
 	}
 
@@ -458,7 +459,7 @@ function create_blockbase_child_admin_notice_success() {
 
 function create_blockbase_get_new_parent( $theme ) {
 
-	if( $theme['grandchild'] == true ) {
+	if( is_child_theme() ) {
 		return wp_get_theme()->get( 'Template' );
 	} elseif( $theme['type'] == 'child' ) {
 		return wp_get_theme()->get( 'TextDomain' );

--- a/index.php
+++ b/index.php
@@ -65,7 +65,7 @@ function blockbase_get_style_css( $theme ) {
 	$uri = $theme['uri'];
 	$author = $theme['author'];
 	$author_uri = $theme['author_uri'];
-	$template = $theme['type'] == 'child' ? "Template: ". wp_get_theme()->get( 'Name' ) ."\n" : "";
+	$template = !create_blockbase_get_new_parent( $theme ) ? "" : "Template: ". create_blockbase_get_new_parent( $theme ) ."\n";
 
 	return "/*\n" .
 	"Theme Name: {$name}\n" .
@@ -96,7 +96,7 @@ function blockbase_get_readme_txt( $theme ) {
 	return "=== {$name} ===
 Contributors: {$author}
 Requires at least: 5.8
-Tested up to: 5.8
+Tested up to: 5.9
 Requires PHP: 5.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -233,7 +233,8 @@ function gutenberg_edit_site_export_theme( $theme ) {
 	$theme['uri'] = sanitize_text_field( $theme['uri'] );
 	$theme['author'] = sanitize_text_field( $theme['author'] );
 	$theme['author_uri'] = sanitize_text_field( $theme['author_uri'] );
-
+	$theme['type'] = sanitize_text_field( $theme['type'] );
+	$theme['grandchild'] = filter_var( sanitize_text_field( $theme['grandchild'] ), FILTER_VALIDATE_BOOLEAN);
 	$theme['slug'] = sanitize_title( $theme['name'] );
 	// Create ZIP file in the temporary directory.
 	$filename = tempnam( get_temp_dir(), $theme['slug'] );
@@ -304,7 +305,7 @@ function create_blockbase_theme_page() {
 				<label><?php _e('Author', 'create-blockbase-theme'); ?><br /><input placeholder="<?php _e('Automattic', 'create-blockbase-theme'); ?>" type="text" name="theme[author]" class="regular-text" /></label><br /><br />
 				<label><?php _e('Author URI', 'create-blockbase-theme'); ?><br /><input placeholder="<?php _e('https://automattic.com/', 'create-blockbase-theme'); ?>" type="text" name="theme[author_uri]" class="regular-text code" /></label><br /><br />
 				<input type="hidden" name="page" value="create-blockbase-theme" />
-				<input type="hidden" name="grandchild" value="<?php echo is_child_theme() === 1 ? 'true' : 'false'; ?>" />
+				<input type="hidden" name="theme[grandchild]" value="<?php echo is_child_theme(); ?>" />
 				<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_blockbase_theme' ); ?>" />
 				<input type="submit" value="<?php _e('Create Block theme', 'create-blockbase-theme'); ?>" class="button button-primary" />
 >>>>>>> d5ea34f (hide options when active theme is a child theme)
@@ -370,4 +371,15 @@ function create_blockbase_child_admin_notice_success() {
 			<p><?php _e( 'New block theme created!', 'create-block-theme' ); ?></p>
 		</div>
 	<?php
+}
+
+function create_blockbase_get_new_parent( $theme ) {
+
+	if( $theme['grandchild'] == true ) {
+		return wp_get_theme()->get( 'Template' );
+	} elseif( $theme['type'] == 'child' ) {
+		return wp_get_theme()->get( 'TextDomain' );
+	}
+
+	return false;
 }

--- a/index.php
+++ b/index.php
@@ -269,6 +269,7 @@ add_action(
 function create_blockbase_theme_page() {
 	?>
 		<div class="wrap">
+<<<<<<< HEAD
 			<h2><?php _e('Create Block Theme', 'create-block-theme'); ?></h2>
 			<p><?php _e('Save your current block templates and theme.json settings as a new theme.', 'create-block-theme'); ?></p>
 			<form method="get">
@@ -285,6 +286,28 @@ function create_blockbase_theme_page() {
 				<input type="hidden" name="page" value="create-block-theme" />
 				<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_block_theme' ); ?>" />
 				<input type="submit" value="<?php _e('Create block theme', 'create-block-theme'); ?>" class="button button-primary" />
+=======
+			<h2><?php _e('Create Block Theme', 'create-blockbase-theme'); ?></h2>
+			<p><?php _e('Save your current block templates and theme.json settings as a new theme.', 'create-blockbase-theme'); ?></p>
+			<p><?php wp_kses_post( _e( 'The new theme will be based on whatever theme you have active at the moment. <br />If you want a fresh start, try using <a href="https://github.com/WordPress/theme-experiments/tree/master/emptytheme">Empty Theme</a> as a base.', 'create-blockbase-theme' ) ); ?></p>
+			<p><?php _e('The current active theme is:', 'create-blockbase-theme'); ?> <?php echo wp_get_theme()->get('Name'); ?></p>
+			<form method="get">
+				<label><?php _e('Theme name', 'create-blockbase-theme'); ?><br /><input placeholder="<?php _e('Blockbase', 'create-blockbase-theme'); ?>" type="text" name="theme[name]" class="regular-text" required /></label><br /><br />
+				<label><?php _e('Theme description', 'create-blockbase-theme'); ?><br /><textarea placeholder="<?php _e('Blockbase is a simple theme that supports full-site editing. Use it to build something beautiful.', 'create-blockbase-theme'); ?>" rows="4" cols="50" name="theme[description]" class="regular-text"></textarea></label><br /><br />
+				<?php if ( ! is_child_theme() ): ?>
+				<label><input checked value="block" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Standalone theme', 'create-blockbase-theme'); ?></label><br /><br />
+				<label><input value="child" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Child theme of the current active theme', 'create-blockbase-theme'); ?></label><br /><br />
+				<?php else: ?>
+				<input type="hidden" name="theme[type]" value="child" />
+				<?php endif; ?>
+				<label><?php _e('Theme URI', 'create-blockbase-theme'); ?><br /><input placeholder="https://github.com/automattic/themes/tree/trunk/blockbase" type="text" name="theme[uri]" class="regular-text code" /></label><br /><br />
+				<label><?php _e('Author', 'create-blockbase-theme'); ?><br /><input placeholder="<?php _e('Automattic', 'create-blockbase-theme'); ?>" type="text" name="theme[author]" class="regular-text" /></label><br /><br />
+				<label><?php _e('Author URI', 'create-blockbase-theme'); ?><br /><input placeholder="<?php _e('https://automattic.com/', 'create-blockbase-theme'); ?>" type="text" name="theme[author_uri]" class="regular-text code" /></label><br /><br />
+				<input type="hidden" name="page" value="create-blockbase-theme" />
+				<input type="hidden" name="grandchild" value="<?php echo is_child_theme() === 1 ? 'true' : 'false'; ?>" />
+				<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_blockbase_theme' ); ?>" />
+				<input type="submit" value="<?php _e('Create Block theme', 'create-blockbase-theme'); ?>" class="button button-primary" />
+>>>>>>> d5ea34f (hide options when active theme is a child theme)
 			</form>
 		</div>
 	<?php

--- a/index.php
+++ b/index.php
@@ -53,7 +53,7 @@ function flatten_theme_json( $data ) {
 	return $data;
 }
 
-function gutenberg_edit_site_get_theme_json_for_export($theme) {
+function gutenberg_edit_site_get_theme_json_for_export() {
 	$user_theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_user_data();
 	return flatten_theme_json( $user_theme_json->get_raw_data() );
 }
@@ -153,9 +153,8 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 	foreach ( $templates as $template ) {
 
 		//Currently, when building against CHILD themes of Blockbase, block templates provided by Blockbase, not modified by the child theme or the user are included in the page. This is a bug.
-
-		//if the theme is blockbase and the source is "theme" we don't want it
-		if ($template->source === 'theme' && strpos($template->theme, 'blockbase') !== false) {
+		//if the theme is a child and the source is "theme" we don't want it
+		if ($template->source === 'theme' && $theme['type'] === 'child') {
 			continue;
 		}
 
@@ -176,8 +175,8 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 	foreach ( $template_parts as $template_part ) {
 
 		//Currently, when building against CHILD themes of Blockbase, block template parts provided by Blockbase, not modified by the child theme or the user are included in the page. This is a bug.
-		//if the theme is blockbase and the source is "theme" we don't want it
-		if ($template_part->source === 'theme' && strpos($template_part->theme, 'blockbase') !== false) {
+		//if the theme is a child and the source is "theme" we don't want it
+		if ($template->source === 'theme' && $theme['type'] === 'child') {
 			continue;
 		}
 
@@ -192,7 +191,7 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 	// TODO only get child theme settings not the parent.
 	$zip->addFromString(
 		$theme['slug'] . '/theme.json',
-		wp_json_encode( gutenberg_edit_site_get_theme_json_for_export($theme), JSON_PRETTY_PRINT )
+		wp_json_encode( gutenberg_edit_site_get_theme_json_for_export(), JSON_PRETTY_PRINT )
 	);
 
 	// Add style.css.


### PR DESCRIPTION
This PR refactors the plugin so that it can be used with any block theme, not just Blockbase. These are the cases that it covers:

- If the active theme is a classic theme: it will show an error.
- If the active theme is a block theme child of another theme: the generated theme will be a child theme of the parent of the active theme, copying the template files and settings of the active theme plus the user changes on templates and Global Styles. I've tested this scenario using Geologist.
- If the active theme is a standalone block theme: the form will show two options for the new theme. I've tested this one with Remote and Blockbase.
  - We can generate a child theme of the active theme. The new theme will only contain the user changes in templates and Global Styles, the rest is inherited from the parent.
  - We can generate a standalone based on the active theme. The new theme will be a copy of the active theme plus the customizations made by the user.

