### PR TITLE
Export tabs in theme.json

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -234,9 +234,11 @@ class Create_Block_Theme_Admin {
 
 	function add_theme_json_to_zip ( $zip, $export_type ) {
 		$theme_json = MY_Theme_JSON_Resolver::export_theme_data( $export_type );
+		$theme_json = wp_json_encode( $theme_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		$theme_json = preg_replace( '~(?:^|\G)\h{4}~m', "\t", $theme_json );
 		$zip->addFromString(
 			'theme.json',
-			wp_json_encode( $theme_json, JSON_PRETTY_PRINT )
+			$theme_json
 		);
 		return $zip;
 	}


### PR DESCRIPTION
Blatently stolen from https://github.com/WordPress/gutenberg/pull/39751

When theme.json is exported export with tabs instead of spaces.