### PR TITLE
Add/standalone themes

### DIFF
--- a/gutenberg_additions.php
+++ b/gutenberg_additions.php
@@ -73,7 +73,7 @@ function augment_gutenberg_with_utilities() {
 		 * 'all' will include settings from the current theme as well as the parent theme (if it has one)
 		 */
 		public static function export_theme_data( $content ) {
-	        $theme = new WP_Theme_JSON_Gutenberg();
+			$theme = new WP_Theme_JSON_Gutenberg();
 
 			if ( $content === 'all' && wp_get_theme()->parent() ) {
 				// Get parent theme.json.
@@ -84,13 +84,13 @@ function augment_gutenberg_with_utilities() {
 			}
 
 			if ( $content === 'all' || $content === 'current' ) {
-	        		$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
-	        		$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
+				$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
+				$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
 				$theme_theme     = new WP_Theme_JSON_Gutenberg( $theme_json_data );
  				$theme->merge( $theme_theme );
 			}
 
-	        $theme->merge( static::get_user_data() );
+			$theme->merge( static::get_user_data() );
 
 			$data = MY_Theme_JSON_Resolver::flatten_theme_json($theme->get_raw_data(), null);
 

--- a/gutenberg_additions.php
+++ b/gutenberg_additions.php
@@ -73,8 +73,7 @@ function augment_gutenberg_with_utilities() {
 		 * 'all' will include settings from the current theme as well as the parent theme (if it has one)
 		 */
 		public static function export_theme_data( $content ) {
-
-	        	$theme = new WP_Theme_JSON_Gutenberg();
+	        $theme = new WP_Theme_JSON_Gutenberg();
 
 			if ( $content === 'all' && wp_get_theme()->parent() ) {
 				// Get parent theme.json.

--- a/gutenberg_additions.php
+++ b/gutenberg_additions.php
@@ -90,12 +90,11 @@ function augment_gutenberg_with_utilities() {
  				$theme->merge( $theme_theme );
 			}
 
-	        	$theme->merge( static::get_user_data() );
+	        $theme->merge( static::get_user_data() );
 
 			$data = MY_Theme_JSON_Resolver::flatten_theme_json($theme->get_raw_data(), null);
 
 			return $data;
-
 		}
 
 	}

--- a/index.php
+++ b/index.php
@@ -390,8 +390,8 @@ function create_blockbase_theme_page() {
 			<p><?php wp_kses_post( _e( 'The new theme will be based on whatever theme you have active at the moment. <br />If you want a fresh start, try using <a href="https://github.com/WordPress/theme-experiments/tree/master/emptytheme">Empty Theme</a> as a base.', 'create-block-theme' ) ); ?></p>
 			<p><?php _e('The current active theme is:', 'create-block-theme'); ?> <?php echo wp_get_theme()->get('Name'); ?></p>
 			<form method="get">
-				<label><?php _e('Theme name', 'create-block-theme'); ?><br /><input placeholder="<?php _e('Blockbase', 'create-block-theme'); ?>" type="text" name="theme[name]" class="regular-text" required /></label><br /><br />
-				<label><?php _e('Theme description', 'create-block-theme'); ?><br /><textarea placeholder="<?php _e('Blockbase is a simple theme that supports full-site editing. Use it to build something beautiful.', 'create-block-theme'); ?>" rows="4" cols="50" name="theme[description]" class="regular-text"></textarea></label><br /><br />
+				<label><?php _e('Theme Name', 'create-block-theme'); ?><br /><input required placeholder="<?php echo wp_get_theme()->get('Name'); ?>" type="text" name="theme[name]" class="regular-text" required /></label><br /><br />
+				<label><?php _e('Theme Description', 'create-block-theme'); ?><br /><textarea placeholder="<?php echo wp_get_theme()->get('Description'); ?>" rows="4" cols="50" name="theme[description]" class="regular-text"></textarea></label><br /><br />
 				<?php if ( ! is_child_theme() ): ?>
 				<label><input checked value="child" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Child theme of the current active theme', 'create-block-theme'); ?></label><br /><br />
 				<label><input value="block" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Standalone theme', 'create-block-theme'); ?></label><br /><br />
@@ -399,9 +399,9 @@ function create_blockbase_theme_page() {
 				<input type="hidden" name="theme[type]" value="child" />
 				<input type="hidden" name="theme[template]" value="<?php echo wp_get_theme()->get('Template'); ?>" />
 				<?php endif; ?>
-				<label><?php _e('Theme URI', 'create-block-theme'); ?><br /><input placeholder="https://github.com/automattic/themes/tree/trunk/blockbase" type="text" name="theme[uri]" class="regular-text code" /></label><br /><br />
-				<label><?php _e('Author', 'create-block-theme'); ?><br /><input placeholder="<?php _e('Automattic', 'create-block-theme'); ?>" type="text" name="theme[author]" class="regular-text" /></label><br /><br />
-				<label><?php _e('Author URI', 'create-block-theme'); ?><br /><input placeholder="<?php _e('https://automattic.com/', 'create-block-theme'); ?>" type="text" name="theme[author_uri]" class="regular-text code" /></label><br /><br />
+				<label><?php _e('Theme URI', 'create-block-theme'); ?><br /><input placeholder="<?php echo wp_get_theme()->get('ThemeURI'); ?>" type="text" name="theme[uri]" class="regular-text code" /></label><br /><br />
+				<label><?php _e('Author', 'create-block-theme'); ?><br /><input placeholder="<?php echo wp_get_theme()->get('Author'); ?>" type="text" name="theme[author]" class="regular-text" /></label><br /><br />
+				<label><?php _e('Author URI', 'create-block-theme'); ?><br /><input placeholder="<?php echo wp_get_theme()->get('AuthorURI'); ?>" type="text" name="theme[author_uri]" class="regular-text code" /></label><br /><br />
 				<input type="hidden" name="page" value="create-block-theme" />
 				<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_block_theme' ); ?>" />
 				<input type="submit" value="<?php _e('Create block theme', 'create-block-theme'); ?>" class="button button-primary" />

--- a/index.php
+++ b/index.php
@@ -475,8 +475,6 @@ function create_blockbase_child_admin_notice_success() {
 }
 
 function create_block_theme_get_new_parent( $theme ) {
-
-
 	if( is_child_theme() ) {
 		return wp_get_theme()->get( 'Template' );
 	} elseif( $theme['type'] == 'child' ) {

--- a/index.php
+++ b/index.php
@@ -103,21 +103,22 @@ GNU General Public License for more details.
 
 /**
  * Build the CSS that a generated theme will include.
- * When building a STANDALONE theme from Blockbase the ponyfill.css will be included.
- * When building a GRANDCHILD theme the CURRENT theme's CSS is included.
+ * When building a STANDALONE theme (from a parent theme) the CURRENT (parent) theme's CSS is included.
+ * When building a GRANDCHILD theme the CURRENT (child) theme's CSS is included.
  * When building a CHILD theme no extra CSS is included.
  */
 function create_block_theme_get_theme_css( $theme ) {
 
 	// if we are building a CHILD theme we don't need any CSS
-	if ( $theme['type'] === 'child' ) {
+	if ( $theme['type'] === 'child' && !$theme['template'] ) {
 		return '';
 	}
 
 	$css_string = '';
 
-	$current_theme = wp_get_theme( );
-	if ( $current_theme->exists() && $current_theme->get( 'TextDomain' ) !== 'blockbase' ){
+	$current_theme = wp_get_theme();
+
+	if ( $current_theme->exists() ){
 		foreach ($current_theme->get_files('css', -1) as $key => $value) {
 			if (strpos($key, '.css') !== false && file_exists( $value ) ) {
 
@@ -396,6 +397,7 @@ function create_blockbase_theme_page() {
 				<label><input value="block" type="radio" name="theme[type]" class="regular-text code" /><?php _e('Standalone theme', 'create-block-theme'); ?></label><br /><br />
 				<?php else: ?>
 				<input type="hidden" name="theme[type]" value="child" />
+				<input type="hidden" name="theme[template]" value="<?php echo wp_get_theme()->get('Template'); ?>" />
 				<?php endif; ?>
 				<label><?php _e('Theme URI', 'create-block-theme'); ?><br /><input placeholder="https://github.com/automattic/themes/tree/trunk/blockbase" type="text" name="theme[uri]" class="regular-text code" /></label><br /><br />
 				<label><?php _e('Author', 'create-block-theme'); ?><br /><input placeholder="<?php _e('Automattic', 'create-block-theme'); ?>" type="text" name="theme[author]" class="regular-text" /></label><br /><br />

--- a/index.php
+++ b/index.php
@@ -278,6 +278,13 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 			continue;
 		}
 
+		// _remove_theme_attribute_in_block_template_content is provided by Gutenberg in the Site Editor's template export workflow.
+		if ( function_exists( '_remove_theme_attribute_in_block_template_content' ) ) {
+			$template_part->content = _remove_theme_attribute_in_block_template_content( $template_part->content );
+		} else if ( function_exists( '_remove_theme_attribute_from_content' ) ) {
+			$template_part->content = _remove_theme_attribute_from_content( $template_part->content );
+		}
+	
 		$zip->addFromString(
 			$theme['slug'] . '/parts/' . $template_part->slug . '.html',
 			$template_part->content

--- a/index.php
+++ b/index.php
@@ -52,7 +52,7 @@ Tested up to: 5.9
 Requires PHP: 5.7
 Version: 0.0.1
 License: GNU General Public License v2 or later
-License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE" . 
+License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE" .
 $template .
 "Text Domain: {$slug}
 Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
@@ -207,7 +207,7 @@ function '.$theme['slug'].'_get_fonts_url() {
 		return "";
 	}
 
-	
+
 	if ( ! empty( $theme_data["typography"]["fontFamilies"]["theme"] ) ) {
 		foreach( $theme_data["typography"]["fontFamilies"]["theme"] as $font ) {
 			if ( ! empty( $font["google"] ) ) {
@@ -222,7 +222,7 @@ function '.$theme['slug'].'_get_fonts_url() {
 
 	// Make a single request for the theme or user fonts.
 	return esc_url_raw( "https://fonts.googleapis.com/css2?" . implode( "&", array_unique( $font_families ) ) . "&display=swap" );
-}	
+}
  	';
 }
 
@@ -285,7 +285,7 @@ function gutenberg_edit_site_export_theme_create_zip( $filename, $theme ) {
 		} else if ( function_exists( '_remove_theme_attribute_from_content' ) ) {
 			$template_part->content = _remove_theme_attribute_from_content( $template_part->content );
 		}
-	
+
 		$zip->addFromString(
 			$theme['slug'] . '/parts/' . $template_part->slug . '.html',
 			$template_part->content


### PR DESCRIPTION
This work borrows very heavily from @MaggieCabrera 's work in #32.

This works exporting any parent theme as a standalone theme.  

To test attempt to export ALL THREE kinds of themes:

* GRANDCHILD : Activate a Blockbase CHILD theme (such as Geologist).  After making changes export the theme.  It should be a BLOCKBASE child theme with all of the theme.json values from the activated theme as well as any changes you have made.  The child theme's /assets/theme.css resource should be included. Templates and template parts from the active theme should also be included.
* CHILD : Activate Blockbase.  After making changes export the theme (selecting 'Child them of the current active theme' from the Create Block Theme page).  The exported theme.json should ONLY include changes made by the user.  The /assets/theme.css file should be empty and only changes made to templates and template-parts should be included.  Repeat the process with a non-Blockbase Block theme (such as TwentyTwentyTwo).
* STANDALONE : Activate Blockbase.  After making changes export the theme (selecting 'Standalone theme' from the Create Block Theme page).  The exported theme.json should include ALL of the settings from Blockbase as well as any changes you made.  The /assets/theme.css file should include the contents of Blockbase's /assets/ponyfill.css file.  That /assets/theme.css file should be automatically loaded (in both the view and editor).  Likewise any fonts selected (as defined in the theme.json) should be loaded (accomplished by the bare-bones functions.php file included in the generated theme.  Repeat the process with a non-Blockbase Block theme (such as TwentyTwentyTwo)

Note: This does NOT YET export any of the theme's PATTERNS.  As such any of the templates that leverage those patterns will not work.  
