### PR TITLE
Get the correct merged theme.json data

### DIFF
--- a/admin/resolver_additions.php
+++ b/admin/resolver_additions.php
@@ -38,7 +38,7 @@ function augment_resolver_with_utilities() {
 
 			$theme->merge( static::get_user_data() );
 
-			$data = MY_Theme_JSON_Resolver::$theme->get_data();
+			$data = $theme->get_data();
 
 			$theme_json = wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 			return preg_replace ( '~(?:^|\G)\h{4}~m', "\t", $theme_json );


### PR DESCRIPTION
Fixes #82 

This seems to have been a preexisting bug, as just calling get_data on the merged $theme appears to work across all block themes. However, it would be ideal if this was tested and confirmed.

Tested using the empty theme.json from the original issue, as well as Blockbase.