### PR TITLE
Added a 'save' option 

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -423,8 +423,8 @@ class Create_Block_Theme_Admin {
 
 			$template->content = _remove_theme_attribute_in_block_template_content( $template->content );
 
-			// NOTE: Dashes are replaced with \u002d in the content that we get (noteably in things like css variables used in templates)
-			// This replaces that with dashes again.
+			// NOTE: Dashes are encoded as \u002d in the content that we get (noteably in things like css variables used in templates)
+			// This replaces that with dashes again. We should consider decoding the entire string but that is proving difficult.
 			$template->content = str_replace( '\u002d', '-', $template->content );
 
 			if ( $new_slug ) {
@@ -452,8 +452,8 @@ class Create_Block_Theme_Admin {
 
 			$template_part->content = _remove_theme_attribute_in_block_template_content( $template_part->content );
 
-			// NOTE: Dashes are replaced with \u002d in the content that we get (noteably in things like css variables used in templates)
-			// This replaces that with dashes again.
+			// NOTE: Dashes are encoded as \u002d in the content that we get (noteably in things like css variables used in templates)
+			// This replaces that with dashes again. We should consider decoding the entire string but that is proving difficult.
 			$template_part->content = str_replace( '\u002d', '-', $template_part->content );
 
 			if ( $new_slug ) {
@@ -496,8 +496,8 @@ class Create_Block_Theme_Admin {
 
 			$template->content = _remove_theme_attribute_in_block_template_content( $template->content );
 
-			//NOTE: Dashes are replaced with \u002d in the content that we get (noteably in things like css variables used in templates)
-			// This replaces that with dashes again.
+			// NOTE: Dashes are encoded as \u002d in the content that we get (noteably in things like css variables used in templates)
+			// This replaces that with dashes again. We should consider decoding the entire string but that is proving difficult.
 			$template->content = str_replace( '\u002d', '-', $template->content );
 
 			file_put_contents(
@@ -522,8 +522,8 @@ class Create_Block_Theme_Admin {
 
 			$template_part->content = _remove_theme_attribute_in_block_template_content( $template_part->content );
 
-			//NOTE: Dashes are replaced with \u002d in the content that we get (noteably in things like css variables used in templates)
-			// This replaces that with dashes again.
+			// NOTE: Dashes are encoded as \u002d in the content that we get (noteably in things like css variables used in templates)
+			// This replaces that with dashes again. We should consider decoding the entire string but that is proving difficult.
 			$template_part->content = str_replace( '\u002d', '-', $template_part->content );
 
 			file_put_contents(

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -273,18 +273,22 @@ class Create_Block_Theme_Admin {
 
 	function add_theme_json_to_zip ( $zip, $export_type ) {
 		$theme_json = MY_Theme_JSON_Resolver::export_theme_data( $export_type );
+		$theme_json = wp_json_encode( $theme_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		$theme_json = preg_replace( '~(?:^|\G)\h{4}~m', "\t", $theme_json );
 		$zip->addFromString(
 			'theme.json',
-			wp_json_encode( $theme_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES  )
+			$theme_json
 		);
 		return $zip;
 	}
 
 	function add_theme_json_to_local ( $export_type ) {
 		$theme_json = MY_Theme_JSON_Resolver::export_theme_data( $export_type );
+		$theme_json = wp_json_encode( $theme_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		$theme_json = preg_replace( '~(?:^|\G)\h{4}~m', "\t", $theme_json );
 		file_put_contents(
 			get_template_directory() . '/theme.json',
-			wp_json_encode( $theme_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES )
+			$theme_json
 		);
 	}
 

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -402,6 +402,8 @@ class Create_Block_Theme_Admin {
 		if ( $new_slug ) {
 			$template->content = str_replace( $old_slug, $new_slug, $template->content );
 		}
+
+		return $template;
 	}
 
 	/*
@@ -467,22 +469,22 @@ class Create_Block_Theme_Admin {
 
 		$theme_templates = $this->get_theme_templates( $export_type, $new_slug );
 
-		if ( $theme_templates['templates'] ) {
+		if ( $theme_templates->templates ) {
 			$zip->addEmptyDir( 'templates' );
 		}
 
-		if ( $theme_templates['parts'] ) {
+		if ( $theme_templates->parts ) {
 			$zip->addEmptyDir( 'parts' );
 		}
 
-		foreach ( $theme_templates['templates'] as $template ) {
+		foreach ( $theme_templates->templates as $template ) {
 			$zip->addFromString(
 				'templates/' . $template->slug . '.html',
 				$template->content
 			);
 		}
 
-		foreach ( $theme_templates['parts'] as $template_part ) {
+		foreach ( $theme_templates->parts as $template_part ) {
 			$zip->addFromString(
 				'parts/' . $template_part->slug . '.html',
 				$template_part->content
@@ -496,14 +498,14 @@ class Create_Block_Theme_Admin {
 
 		$theme_templates = $this->get_theme_templates( $export_type, null );
 
-		foreach ( $theme_templates['templates'] as $template ) {
+		foreach ( $theme_templates->templates as $template ) {
 			file_put_contents(
 				get_template_directory() . '/templates/' . $template->slug . '.html',
 				$template->content
 			);
 		}
 
-		foreach ( $theme_templates['parts'] as $template_part ) {
+		foreach ( $theme_templates->parts as $template_part ) {
 			file_put_contents(
 				get_template_directory() . '/parts/' . $template_part->slug . '.html',
 				$template_part->content

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -662,6 +662,8 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 					$this->save_theme_locally( 'all' );
 				}
 				$this->clear_user_customizations();
+
+				add_action( 'admin_notices', [ $this, 'admin_notice_save_success' ] );
 			}
 	
 			else if ( is_child_theme() ) {
@@ -671,7 +673,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 				else {
 					$this->export_child_theme( $_GET['theme'] );
 				}
-	
+				add_action( 'admin_notices', [ $this, 'admin_notice_export_success' ] );
 			} else {
 				if( $_GET['theme']['type'] === 'child' ) {
 					$this->create_child_theme( $_GET['theme'] );
@@ -682,9 +684,9 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 				else {
 					$this->export_theme( $_GET['theme'] );
 				}
+				add_action( 'admin_notices', [ $this, 'admin_notice_export_success' ] );
 			}
 
-			add_action( 'admin_notices', [ $this, 'admin_notice_success' ] );
 		}
 	}
 
@@ -695,10 +697,18 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 		printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
 	}	
 
-	function admin_notice_success() {
+	function admin_notice_export_success() {
 		?>
 			<div class="notice notice-success is-dismissible">
-				<p><?php _e( 'New block theme created!', 'create-block-theme' ); ?></p>
+				<p><?php _e( 'Block theme exported sucessfuly!', 'create-block-theme' ); ?></p>
+			</div>
+		<?php
+	}
+
+	function admin_notice_save_success() {
+		?>
+			<div class="notice notice-success is-dismissible">
+				<p><?php _e( 'Block theme saved and user customizations cleared!', 'create-block-theme' ); ?></p>
 			</div>
 		<?php
 	}

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -411,6 +411,7 @@ class Create_Block_Theme_Admin {
 	 */
 	function get_theme_templates( $export_type, $new_slug ) {
 
+		$old_slug = wp_get_theme()->get( 'TextDomain' );
 		$templates = gutenberg_get_block_templates();
 		$template_parts = gutenberg_get_block_templates ( array(), 'wp_template_part' );
 		$exported_templates = [];

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -34,7 +34,22 @@ class Create_Block_Theme_Admin {
 	}
 
 	function clear_user_customizations() {
-		//TODO
+
+		// Clear all values in the user theme.json
+		$user_custom_post_type_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+		$global_styles_controller = new Gutenberg_REST_Global_Styles_Controller();
+		$update_request = new WP_REST_Request( 'PUT', '/wp/v2/global-styles/' );
+		$update_request->set_param( 'id', $user_custom_post_type_id );
+		$update_request->set_param( 'settings', [] );
+		$update_request->set_param( 'styles', [] );
+		$updated_global_styles = $global_styles_controller->update_item( $update_request );
+		delete_transient( 'global_styles' );
+		delete_transient( 'global_styles_' . get_stylesheet() );
+		delete_transient( 'gutenberg_global_styles' );
+		delete_transient( 'gutenberg_global_styles_' . get_stylesheet() );
+
+
+
 	}
 
 	/**

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -272,23 +272,17 @@ class Create_Block_Theme_Admin {
 	}
 
 	function add_theme_json_to_zip ( $zip, $export_type ) {
-		$theme_json = MY_Theme_JSON_Resolver::export_theme_data( $export_type );
-		$theme_json = wp_json_encode( $theme_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-		$theme_json = preg_replace( '~(?:^|\G)\h{4}~m', "\t", $theme_json );
 		$zip->addFromString(
 			'theme.json',
-			$theme_json
+			MY_Theme_JSON_Resolver::export_theme_data( $export_type )
 		);
 		return $zip;
 	}
 
 	function add_theme_json_to_local ( $export_type ) {
-		$theme_json = MY_Theme_JSON_Resolver::export_theme_data( $export_type );
-		$theme_json = wp_json_encode( $theme_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-		$theme_json = preg_replace( '~(?:^|\G)\h{4}~m', "\t", $theme_json );
 		file_put_contents(
 			get_template_directory() . '/theme.json',
-			$theme_json
+			MY_Theme_JSON_Resolver::export_theme_data( $export_type )
 		);
 	}
 

--- a/admin/gutenberg_additions.php
+++ b/admin/gutenberg_additions.php
@@ -94,7 +94,9 @@ function augment_gutenberg_with_utilities() {
 
 			$data = MY_Theme_JSON_Resolver::flatten_theme_json($theme->get_raw_data(), null);
 
-			return $data;
+			$theme_json = wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+			return preg_replace ( '~(?:^|\G)\h{4}~m', "\t", $theme_json );
+
 		}
 
 	}


### PR DESCRIPTION
Added a 'Save Theme' option to save the theme.json and template changes to local theme folder and clear user changes.

Addresses: #45 and enables a development workflow.

![image](https://user-images.githubusercontent.com/146530/158199850-49ddba0b-0c21-43fc-854d-ee0098efc0f5.png)

To Test:

* Start with a theme activated.  (I have done most testing with Archeo but ANY theme [parent or child, Blockbase or not] should work fine.)
* Make sure you begin with NO user changes to the theme (such as color, font or template changes)
* Make changes to the theme using the FSE (or the Customizer).  A good test for this is to change the color values of the theme colors.
* Make changes to a template part (for instance add a simple paragraph block)
* Make a change to a template (another simple change you can easily see)
* Create a brand-new template and template part.
* Use the Plugin to 'Overwrite'.
* Load the site (view).  Note that it still looks the same (global style changes and template changes are still in tact)
* Attempt to "Reset to Defaults" the Global Styles using the FSE (nothing changes)
<img src="https://user-images.githubusercontent.com/146530/158200913-678869f2-76d7-4929-bc6f-ed9d81c43503.png" width=200>
* Attempt to "Clear Customizations" from the template part you previously edited.  Note that it is no longer an option.
<img src="https://user-images.githubusercontent.com/146530/158201217-99db23b8-997e-4bd7-a2e8-802443ba6c73.png" width=200>
* Observe the changes made to theme.json file in the theme in the filesystem.  Note that the Global Styles changes made in the FSE are now represented in the theme.json file in `/wp-content/themes/SLUG/theme.json`
* Note the changes made to templates in the theme filesystem, as well as additional templates/parts added based on the templates created with the FSE

This change also clears user settings when a theme is 'saved' addressing #50 