### PR TITLE
Automate/deployment

### DIFF
--- a/.github/workflows/deploy-to-dotorg.yml
+++ b/.github/workflows/deploy-to-dotorg.yml
@@ -1,0 +1,16 @@
+name: Deploy to WordPress.org
+on:
+  push:
+    tags:
+    - "*"
+jobs:
+  tag:
+    name: New tag
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@trunk
+    - name: Create Block Theme Plugin Deploy to WordPress.org
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/deploy-to-dotorg.yml
+++ b/.github/workflows/deploy-to-dotorg.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
     - "*"
+  workflow_dispatch:
 jobs:
   tag:
     name: New tag


### PR DESCRIPTION
This change adds a deployment action triggered when a tag is created.

To deploy a build create a tag from /trunk labeled the same as the version to be shipped.

For this to work SVN_USERNAME and SVN_PASSWORD need to be stored as secrets on this account.  (I'm not sure who has access to that for this repository.  I do not.)

Fixes: #83