### PR TITLE
Add function to gather CSS to be exported for themes

### DIFF
--- a/index.php
+++ b/index.php
@@ -109,25 +109,32 @@ GNU General Public License for more details.
  * When building a CHILD theme no extra CSS is included.
  */
 function create_block_theme_get_theme_css( $theme ) {
-	// NOTE: Themes that keep their CSS in a structure other than Blockbase's will need something different...
+
+	// if we are building a CHILD theme we don't need any CSS
+	if ( $theme['type'] === 'child' ) {
+		return '';
+	}
+
+	$css_string = '';
+
+	// For those themes that keep styles in styles.css include anything that isn't metadata.
+	$style_string = file_get_contents(get_stylesheet_directory() . '/style.css');
+	$css_string .= substr( $style_string, strpos( $style_string, "*/" ) + 2 ) . "\n";
 
 	// if we are building a STANDALONE theme we need the CURRENT theme's CSS OR ponyfill.css (if our theme is Blockbase)
 	// if we are building a GRANDCHILD theme we need the CURRENT theme's CSS
 	if ($theme['type'] == 'block' || is_child_theme()) {
-		if ( get_stylesheet() === 'blockbase' ) {
+		if ( strpos(get_stylesheet(), 'blockbase') !== false ) {
 			//return Blockbase's /assets/ponyfill.css
-			return file_get_contents(get_stylesheet_directory() . '/assets/ponyfill.css');
+			$css_string .= file_get_contents(get_stylesheet_directory() . '/assets/ponyfill.css');
 		}
 		else if (file_exists(get_stylesheet_directory() . '/assets/theme.css')) {
 			//return the current theme's /assets/theme.css
-			return file_get_contents(get_stylesheet_directory() . '/assets/theme.css');
+			$css_string .= file_get_contents(get_stylesheet_directory() . '/assets/theme.css');
 		}
-		// It's a child theme but there's no theme.css so I dunno what to do. :)
-		return '';
 	}
 
-	// if we are building a CHILD theme we don't need any CSS
-	return '';
+	return $css_string;
 }
 
 /**

--- a/index.php
+++ b/index.php
@@ -103,6 +103,34 @@ GNU General Public License for more details.
 }
 
 /**
+ * Build the CSS that a generated theme will include.
+ * When building a STANDALONE theme from Blockbase the ponyfill.css will be included.
+ * When building a GRANDCHILD theme the CURRENT theme's CSS is included.
+ * When building a CHILD theme no extra CSS is included.
+ */
+function create_block_theme_get_theme_css( $theme ) {
+	// NOTE: Themes that keep their CSS in a structure other than Blockbase's will need something different...
+
+	// if we are building a STANDALONE theme we need the CURRENT theme's CSS OR ponyfill.css (if our theme is Blockbase)
+	// if we are building a GRANDCHILD theme we need the CURRENT theme's CSS
+	if ($theme['type'] == 'block' || is_child_theme()) {
+		if ( get_stylesheet() === 'blockbase' ) {
+			//return Blockbase's /assets/ponyfill.css
+			return file_get_contents(get_stylesheet_directory() . '/assets/ponyfill.css');
+		}
+		else if (file_exists(get_stylesheet_directory() . '/assets/theme.css')) {
+			//return the current theme's /assets/theme.css
+			return file_get_contents(get_stylesheet_directory() . '/assets/theme.css');
+		}
+		// It's a child theme but there's no theme.css so I dunno what to do. :)
+		return '';
+	}
+
+	// if we are building a CHILD theme we don't need any CSS
+	return '';
+}
+
+/**
  * Creates an export of the current templates and
  * template parts from the site editor at the
  * specified path in a ZIP file.
@@ -177,7 +205,7 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 	// Add theme.css combining all the current theme's css files.
 	$zip->addFromString(
 		$theme['slug'] . '/assets/theme.css',
-		''
+		create_block_theme_get_theme_css( $theme )
 	);
 
 	// Add readme.txt.

--- a/index.php
+++ b/index.php
@@ -117,23 +117,21 @@ function create_block_theme_get_theme_css( $theme ) {
 
 	$css_string = '';
 
-	// For those themes that keep styles in styles.css include anything that isn't metadata.
-	$style_string = file_get_contents(get_stylesheet_directory() . '/style.css');
-	$css_string .= substr( $style_string, strpos( $style_string, "*/" ) + 2 ) . "\n";
-
-	// if we are building a STANDALONE theme we need the CURRENT theme's CSS OR ponyfill.css (if our theme is Blockbase)
-	// if we are building a GRANDCHILD theme we need the CURRENT theme's CSS
-	if ($theme['type'] == 'block' || is_child_theme()) {
-		if ( strpos(get_stylesheet(), 'blockbase') !== false ) {
-			//return Blockbase's /assets/ponyfill.css
-			$css_string .= file_get_contents(get_stylesheet_directory() . '/assets/ponyfill.css');
-		}
-		else if (file_exists(get_stylesheet_directory() . '/assets/theme.css')) {
-			//return the current theme's /assets/theme.css
-			$css_string .= file_get_contents(get_stylesheet_directory() . '/assets/theme.css');
+	$current_theme = wp_get_theme( );
+	if ( $current_theme->exists() && $current_theme->get( 'TextDomain' ) !== 'blockbase' ){
+		foreach ($current_theme->get_files('css', -1) as $key => $value) {
+			if (strpos($key, '.css') !== false && file_exists( $value ) ) {
+				$css_string .= "
+/*
+*
+* Styles from " . $current_theme->get_stylesheet() . "/" . $key . "
+*
+*/
+";
+				$css_string .= file_get_contents( $value );
+			}
 		}
 	}
-
 	return $css_string;
 }
 

--- a/index.php
+++ b/index.php
@@ -121,17 +121,33 @@ function create_block_theme_get_theme_css( $theme ) {
 	if ( $current_theme->exists() && $current_theme->get( 'TextDomain' ) !== 'blockbase' ){
 		foreach ($current_theme->get_files('css', -1) as $key => $value) {
 			if (strpos($key, '.css') !== false && file_exists( $value ) ) {
+
+				$css_contents = file_get_contents( $value );
+
+				if ($key === "style.css") {
+					// Remove metadata from style.css file
+					$css_contents = trim( substr( $css_contents, strpos( $css_contents, "*/" ) + 2 ) );
+				}
+
+				// If there is nothing but metadata in the style.css file don't include it.
+				if ( strlen($css_contents) === 0 ) {
+					continue;
+				}
+
 				$css_string .= "
+
 /*
 *
 * Styles from " . $current_theme->get_stylesheet() . "/" . $key . "
 *
 */
+
 ";
-				$css_string .= file_get_contents( $value );
+				$css_string .= $css_contents;
 			}
 		}
 	}
+
 	return $css_string;
 }
 


### PR DESCRIPTION
This change will export CSS for the new theme.

When building a BLOCKBASE CHILD theme no CSS should be exported.
When building a BLOCKBASE GRANDCHILD (for instance using Geologist as the source theme) then the SOURCE THEME's CSS should be exported.

Additionally this will export any CSS in the styles.css file into the child's /assets/theme.css class.  

Evaluated with Blockbase and Geologist.

NOTE: This code will also export STANDALONE themes (from Blockbase) which would include blockbase's ponyfill.css.  However the plugin doesn't yet export standalone themes so this portion isn't testable yet.
