### PR TITLE
Refactor all of the namespaced items during cloning

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -257,11 +257,11 @@ class Create_Block_Theme_Admin {
 		);
 
 		// Add all the files (except for templates)
-		foreach ( $files as $name => $file )
-		{
+		foreach ( $files as $name => $file ) {
+
 			// Skip directories (they would be added automatically)
-			if ( ! $file->isDir() )
-			{
+			if ( ! $file->isDir() ) {
+
 				// Get real and relative path for current file
 				$file_path = $file->getRealPath();
 
@@ -276,15 +276,26 @@ class Create_Block_Theme_Admin {
 				}
 
 				$relative_path = substr( $file_path, strlen( $theme_path ) + 1 );
-				$contents = file_get_contents( $file_path );
 
-				// Replace namespace values if provided
-				if ( $new_slug ) {
-					$contents = $this->replace_namespace( $contents, $new_slug );
+				// Replace only text files, skip png's and other stuff.
+				$valid_extensions = array( 'php', 'css', 'scss', 'js', 'txt', 'html' );
+				$valid_extensions_regex = implode( '|', $valid_extensions );
+				if ( ! preg_match( "/\.({$valid_extensions_regex})$/", $relative_path ) ) {
+					$zip->addFile( $file_path, $relative_path );
+				}
+				
+				else {
+					$contents = file_get_contents( $file_path );
+
+					// Replace namespace values if provided
+					if ( $new_slug ) {
+						$contents = $this->replace_namespace( $contents, $new_slug );
+					}
+
+					// Add current file to archive
+					$zip->addFromString( $relative_path, $contents );
 				}
 
-				// Add current file to archive
-				$zip->addFromString( $relative_path, $contents );
 			}
 		}
 

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -263,7 +263,7 @@ class Create_Block_Theme_Admin {
 			if ( ! $file->isDir() ) {
 
 				// Get real and relative path for current file
-				$file_path = $file->getRealPath();
+				$file_path = wp_normalize_path( $file );
 
 				// If the path is for templates/parts ignore it
 				if ( 

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -513,8 +513,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 				<label><input value="child" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/><?php _e('Create child of ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?></label>
 				<?php _e('[Create a new child theme. The currently activated theme will be the parent theme.]', 'create-block-theme'); ?><br /><br />
 				<label><input value="clone" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/><?php _e('Clone ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
-				<?php _e('[Create a new theme cloning the activated theme. The resulting theme will have all of the assets of the activated theme as well as user changes.]', 'create-block-theme'); ?>
-				<p><b><?php _e('NOTE: Cloned themes created from this theme will have the original namespacing. This should be changed manually once the theme has been created.', 'create-block-theme'); ?></b></p></label><br /><br />
+				<?php _e('[Create a new theme cloning the activated theme. The resulting theme will have all of the assets of the activated theme as well as user changes.]', 'create-block-theme'); ?></label><br /><br />
 				<?php endif; ?>
 			
 				<div hidden id="new_theme_metadata_form">

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -39,7 +39,7 @@ class Create_Block_Theme_Admin {
 		$zip = $this->create_zip( $filename );
 
 		$zip = $this->copy_theme_to_zip( $zip );
-		$zip = $this->add_templates_to_zip( $zip, 'current' );
+		$zip = $this->add_templates_to_zip( $zip, 'current', $theme['slug'] );
 		$zip = $this->add_theme_json_to_zip( $zip, 'current' );
 
 		$zip->close();
@@ -177,7 +177,7 @@ class Create_Block_Theme_Admin {
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
 		$zip = $this->create_zip( $filename );
 
-		$zip = $this->add_templates_to_zip( $zip, 'user' );
+		$zip = $this->add_templates_to_zip( $zip, 'user', $theme['slug'] );
 		$zip = $this->add_theme_json_to_zip( $zip, 'user' );
 
 		// Add readme.txt.
@@ -219,7 +219,7 @@ class Create_Block_Theme_Admin {
 		$zip = $this->create_zip( $filename );
 
 		$zip = $this->copy_theme_to_zip( $zip );
-		$zip = $this->add_templates_to_zip( $zip, 'all' );
+		$zip = $this->add_templates_to_zip( $zip, 'all', $theme['slug'] );
 		$zip = $this->add_theme_json_to_zip( $zip, 'all' );
 
 		$zip->close();
@@ -290,6 +290,8 @@ class Create_Block_Theme_Admin {
 
 	function replace_namespace( $content, $new_slug ) {
 
+		$old_slug = wp_get_theme()->get( 'TextDomain' );
+
 		// NOTE: This has the potential of renaming functions with mixed-separators.
 		// If the source theme has a single-word slug but the new theme has a multi-word slug
 		// then function will look like: function apple-bumpkin_support() 
@@ -302,7 +304,6 @@ class Create_Block_Theme_Admin {
 			die('TODO: Uh.. return to the page because of an error without downloading anything. <br><br> Because the source theme has a single name the new theme name must also have a single name.  Please either rename your theme or clone a theme that has a multi-word name.');
 		}
 
-		$old_slug = wp_get_theme()->get( 'TextDomain' );
 		$new_slug_underscore = str_replace( '-', '_', $new_slug );
 		$old_slug_underscore = str_replace( '-', '_', $old_slug );
 

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -170,10 +170,7 @@ class Create_Block_Theme_Admin {
 		$theme['uri'] = sanitize_text_field( $theme['uri'] );
 		$theme['author'] = sanitize_text_field( $theme['author'] );
 		$theme['author_uri'] = sanitize_text_field( $theme['author_uri'] );
-		//NOTE: We aren't using get_theme_slug() here because there's no issues 
-		//if themes created in this situation have different word counts since
-		//we aren't doing any refactoring of namespaces.
-		$theme['slug'] = sanitize_title( $theme['name'] );
+		$theme['slug'] = $this->get_theme_slug( $theme['name'] );
 		$theme['template'] = wp_get_theme()->get( 'TextDomain' );
 
 		// Create ZIP file in the temporary directory.
@@ -581,13 +578,6 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 
 			add_action( 'admin_notices', [ $this, 'admin_notice_success' ] );
 		}
-	}
-
-	function admin_notice_incompatible_names() {
-		$class = 'notice notice-error';
-		$message = __( 'Because the source theme has a single name the new theme name must also have a single name.  Please either rename your theme or clone a theme that has a multi-word name.', 'create-block-theme' );
-
-		printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
 	}
 
 	function admin_notice_error() {

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -38,7 +38,7 @@ class Create_Block_Theme_Admin {
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
 		$zip = $this->create_zip( $filename );
 
-		$zip = $this->copy_theme_to_zip( $zip );
+		$zip = $this->copy_theme_to_zip( $zip, null, null );
 		$zip = $this->add_templates_to_zip( $zip, 'current', null );
 		$zip = $this->add_theme_json_to_zip( $zip, 'current' );
 
@@ -69,7 +69,7 @@ class Create_Block_Theme_Admin {
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
 		$zip = $this->create_zip( $filename );
 
-		$zip = $this->copy_theme_to_zip( $zip, $theme['slug'] );
+		$zip = $this->copy_theme_to_zip( $zip, $theme['slug'], $theme['name'] );
 		$zip = $this->add_templates_to_zip( $zip, 'current', $theme['slug'] );
 		$zip = $this->add_theme_json_to_zip( $zip, 'current' );
 
@@ -123,7 +123,7 @@ class Create_Block_Theme_Admin {
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
 		$zip = $this->create_zip( $filename );
 
-		$zip = $this->copy_theme_to_zip( $zip, $theme['slug'] );
+		$zip = $this->copy_theme_to_zip( $zip, $theme['slug'], $theme['name']);
 
 		$zip = $this->add_templates_to_zip( $zip, 'all', $theme['slug'] );
 		$zip = $this->add_theme_json_to_zip( $zip, 'all' );
@@ -221,7 +221,7 @@ class Create_Block_Theme_Admin {
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
 		$zip = $this->create_zip( $filename );
 
-		$zip = $this->copy_theme_to_zip( $zip );
+		$zip = $this->copy_theme_to_zip( $zip, null, null );
 		$zip = $this->add_templates_to_zip( $zip, 'all', null );
 		$zip = $this->add_theme_json_to_zip( $zip, 'all' );
 
@@ -244,7 +244,7 @@ class Create_Block_Theme_Admin {
 		return $zip;
 	}
 
-	function copy_theme_to_zip( $zip, $new_slug ) {
+	function copy_theme_to_zip( $zip, $new_slug, $new_name ) {
 
 		// Get real path for our folder
 		$theme_path = get_stylesheet_directory();
@@ -289,7 +289,7 @@ class Create_Block_Theme_Admin {
 
 					// Replace namespace values if provided
 					if ( $new_slug ) {
-						$contents = $this->replace_namespace( $contents, $new_slug );
+						$contents = $this->replace_namespace( $contents, $new_slug, $new_name );
 					}
 
 					// Add current file to archive
@@ -302,14 +302,16 @@ class Create_Block_Theme_Admin {
 		return $zip;
 	}
 
-	function replace_namespace( $content, $new_slug ) {
+	function replace_namespace( $content, $new_slug, $new_name ) {
 
 		$old_slug = wp_get_theme()->get( 'TextDomain' );
 		$new_slug_underscore = str_replace( '-', '_', $new_slug );
 		$old_slug_underscore = str_replace( '-', '_', $old_slug );
+		$old_name = wp_get_theme()->get( 'Name' );
 
 		$content = str_replace( $old_slug, $new_slug, $content );
 		$content = str_replace( $old_slug_underscore, $new_slug_underscore, $content );
+		$content = str_replace( $old_name, $new_name, $content );
 
 		return $content;
 	}


### PR DESCRIPTION
This addresses #43

When a theme is cloned (either a CHILD theme to make a sibling or a PARENT theme to make a completely new theme) the resources that are copied from the source theme are modified to have the namespaced resources changed to the new name.

The only (current) stipulation is that if the SOURCE theme has a single-word name (such as 'apples') and the DESTINATION theme has a multi-word name (such as 'red-fruit') the export is prevented.

This is because of the naming differences where some resources should have underscores (such as function names in PHP files) and some should have hyphens (such as text-domain values... also in PHP files).  Determining which instance should be refactored to which is much more complicated than the existing logic (which covers most use-cases).

TODO: Currently the failing situation noted above doesn't show an error on the form page but instead is just dumping the error message to the page.

To Test:

* Activate a Block Theme.  A theme with patterns is the best test.  (I used Archeo)
* Make changes to templates and styles.
* CLONE the theme using the Create Block Theme plugin
* Install and activate the created theme, note that the style and templates mirror the source theme, but with the changes made.
* Observe the resources.  Note that any resources referencing the original theme slug now reference the new theme slug.