### PR TITLE
Fix parts export for child themes

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -339,9 +339,9 @@ class Create_Block_Theme_Admin {
 			}
 
 			if ( 
-				$template->source === 'theme' && 
+				$template_part->source === 'theme' && 
 				$export_type === 'current' && 
-				! file_exists( $parts_path . $template->slug . '.html' ) 
+				! file_exists( $parts_path . $template_part->slug . '.html' ) 
 			) {
 				continue;
 			}


### PR DESCRIPTION
Corrected the logic to build template parts that were incorrectly referencing templates.  Poor copy pasta served cold.

Fixes: #46 