### PR TITLE
Save a theme variation

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -33,8 +33,9 @@ class Create_Block_Theme_Admin {
 		$this->add_theme_json_to_local( $export_type );
 	}
 
-	function save_variation_locally ( $export_type ) {
+	function save_variation ( $export_type, $theme ) {
 		$this->add_theme_json_variation_to_local( $export_type );
+		$this->export_theme( $theme );
 	}
 
 	function clear_user_customizations() {
@@ -801,12 +802,13 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 
 			else if ( $_GET['theme']['type'] === 'variation' ) {
 				if ( is_child_theme() ) {
-					$this->save_variation_locally( 'current' );
+					$this->save_variation( 'current', $_GET['theme'] );
 				}
 				else {
-					$this->save_variation_locally( 'all' );
+					$this->save_variation( 'all', $_GET['theme'] );
 				}
-				die('eeeee');
+
+				add_action( 'admin_notices', [ $this, 'admin_notice_variation_success' ] );
 			}
 
 			else if ( $_GET['theme']['type'] === 'blank' ) {
@@ -880,6 +882,16 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 		?>
 			<div class="notice notice-success is-dismissible">
 				<p><?php printf( esc_html__( 'Blank theme created, head over to Appearance > Themes to activate %1$s', 'create-block-theme' ), esc_html( $theme_name ) ); ?></p>
+			</div>
+		<?php
+	}
+
+	function admin_notice_variation_success() {
+		$theme_name = $_GET['theme']['name'];
+
+		?>
+			<div class="notice notice-success is-dismissible">
+				<p><?php printf( esc_html__( 'Your variation of %1$s has been created succesfully', 'create-block-theme' ), esc_html( $theme_name ) ); ?></p>
 			</div>
 		<?php
 	}

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -339,10 +339,22 @@ class Create_Block_Theme_Admin {
 	function add_theme_json_variation_to_local ( $export_type, $theme ) {
 		$variation_slug = sanitize_title( $theme['variation'] );
 		$variation_path = get_stylesheet_directory() . DIRECTORY_SEPARATOR . 'styles' . DIRECTORY_SEPARATOR;
+		$file_counter = 0;
+
 		if ( ! file_exists( $variation_path ) ) {
 			mkdir( $variation_path, 0755, true );
 		}
+		
+		if ( file_exists( $variation_path . $variation_slug . '.json' ) ) {
+			$file_counter++;
+			while ( file_exists( $variation_path . $variation_slug . '_' . $file_counter . '.json' ) ) {
+				$file_counter++;
+		   	}
+			$variation_slug = $variation_slug . '_' . $file_counter;
+		}
 
+		$_GET['theme']['variation_slug'] = $variation_slug;
+		
 		file_put_contents(
 			$variation_path . $variation_slug . '.json',
 			MY_Theme_JSON_Resolver::export_theme_data( $export_type )
@@ -912,7 +924,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 
 	function admin_notice_variation_success() {
 		$theme_name = wp_get_theme()->get( 'Name' );
-		$variation_name = get_stylesheet_directory() . DIRECTORY_SEPARATOR . 'styles' . DIRECTORY_SEPARATOR . sanitize_title( $_GET['theme']['variation'] ) .'.json';
+		$variation_name = get_stylesheet_directory() . DIRECTORY_SEPARATOR . 'styles' . DIRECTORY_SEPARATOR . $_GET['theme']['variation_slug'] .'.json';
 
 		?>
 			<div class="notice notice-success is-dismissible">

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -35,8 +35,7 @@ class Create_Block_Theme_Admin {
 	}
 
 	function save_variation ( $export_type, $theme ) {
-		$this->add_theme_json_variation_to_local( $export_type );
-		$this->export_theme( $theme );
+		$this->add_theme_json_variation_to_local( $export_type, $theme );
 	}
 
 	function clear_user_customizations() {
@@ -337,14 +336,14 @@ class Create_Block_Theme_Admin {
 		);
 	}
 
-	function add_theme_json_variation_to_local ( $export_type ) {
+	function add_theme_json_variation_to_local ( $export_type, $theme ) {
 		$variation_path = get_stylesheet_directory() . DIRECTORY_SEPARATOR . 'styles' . DIRECTORY_SEPARATOR;
 		if ( ! file_exists( $variation_path ) ) {
 			mkdir( $variation_path, 0755, true );
 		}
 
 		file_put_contents(
-			$variation_path . '/variation.json',
+			$variation_path . '/' . $theme['variation'] . '.json',
 			MY_Theme_JSON_Resolver::export_theme_data( $export_type )
 		);
 	}
@@ -791,12 +790,12 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 
 			// Check user capabilities.
 			if ( ! current_user_can( 'edit_theme_options' ) ) {
-				return add_action( 'admin_notices', [ $this, 'admin_notice_error' ] );
+				return add_action( 'admin_notices', [ $this, 'admin_notice_error_theme_name' ] );
 			}
 
 			// Check nonce
 			if ( ! wp_verify_nonce( $_GET['nonce'], 'create_block_theme' ) ) {
-				return add_action( 'admin_notices', [ $this, 'admin_notice_error' ] );
+				return add_action( 'admin_notices', [ $this, 'admin_notice_error_theme_name' ] );
 			}
 
 			if ( $_GET['theme']['type'] === 'save' ) {
@@ -812,6 +811,11 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 			}
 
 			else if ( $_GET['theme']['type'] === 'variation' ) {
+
+				if ( $_GET['theme']['variation'] === '' ) {
+					return add_action( 'admin_notices', [ $this, 'admin_notice_error_variation_name' ] );
+				}
+
 				if ( is_child_theme() ) {
 					$this->save_variation( 'current', $_GET['theme'] );
 				}
@@ -824,7 +828,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 
 			else if ( $_GET['theme']['type'] === 'blank' ) {
 				if ( $_GET['theme']['name'] === '' ) {
-					return add_action( 'admin_notices', [ $this, 'admin_notice_error' ] );
+					return add_action( 'admin_notices', [ $this, 'admin_notice_error_theme_name' ] );
 				}
 				$this->create_blank_theme( $_GET['theme'] );
 
@@ -834,7 +838,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 			else if ( is_child_theme() ) {
 				if ( $_GET['theme']['type'] === 'sibling' ) {
 					if ( $_GET['theme']['name'] === '' ) {
-						return add_action( 'admin_notices', [ $this, 'admin_notice_error' ] );
+						return add_action( 'admin_notices', [ $this, 'admin_notice_error_theme_name' ] );
 					}
 					$this->create_sibling_theme( $_GET['theme'] );
 				}
@@ -845,13 +849,13 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 			} else {
 				if( $_GET['theme']['type'] === 'child' ) {
 					if ( $_GET['theme']['name'] === '' ) {
-						return add_action( 'admin_notices', [ $this, 'admin_notice_error' ] );
+						return add_action( 'admin_notices', [ $this, 'admin_notice_error_theme_name' ] );
 					}
 					$this->create_child_theme( $_GET['theme'] );
 				}
 				else if( $_GET['theme']['type'] === 'clone' ) {
 					if ( $_GET['theme']['name'] === '' ) {
-						return add_action( 'admin_notices', [ $this, 'admin_notice_error' ] );
+						return add_action( 'admin_notices', [ $this, 'admin_notice_error_theme_name' ] );
 					}
 					$this->clone_theme( $_GET['theme'] );
 				}
@@ -864,9 +868,16 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 		}
 	}
 
-	function admin_notice_error() {
+	function admin_notice_error_theme_name_theme_name() {
 		$class = 'notice notice-error';
 		$message = __( 'Please specify a theme name.', 'create-block-theme' );
+
+		printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
+	}
+
+	function admin_notice_error_variation_name() {
+		$class = 'notice notice-error';
+		$message = __( 'Please specify a variation name.', 'create-block-theme' );
 
 		printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
 	}

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -33,6 +33,10 @@ class Create_Block_Theme_Admin {
 		$this->add_theme_json_to_local( $export_type );
 	}
 
+	function save_variation_locally ( $export_type ) {
+		$this->add_theme_json_variation_to_local( $export_type );
+	}
+
 	function clear_user_customizations() {
 
 		// Clear all values in the user theme.json
@@ -327,6 +331,18 @@ class Create_Block_Theme_Admin {
 	function add_theme_json_to_local ( $export_type ) {
 		file_put_contents(
 			get_stylesheet_directory() . '/theme.json',
+			MY_Theme_JSON_Resolver::export_theme_data( $export_type )
+		);
+	}
+
+	function add_theme_json_variation_to_local ( $export_type ) {
+		$variation_path = get_stylesheet_directory() . DIRECTORY_SEPARATOR . 'styles' . DIRECTORY_SEPARATOR;
+		if ( ! file_exists( $variation_path ) ) {
+			mkdir( $variation_path, 0755, true );
+		}
+
+		file_put_contents(
+			$variation_path . '/variation.json',
 			MY_Theme_JSON_Resolver::export_theme_data( $export_type )
 		);
 	}
@@ -704,6 +720,12 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 								<?php _e('[Generates a boilerplate "empty" theme inside of this site\'s themes directory.]', 'create-block-theme'); ?>
 							</label>
 							<br /><br />
+							<label>
+								<input value="variation" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').setAttribute('hidden', null);" />
+								<?php _e('Create a style variation ', 'create-block-theme'); ?><br />
+								<?php _e('[Generates a style variation for the current theme. Any template changes will be ignored.]', 'create-block-theme'); ?>
+							</label>
+							<br /><br />
 
 							<input type="submit" value="<?php _e('Create theme', 'create-block-theme'); ?>" class="button button-primary" />
 
@@ -775,6 +797,16 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 				$this->clear_user_customizations();
 
 				add_action( 'admin_notices', [ $this, 'admin_notice_save_success' ] );
+			}
+
+			else if ( $_GET['theme']['type'] === 'variation' ) {
+				if ( is_child_theme() ) {
+					$this->save_variation_locally( 'current' );
+				}
+				else {
+					$this->save_variation_locally( 'all' );
+				}
+				die('eeeee');
 			}
 
 			else if ( $_GET['theme']['type'] === 'blank' ) {

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -869,7 +869,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 		}
 	}
 
-	function admin_notice_error_theme_name_theme_name() {
+	function admin_notice_error_theme_name() {
 		$class = 'notice notice-error';
 		$message = __( 'Please specify a theme name.', 'create-block-theme' );
 

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -711,7 +711,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 								<br /><br />
 							<?php endif; ?>
 							<label>
-								<input value="save" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', true );toggleForm( 'new_variation_metadata_form', true ):" />
+								<input value="save" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', true );toggleForm( 'new_variation_metadata_form', true );" />
 								<?php _e('Overwrite ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?><br />
 								<?php _e('[Save USER changes as THEME changes and delete the USER changes.  Your changes will be saved in the theme on the folder.]', 'create-block-theme'); ?>
 							</label>

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -681,7 +681,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 							<p><?php printf( esc_html__('Export your current block theme (%1$s) with changes you made to Templates, Template Parts and Global Styles.', 'create-block-theme'),  esc_html( wp_get_theme()->get('Name') ) ); ?></p>
 
 							<label>
-								<input checked value="export" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', true );" />
+								<input checked value="export" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', true );toggleForm( 'new_variation_metadata_form', true );" />
 								<?php _e('Export ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?><br />
 								<?php _e('[Export the activated theme with user changes]', 'create-block-theme'); ?>
 							</label>
@@ -711,7 +711,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 								<br /><br />
 							<?php endif; ?>
 							<label>
-								<input value="save" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', true );" />
+								<input value="save" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', true );toggleForm( 'new_variation_metadata_form', true ):" />
 								<?php _e('Overwrite ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?><br />
 								<?php _e('[Save USER changes as THEME changes and delete the USER changes.  Your changes will be saved in the theme on the folder.]', 'create-block-theme'); ?>
 							</label>

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -26,6 +26,7 @@ class Create_Block_Theme_Admin {
 		$page_title=__('Create Block Theme', 'create-block-theme');
 		$menu_title=__('Create Block Theme', 'create-block-theme');
 		add_theme_page( $page_title, $menu_title, 'edit_theme_options', 'create-block-theme', [ $this, 'create_admin_form_page' ] );
+		add_action('admin_enqueue_scripts', [ $this, 'form_script' ] );
 	}
 
 	function save_theme_locally( $export_type ) {
@@ -680,14 +681,14 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 							<p><?php printf( esc_html__('Export your current block theme (%1$s) with changes you made to Templates, Template Parts and Global Styles.', 'create-block-theme'),  esc_html( wp_get_theme()->get('Name') ) ); ?></p>
 
 							<label>
-								<input checked value="export" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').setAttribute('hidden', null);" />
+								<input checked value="export" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', true );" />
 								<?php _e('Export ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?><br />
 								<?php _e('[Export the activated theme with user changes]', 'create-block-theme'); ?>
 							</label>
 							<br /><br />
 							<?php if ( is_child_theme() ): ?>
 								<label>
-									<input value="sibling" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/>
+									<input value="sibling" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', false );"/>
 									<?php _e('Create sibling of ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
 								</label>
 								<br />
@@ -696,35 +697,35 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 								<br />
 							<?php else: ?>
 								<label>
-									<input value="child" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/>
+									<input value="child" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', false );"/>
 									<?php _e('Create child of ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?>
 								</label>
 								<br />
 								<?php _e('[Create a new child theme. The currently activated theme will be the parent theme.]', 'create-block-theme'); ?>
 								<br /><br />
 								<label>
-									<input value="clone" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden');"/>
+									<input value="clone" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', false );"/>
 									<?php _e('Clone ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?><br />
 									<?php _e('[Create a new theme cloning the activated theme. The resulting theme will have all of the assets of the activated theme as well as user changes.]', 'create-block-theme'); ?>
 								</label>
 								<br /><br />
 							<?php endif; ?>
 							<label>
-								<input value="save" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').setAttribute('hidden', null);" />
+								<input value="save" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', true );" />
 								<?php _e('Overwrite ', 'create-block-theme'); echo wp_get_theme()->get('Name'); ?><br />
 								<?php _e('[Save USER changes as THEME changes and delete the USER changes.  Your changes will be saved in the theme on the folder.]', 'create-block-theme'); ?>
 							</label>
 							<br /><br />
 							<label>
-								<input value="blank" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').removeAttribute('hidden', null);" />
+								<input value="blank" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', false );" />
 								<?php _e('Create blank theme ', 'create-block-theme'); ?><br />
 								<?php _e('[Generates a boilerplate "empty" theme inside of this site\'s themes directory.]', 'create-block-theme'); ?>
 							</label>
 							<br /><br />
 							<label>
-								<input value="variation" type="radio" name="theme[type]" class="regular-text code" onchange="document.getElementById('new_theme_metadata_form').setAttribute('hidden', null);" />
+								<input value="variation" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_variation_metadata_form', false );" />
 								<?php _e('Create a style variation ', 'create-block-theme'); ?><br />
-								<?php _e('[Generates a style variation for the current theme. Any template changes will be ignored.]', 'create-block-theme'); ?>
+								<?php printf( esc_html__('[Saves user changes as a style variation of %1$s.]', 'create-block-theme'),  esc_html( wp_get_theme()->get('Name') ) ); ?>
 							</label>
 							<br /><br />
 
@@ -734,6 +735,12 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 					</div>
 					<div id="col-right">
 						<div class="col-wrap">
+							<div hidden id="new_variation_metadata_form">
+								<label>
+									<?php _e('Variation Name (*):', 'create-block-theme'); ?><br />
+									<input placeholder="<?php _e('Variation Name', 'create-block-theme'); ?>" type="text" name="theme[variation]" class="large-text" />
+								</label>
+							</div>
 							<div hidden id="new_theme_metadata_form">
 								<label>
 									<?php _e('Theme Name (*):', 'create-block-theme'); ?><br />
@@ -772,6 +779,10 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 			</form>
 		</div>
 	<?php
+	}
+
+	function form_script() {
+		wp_enqueue_script('form-script', plugin_dir_url(__FILE__) . '/js/form-script.js');
 	}
 
 	function blockbase_save_theme() {
@@ -888,10 +899,11 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 
 	function admin_notice_variation_success() {
 		$theme_name = $_GET['theme']['name'];
+		$variation_name = get_stylesheet_directory() . '/styles/' . $_GET['theme']['variation'] .'.json';
 
 		?>
 			<div class="notice notice-success is-dismissible">
-				<p><?php printf( esc_html__( 'Your variation of %1$s has been created succesfully', 'create-block-theme' ), esc_html( $theme_name ) ); ?></p>
+				<p><?php printf( esc_html__( 'Your variation of %1$s has been created succesfully. The new variation file is in %2$s', 'create-block-theme' ), esc_html( $theme_name ) , esc_html( $variation_name )  ); ?></p>
 			</div>
 		<?php
 	}

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -910,12 +910,12 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 	}
 
 	function admin_notice_variation_success() {
-		$theme_name = $_GET['theme']['name'];
+		$theme_name = wp_get_theme()->get( 'Name' );
 		$variation_name = get_stylesheet_directory() . '/styles/' . $_GET['theme']['variation'] .'.json';
 
 		?>
 			<div class="notice notice-success is-dismissible">
-				<p><?php printf( esc_html__( 'Your variation of %1$s has been created succesfully. The new variation file is in %2$s', 'create-block-theme' ), esc_html( $theme_name ) , esc_html( $variation_name )  ); ?></p>
+				<p><?php printf( esc_html__( 'Your variation of %1$s has been created successfully. The new variation file is in %2$s', 'create-block-theme' ), esc_html( $theme_name ) , esc_html( $variation_name )  ); ?></p>
 			</div>
 		<?php
 	}

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -822,6 +822,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 				else {
 					$this->save_variation( 'all', $_GET['theme'] );
 				}
+				$this->clear_user_customizations();
 
 				add_action( 'admin_notices', [ $this, 'admin_notice_variation_success' ] );
 			}

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -337,13 +337,14 @@ class Create_Block_Theme_Admin {
 	}
 
 	function add_theme_json_variation_to_local ( $export_type, $theme ) {
+		$variation_slug = sanitize_title( $theme['variation'] );
 		$variation_path = get_stylesheet_directory() . DIRECTORY_SEPARATOR . 'styles' . DIRECTORY_SEPARATOR;
 		if ( ! file_exists( $variation_path ) ) {
 			mkdir( $variation_path, 0755, true );
 		}
 
 		file_put_contents(
-			$variation_path . '/' . $theme['variation'] . '.json',
+			$variation_path . $variation_slug . '.json',
 			MY_Theme_JSON_Resolver::export_theme_data( $export_type )
 		);
 	}
@@ -718,13 +719,13 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 							<label>
 								<input value="blank" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_theme_metadata_form', false );" />
 								<?php _e('Create blank theme ', 'create-block-theme'); ?><br />
-								<?php _e('[Generates a boilerplate "empty" theme inside of this site\'s themes directory.]', 'create-block-theme'); ?>
+								<?php _e('[Generate a boilerplate "empty" theme inside of this site\'s themes directory.]', 'create-block-theme'); ?>
 							</label>
 							<br /><br />
 							<label>
 								<input value="variation" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( 'new_variation_metadata_form', false );" />
 								<?php _e('Create a style variation ', 'create-block-theme'); ?><br />
-								<?php printf( esc_html__('[Saves user changes as a style variation of %1$s.]', 'create-block-theme'),  esc_html( wp_get_theme()->get('Name') ) ); ?>
+								<?php printf( esc_html__('[Save user changes as a style variation of %1$s.]', 'create-block-theme'),  esc_html( wp_get_theme()->get('Name') ) ); ?>
 							</label>
 							<br /><br />
 
@@ -911,7 +912,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 
 	function admin_notice_variation_success() {
 		$theme_name = wp_get_theme()->get( 'Name' );
-		$variation_name = get_stylesheet_directory() . '/styles/' . $_GET['theme']['variation'] .'.json';
+		$variation_name = get_stylesheet_directory() . DIRECTORY_SEPARATOR . 'styles' . DIRECTORY_SEPARATOR . sanitize_title( $_GET['theme']['variation'] ) .'.json';
 
 		?>
 			<div class="notice notice-success is-dismissible">

--- a/admin/js/form-script.js
+++ b/admin/js/form-script.js
@@ -1,0 +1,9 @@
+function toggleForm( formID, hide ){
+	if( formID == 'new_theme_metadata_form' && !hide ) {
+		toggleForm( 'new_variation_metadata_form', true );
+	}
+	if( formID == 'new_variation_metadata_form' && !hide ) {
+		toggleForm( 'new_theme_metadata_form', true );
+	}
+	document.getElementById( formID ).toggleAttribute('hidden', hide);
+}


### PR DESCRIPTION
This new option saves the users global styles changes into a variation instead of a child theme or a new clone of the theme. I opted in for the easiest way to do this, saving the file locally with a generic file name and downloading the zip file, but it's up for discussion if we want to do it this way:

- Should we ask the user for a variation name?
- Should the exported ZIP file only include the variation or the whole theme included like in this case?
- Is the wording on the new option clear for what the feature does?

<img width="910" alt="Screenshot 2022-07-26 at 10 17 22" src="https://user-images.githubusercontent.com/3593343/180959078-fb699cf0-8964-4e6d-8518-5aeac5673da9.png">

Closes #89