### PR TITLE
fix issue where child theme overrides parent theme templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Creates a new theme by cloning the activated theme. The resulting theme will hav
 Saves user's changes to the theme files and deletes the user's changes.
 
 ### Step 1 – Setup
-Install and activate the [Create Block Theme](https://github.com/Automattic/create-block-theme) plugin. You will also need to be running the latest version of the Gutenberg plugin.
+Install and activate the [Create Block Theme](https://github.com/WordPress/create-block-theme) plugin. You will also need to be running the latest version of the Gutenberg plugin.
 
 ### Step 2 – Style Customizations
 Make changes to your site design using the Site Editor.

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -281,7 +281,7 @@ class Create_Block_Theme_Admin {
 
 	function add_theme_json_to_local ( $export_type ) {
 		file_put_contents(
-			get_template_directory() . '/theme.json',
+			get_stylesheet_directory() . '/theme.json',
 			MY_Theme_JSON_Resolver::export_theme_data( $export_type )
 		);
 	}
@@ -502,14 +502,14 @@ class Create_Block_Theme_Admin {
 
 		foreach ( $theme_templates->templates as $template ) {
 			file_put_contents(
-				get_template_directory() . '/' . $template_folders['wp_template'] . '/' . $template->slug . '.html',
+				get_stylesheet_directory() . '/' . $template_folders['wp_template'] . '/' . $template->slug . '.html',
 				$template->content
 			);
 		}
 
 		foreach ( $theme_templates->parts as $template_part ) {
 			file_put_contents(
-				get_template_directory() . '/' . $template_folders['wp_template_part'] . '/' . $template_part->slug . '.html',
+				get_stylesheet_directory() . '/' . $template_folders['wp_template_part'] . '/' . $template_part->slug . '.html',
 				$template_part->content
 			);
 		}

--- a/create-block-theme.php
+++ b/create-block-theme.php
@@ -3,7 +3,7 @@
 /**
  * @wordpress-plugin
  * Plugin Name: Create Block Theme
- * Plugin URI: https://github.com/Automattic/create-block-theme
+ * Plugin URI: https://github.com/WordPress/create-block-theme
  * Description: Generates a block theme
  * Version: 0.0.2
  * Author: Automattic

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,7 @@ A WordPress plugin to create block themes.
 This tool can create standalone block themes and Blockbase child themes. Find out more about Blockbase at [blockbasetheme.com](https://blockbasetheme.com)
 
 = Step 1 – Setup =
-Install and activate the [Create Block Theme](https://github.com/Automattic/create-block-theme) plugin. If you want to create Blockbase child themes, you will need to install [Blockbase](https://github.com/Automattic/themes/tree/trunk/blockbase) (or a Blockbase child theme if you want your new theme based on it instead). You will also need to be running the latest version of the Gutenberg plugin.
+Install and activate the [Create Block Theme](https://github.com/WordPress/create-block-theme) plugin. If you want to create Blockbase child themes, you will need to install [Blockbase](https://github.com/Automattic/themes/tree/trunk/blockbase) (or a Blockbase child theme if you want your new theme based on it instead). You will also need to be running the latest version of the Gutenberg plugin.
 
 = Step 2 – Style Customizations =
 Make changes to your site design using the Customizer and Site Editor.


### PR DESCRIPTION
### Fix summary

Used [get_stylesheet_directory](https://developer.wordpress.org/reference/functions/get_stylesheet_directory/) to fetch the current theme path and override the theme templates. It works for both child and parent themes.

Also, updated git repo references.

### Testing instructions

* Activate a child theme
* add customisations to templates in FSE
* select "Appearance > Create Block Theme > Override <theme>
* click export

Observe that, parent theme is not disturbed and the customisations are changed only in the child theme.

### Related issues

Fixes: #64 