### PR TITLE
Form cleanup and Theme name check

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -655,11 +655,11 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 		}
 		?>
 		<div class="wrap">
+			<h2><?php _e('Create Block Theme', 'create-block-theme'); ?></h2>
 			<form method="get">
 				<div id="col-container">
 					<div id="col-left">
 						<div class="col-wrap">
-							<h2><?php _e('Create Block Theme', 'create-block-theme'); ?></h2>
 							<p><?php _e('Export your current block theme with changes you made to Templates, Template Parts and Global Styles.', 'create-block-theme'); ?></p>
 
 							<label>

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -843,9 +843,11 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 	}
 
 	function admin_notice_blank_success() {
+		$theme_name = $_GET['theme']['name'];
+
 		?>
 			<div class="notice notice-success is-dismissible">
-				<p><?php _e( 'Blank theme created, head over to Appearance > Themes to activate it!', 'create-block-theme' ); ?></p>
+				<p><?php printf( esc_html__( 'Blank theme created, head over to Appearance > Themes to activate %1$s', 'create-block-theme' ), esc_html( $theme_name ) ); ?></p>
 			</div>
 		<?php
 	}

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -660,7 +660,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 				<div id="col-container">
 					<div id="col-left">
 						<div class="col-wrap">
-							<p><?php _e('Export your current block theme with changes you made to Templates, Template Parts and Global Styles.', 'create-block-theme'); ?></p>
+							<p><?php printf( esc_html__('Export your current block theme (%1$s) with changes you made to Templates, Template Parts and Global Styles.', 'create-block-theme'),  esc_html( wp_get_theme()->get('Name') ) ); ?></p>
 
 							<label>
 								<input checked value="export" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').setAttribute('hidden', null);" />

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -705,7 +705,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 							</label>
 							<br /><br />
 
-							<input type="submit" value="<?php _e('Export theme', 'create-block-theme'); ?>" class="button button-primary" />
+							<input type="submit" value="<?php _e('Create theme', 'create-block-theme'); ?>" class="button button-primary" />
 
 						</div>
 					</div>

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -655,38 +655,96 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 		}
 		?>
 		<div class="wrap">
-			<h2><?php _e('Create Block Theme', 'create-block-theme'); ?></h2>
-			<p><?php _e('Export your current block theme with changes you made to Templates, Template Parts and Global Styles.', 'create-block-theme'); ?></p>
 			<form method="get">
+				<div id="col-container">
+					<div id="col-left">
+						<div class="col-wrap">
+							<h2><?php _e('Create Block Theme', 'create-block-theme'); ?></h2>
+							<p><?php _e('Export your current block theme with changes you made to Templates, Template Parts and Global Styles.', 'create-block-theme'); ?></p>
 
-				<label><input checked value="export" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').setAttribute('hidden', null);" /><?php _e('Export ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?></label>
-				<?php _e('[Export the activated theme with user changes]', 'create-block-theme'); ?></label><br /><br />
-				<?php if ( is_child_theme() ): ?>
-				<label><input value="sibling" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/><?php _e('Create sibling of ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?></label>
-				<?php _e('[Create a new theme cloning the activated child theme.  The parent theme will be the same as the parent of the currently activated theme. The resulting theme will have all of the assets of the activated theme, none of the assets provided by the parent theme, as well as user changes.]', 'create-block-theme'); ?>
-				<p><b><?php _e('NOTE: Sibling themes created from this theme will have the original namespacing. This should be changed manually once the theme has been created.', 'create-block-theme'); ?></b></p><br />
-				<?php else: ?>
-				<label><input value="child" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/><?php _e('Create child of ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?></label>
-				<?php _e('[Create a new child theme. The currently activated theme will be the parent theme.]', 'create-block-theme'); ?><br /><br />
-				<label><input value="clone" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/><?php _e('Clone ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
-				<?php _e('[Create a new theme cloning the activated theme. The resulting theme will have all of the assets of the activated theme as well as user changes.]', 'create-block-theme'); ?></label><br /><br />
-				<?php endif; ?>
-				<label><input value="save" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').setAttribute('hidden', null);" /><?php _e('Overwrite ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?></label>
-				<?php _e('[Save USER changes as THEME changes and delete the USER changes.  Your changes will be saved in the theme on the folder.]', 'create-block-theme'); ?></label><br /><br />
-				<label><input value="blank" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden', null);" /><?php _e('Create blank theme ', 'create-block-theme'); ?></label>
-				<?php _e('[Generates a boilerplate "empty" theme inside of this site\'s themes directory.]', 'create-block-theme'); ?></label><br /><br />
+							<label>
+								<input checked value="export" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').setAttribute('hidden', null);" />
+								<?php _e('Export ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
+								<?php _e('[Export the activated theme with user changes]', 'create-block-theme'); ?>
+							</label>
+							<br /><br />
+							<?php if ( is_child_theme() ): ?>
+								<label>
+									<input value="sibling" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/>
+									<?php _e('Create sibling of ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
+								</label>
+								<?php _e('[Create a new theme cloning the activated child theme.  The parent theme will be the same as the parent of the currently activated theme. The resulting theme will have all of the assets of the activated theme, none of the assets provided by the parent theme, as well as user changes.]', 'create-block-theme'); ?>
+								<p><b><?php _e('NOTE: Sibling themes created from this theme will have the original namespacing. This should be changed manually once the theme has been created.', 'create-block-theme'); ?></b></p>
+								<br />
+							<?php else: ?>
+								<label>
+									<input value="child" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/>
+									<?php _e('Create child of ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
+								</label>
+								<?php _e('[Create a new child theme. The currently activated theme will be the parent theme.]', 'create-block-theme'); ?>
+								<br /><br />
+								<label>
+									<input value="clone" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/>
+									<?php _e('Clone ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
+									<?php _e('[Create a new theme cloning the activated theme. The resulting theme will have all of the assets of the activated theme as well as user changes.]', 'create-block-theme'); ?>
+								</label>
+								<br /><br />
+							<?php endif; ?>
+							<label>
+								<input value="save" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').setAttribute('hidden', null);" />
+								<?php _e('Overwrite ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
 
-				<div hidden id="new_theme_metadata_form">
-                    <p><?php _e('Items indicated with (*) are required.', 'create-block-theme'); ?></p>
-					<label><?php _e('Theme Name (*): The name of the theme.', 'create-block-theme'); ?><br />  <input type="text" name="theme[name]" class="regular-text" /></label><br /><br />
-					<label><?php _e('Theme Description: A short description of the theme.', 'create-block-theme'); ?><br /><textarea rows="4" cols="50" name="theme[description]" class="regular-text"></textarea></label><br /><br />
-					<label><?php _e('Theme URI: The URL of a public web page where users can find more information about the theme.', 'create-block-theme'); ?><br /><input type="text" name="theme[uri]" class="regular-text code" /></label><br /><br />
-					<label><?php _e('Author: The name of the individual or organization who developed the theme.', 'create-block-theme'); ?><br /><input type="text" name="theme[author]" class="regular-text" /></label><br /><br />
-					<label><?php _e('Author URI: The URL of the authoring individual or organization.', 'create-block-theme'); ?><br /><input type="text" name="theme[author_uri]" class="regular-text code" /></label><br /><br />
+								<?php _e('[Save USER changes as THEME changes and delete the USER changes.  Your changes will be saved in the theme on the folder.]', 'create-block-theme'); ?>
+							</label>
+							<br /><br />
+							<label>
+								<input value="blank" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden', null);" />
+								<?php _e('Create blank theme ', 'create-block-theme'); ?>
+								<?php _e('[Generates a boilerplate "empty" theme inside of this site\'s themes directory.]', 'create-block-theme'); ?>
+							</label>
+							<br /><br />
+
+							<input type="submit" value="<?php _e('Export theme', 'create-block-theme'); ?>" class="button button-primary" />
+
+						</div>
+					</div>
+					<div id="col-right">
+						<div class="col-wrap">
+							<div hidden id="new_theme_metadata_form">
+								<label>
+									<?php _e('Theme Name (*):', 'create-block-theme'); ?><br />
+									<input placeholder="<?php _e('Theme Name', 'create-block-theme'); ?>" type="text" name="theme[name]" class="large-text" required />
+								</label>
+								<br /><br />
+								<label>
+									<?php _e('Theme Description:', 'create-block-theme'); ?><br />
+									<textarea placeholder="<?php _e('A short description of the theme.', 'create-block-theme'); ?>" rows="4" cols="50" name="theme[description]" class="large-text"></textarea>
+								</label>
+								<br /><br />
+								<label>
+									<?php _e('Theme URI:', 'create-block-theme'); ?><br />
+									<small><?php _e('The URL of a public web page where users can find more information about the theme.', 'create-block-theme'); ?></small><br />
+									<input placeholder="<?php _e('https://github.com/wordpress/twentytwentytwo/', 'create-block-theme'); ?>" type="text" name="theme[uri]" class="large-text code" />
+								</label>
+								<br /><br />
+								<label>
+									<?php _e('Author:', 'create-block-theme'); ?><br />
+									<small><?php _e('The name of the individual or organization who developed the theme.', 'create-block-theme'); ?></small><br />
+									<input placeholder="<?php _e('the WordPress team', 'create-block-theme'); ?>" type="text" name="theme[author]" class="large-text" />
+								</label>
+								<br /><br />
+								<label>
+									<?php _e('Author URI:', 'create-block-theme'); ?><br />
+									<small><?php _e('The URL of the authoring individual or organization.', 'create-block-theme'); ?></small><br />
+									<input placeholder="<?php _e('https://wordpress.org/', 'create-block-theme'); ?>" type="text" name="theme[author_uri]" class="large-text code" />
+								</label><br />
+								<p><?php _e('Items indicated with (*) are required.', 'create-block-theme'); ?></p><br />
+							</div>
+							<input type="hidden" name="page" value="create-block-theme" />
+							<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_block_theme' ); ?>" />
+						</div>
+					</div>
 				</div>
-				<input type="hidden" name="page" value="create-block-theme" />
-				<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_block_theme' ); ?>" />
-				<input type="submit" value="<?php _e('Export theme', 'create-block-theme'); ?>" class="button button-primary" />
 			</form>
 		</div>
 	<?php

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -778,6 +778,9 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 			}
 
 			else if ( $_GET['theme']['type'] === 'blank' ) {
+				if ( $_GET['theme']['name'] === '' ) {
+					return add_action( 'admin_notices', [ $this, 'admin_notice_error' ] );
+				}
 				$this->create_blank_theme( $_GET['theme'] );
 
 				add_action( 'admin_notices', [ $this, 'admin_notice_blank_success' ] );

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -713,7 +713,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 							<div hidden id="new_theme_metadata_form">
 								<label>
 									<?php _e('Theme Name (*):', 'create-block-theme'); ?><br />
-									<input placeholder="<?php _e('Theme Name', 'create-block-theme'); ?>" type="text" name="theme[name]" class="large-text" required />
+									<input placeholder="<?php _e('Theme Name', 'create-block-theme'); ?>" type="text" name="theme[name]" class="large-text" />
 								</label>
 								<br /><br />
 								<label>
@@ -784,6 +784,9 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 
 			else if ( is_child_theme() ) {
 				if ( $_GET['theme']['type'] === 'sibling' ) {
+					if ( $_GET['theme']['name'] === '' ) {
+						return add_action( 'admin_notices', [ $this, 'admin_notice_error' ] );
+					}
 					$this->create_sibling_theme( $_GET['theme'] );
 				}
 				else {
@@ -792,9 +795,15 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 				add_action( 'admin_notices', [ $this, 'admin_notice_export_success' ] );
 			} else {
 				if( $_GET['theme']['type'] === 'child' ) {
+					if ( $_GET['theme']['name'] === '' ) {
+						return add_action( 'admin_notices', [ $this, 'admin_notice_error' ] );
+					}
 					$this->create_child_theme( $_GET['theme'] );
 				}
 				else if( $_GET['theme']['type'] === 'clone' ) {
+					if ( $_GET['theme']['name'] === '' ) {
+						return add_action( 'admin_notices', [ $this, 'admin_notice_error' ] );
+					}
 					$this->clone_theme( $_GET['theme'] );
 				}
 				else {

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -664,7 +664,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 
 							<label>
 								<input checked value="export" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').setAttribute('hidden', null);" />
-								<?php _e('Export ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
+								<?php _e('Export ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?><br />
 								<?php _e('[Export the activated theme with user changes]', 'create-block-theme'); ?>
 							</label>
 							<br /><br />
@@ -673,6 +673,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 									<input value="sibling" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/>
 									<?php _e('Create sibling of ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
 								</label>
+								<br />
 								<?php _e('[Create a new theme cloning the activated child theme.  The parent theme will be the same as the parent of the currently activated theme. The resulting theme will have all of the assets of the activated theme, none of the assets provided by the parent theme, as well as user changes.]', 'create-block-theme'); ?>
 								<p><b><?php _e('NOTE: Sibling themes created from this theme will have the original namespacing. This should be changed manually once the theme has been created.', 'create-block-theme'); ?></b></p>
 								<br />
@@ -681,25 +682,25 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 									<input value="child" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/>
 									<?php _e('Create child of ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
 								</label>
+								<br />
 								<?php _e('[Create a new child theme. The currently activated theme will be the parent theme.]', 'create-block-theme'); ?>
 								<br /><br />
 								<label>
 									<input value="clone" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/>
-									<?php _e('Clone ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
+									<?php _e('Clone ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?><br />
 									<?php _e('[Create a new theme cloning the activated theme. The resulting theme will have all of the assets of the activated theme as well as user changes.]', 'create-block-theme'); ?>
 								</label>
 								<br /><br />
 							<?php endif; ?>
 							<label>
 								<input value="save" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').setAttribute('hidden', null);" />
-								<?php _e('Overwrite ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
-
+								<?php _e('Overwrite ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?><br />
 								<?php _e('[Save USER changes as THEME changes and delete the USER changes.  Your changes will be saved in the theme on the folder.]', 'create-block-theme'); ?>
 							</label>
 							<br /><br />
 							<label>
 								<input value="blank" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden', null);" />
-								<?php _e('Create blank theme ', 'create-block-theme'); ?>
+								<?php _e('Create blank theme ', 'create-block-theme'); ?><br />
 								<?php _e('[Generates a boilerplate "empty" theme inside of this site\'s themes directory.]', 'create-block-theme'); ?>
 							</label>
 							<br /><br />


### PR DESCRIPTION
Looks like some of the changes we made to the form got lost among the refactors, so I've made a few changes:

- Added placeholder text to the inputs
- Used a two-column layout for the form (I wanted to make the form fields bigger without adding extra CSS and this is what I found that uses core CSS without needing to add some in the plugin).
- Made the theme name a requirement for the cases that show the form to the user.

I'm open to improvements, I don't think it looks the best. Maybe we should audit the dev experience in general of the plugin and have another pass at the design and copy that we are using in general. Maybe we don't want to do that just yet if we want to integrate some of this functionality with the site editor instead of this standalone plugin page. Feel free to discuss this!

Before:

<img width="1396" alt="Screenshot 2022-07-04 at 17 51 58" src="https://user-images.githubusercontent.com/3593343/177187794-1a9c4128-eddf-4199-8871-c8f0125dd9ae.png">


After:

![Screen Capture on 2022-07-04 at 17-45-07](https://user-images.githubusercontent.com/3593343/177187628-37f25051-1722-4315-9ddb-7aec7bf1f35b.gif)

