### PR TITLE
Remove flatten_theme_json logic

### DIFF
--- a/admin/gutenberg_additions.php
+++ b/admin/gutenberg_additions.php
@@ -11,60 +11,6 @@ function augment_gutenberg_with_utilities() {
 	class MY_Theme_JSON_Resolver extends WP_Theme_JSON_Resolver_Gutenberg {
 
 		/**
-		 * 'Flatten' theme data that expresses both theme and user data.
-		 * change property.[custom|theme].value to property.value
-		 * Uses custom value if available, otherwise theme value
-		 * I feel like there should be a function to do this in Gutenberg but I couldn't find it
-		 */
-		private static function flatten_theme_json( $data, $name ) {
-			if ( is_array( $data ) ) {
-
-				// 'settings' can have a 'custom' object that is different and should not be processed in the same way
-				// as values that could be represented as both theme and user (user data being 'custom')
-				if ( $name !== 'settings' ) {
-
-					// When there is BOTH custom AND THEME combine the two
-					if ( array_key_exists( 'custom', $data ) && array_key_exists( 'theme', $data ) ) {
-						$merged = array_merge( $data['custom'], $data['theme'] );
-						// eliminate values with duplicate slugs
-						// TODO: This could probably be done better...
-						$filtered = array();
-						$sluglist = array();
-						foreach ( $merged as $item ) {
-							if( array_key_exists('slug', $item) ) {
-								if( ! in_array($item['slug'], $sluglist) ) {
-									$sluglist[] = $item['slug'];
-									$filtered[] = $item;
-								}
-							}
-							else {
-								$filtered[] = $item;
-							}
-						}
-						return MY_Theme_JSON_Resolver::flatten_theme_json($filtered, $name);
-					}
-
-					// When there is CUSTOM but no THEME return custom
-					if ( array_key_exists( 'custom', $data ) ) {
-						return MY_Theme_JSON_Resolver::flatten_theme_json($data['custom'], $name);
-					}
-
-					// When there is THEME but no CUSTOM return theme
-					if ( array_key_exists( 'theme', $data ) ) {
-						return MY_Theme_JSON_Resolver::flatten_theme_json($data['theme'], $name);
-					}
-
-				}
-
-				foreach( $data as $node_name => $node_value  ) {
-					$data[ $node_name ] = MY_Theme_JSON_Resolver::flatten_theme_json( $node_value, $node_name );
-				}
-			}
-
-			return $data;
-		}
-
-		/**
 		 * Export the combined (and flattened) THEME and CUSTOM data.
 		 *
 		 * @param string $content ['all', 'current', 'user'] Determines which settings content to include in the export.
@@ -92,7 +38,7 @@ function augment_gutenberg_with_utilities() {
 
 			$theme->merge( static::get_user_data() );
 
-			$data = MY_Theme_JSON_Resolver::flatten_theme_json($theme->get_raw_data(), null);
+			$data = MY_Theme_JSON_Resolver::$theme->get_data();
 
 			$theme_json = wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 			return preg_replace ( '~(?:^|\G)\h{4}~m', "\t", $theme_json );


### PR DESCRIPTION
Remove flatten_theme_json logic and replace `get_raw_data()` with a call to `get_data()` which returns the values already flattened, organized and better cleaned up in general.