### PR TITLE
Make Plugin work without Gutenberg

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once (__DIR__ . '/gutenberg_additions.php');
+require_once (__DIR__ . '/resolver_additions.php');
 
 /**
  * The admin-specific functionality of the plugin.
@@ -36,8 +36,8 @@ class Create_Block_Theme_Admin {
 	function clear_user_customizations() {
 
 		// Clear all values in the user theme.json
-		$user_custom_post_type_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
-		$global_styles_controller = new Gutenberg_REST_Global_Styles_Controller();
+		$user_custom_post_type_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+		$global_styles_controller = new WP_REST_Global_Styles_Controller();
 		$update_request = new WP_REST_Request( 'PUT', '/wp/v2/global-styles/' );
 		$update_request->set_param( 'id', $user_custom_post_type_id );
 		$update_request->set_param( 'settings', [] );
@@ -49,8 +49,8 @@ class Create_Block_Theme_Admin {
 		delete_transient( 'gutenberg_global_styles_' . get_stylesheet() );
 
 		//remove all user templates (they have been saved in the theme)
-		$templates = gutenberg_get_block_templates();
-		$template_parts = gutenberg_get_block_templates( array(), 'wp_template_part' );
+		$templates = get_block_templates();
+		$template_parts = get_block_templates( array(), 'wp_template_part' );
 		foreach ( $template_parts as $template ) {
 			if ( $template->source !== 'custom' ) {
 				continue;
@@ -412,8 +412,8 @@ class Create_Block_Theme_Admin {
 	function get_theme_templates( $export_type, $new_slug ) {
 
 		$old_slug = wp_get_theme()->get( 'TextDomain' );
-		$templates = gutenberg_get_block_templates();
-		$template_parts = gutenberg_get_block_templates ( array(), 'wp_template_part' );
+		$templates = get_block_templates();
+		$template_parts = get_block_templates ( array(), 'wp_template_part' );
 		$exported_templates = [];
 		$exported_parts = [];
 
@@ -498,17 +498,18 @@ class Create_Block_Theme_Admin {
 	function add_templates_to_local( $export_type ) {
 
 		$theme_templates = $this->get_theme_templates( $export_type, null );
+		$template_folders = get_block_theme_folders();
 
 		foreach ( $theme_templates->templates as $template ) {
 			file_put_contents(
-				get_template_directory() . '/templates/' . $template->slug . '.html',
+				get_template_directory() . '/' . $template_folders['wp_template'] . '/' . $template->slug . '.html',
 				$template->content
 			);
 		}
 
 		foreach ( $theme_templates->parts as $template_part ) {
 			file_put_contents(
-				get_template_directory() . '/parts/' . $template_part->slug . '.html',
+				get_template_directory() . '/' . $template_folders['wp_template_part'] . '/' . $template_part->slug . '.html',
 				$template_part->content
 			);
 		}

--- a/admin/resolver_additions.php
+++ b/admin/resolver_additions.php
@@ -1,14 +1,14 @@
 <?php
 
-function augment_gutenberg_with_utilities() {
+function augment_resolver_with_utilities() {
 
-	//Ultimately it is desireable for Gutenberg to have this functionality natively.
+	//Ultimately it is desireable for Core to have this functionality natively.
 	// In the meantime we are patching the functionality we are expecting into the Theme JSON Resolver here
-	if ( ! class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
+	if ( ! class_exists( 'WP_Theme_JSON_Resolver' ) ) {
 		return;
 	}
 
-	class MY_Theme_JSON_Resolver extends WP_Theme_JSON_Resolver_Gutenberg {
+	class MY_Theme_JSON_Resolver extends WP_Theme_JSON_Resolver {
 
 		/**
 		 * Export the combined (and flattened) THEME and CUSTOM data.
@@ -19,20 +19,20 @@ function augment_gutenberg_with_utilities() {
 		 * 'all' will include settings from the current theme as well as the parent theme (if it has one)
 		 */
 		public static function export_theme_data( $content ) {
-			$theme = new WP_Theme_JSON_Gutenberg();
+			$theme = new WP_Theme_JSON();
 
 			if ( $content === 'all' && wp_get_theme()->parent() ) {
 				// Get parent theme.json.
 				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
 				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
-				$parent_theme           = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
+				$parent_theme           = new WP_Theme_JSON( $parent_theme_json_data );
 				$theme->merge ($parent_theme);
 			}
 
 			if ( $content === 'all' || $content === 'current' ) {
 				$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
 				$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-				$theme_theme     = new WP_Theme_JSON_Gutenberg( $theme_json_data );
+				$theme_theme     = new WP_Theme_JSON( $theme_json_data );
  				$theme->merge( $theme_theme );
 			}
 
@@ -48,4 +48,4 @@ function augment_gutenberg_with_utilities() {
 	}
 }
 
-add_action( 'plugins_loaded', 'augment_gutenberg_with_utilities' );
+add_action( 'plugins_loaded', 'augment_resolver_with_utilities' );

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: @chaosexanima, @mikachan, @onemaggie, @pbking, @scruffian
 Donate link: https://automattic.com/
 Tags: themes, theme, block-theme
-Requires at least: 5.9
-Tested up to: 5.9
+Requires at least: 6.0 
+Tested up to: 6.0
 Stable tag: 1.0
 Requires PHP: 7.0
 License: GPLv2 or later


### PR DESCRIPTION
Modified gutenberg-specific code to instead leverage resources from core eliminating the need for Gutenberg.  Now requires WP 6.0.

To test, disable Gutenberg and Export, Create, Clone and Overwrite a parent and a child theme. 