### PR TITLE
Add $schema and use Gutenberg classes

### DIFF
--- a/admin/resolver_additions.php
+++ b/admin/resolver_additions.php
@@ -29,7 +29,13 @@ function augment_resolver_with_utilities() {
 				// Get parent theme.json.
 				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
 				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
+
+				// Get the schema from the parent JSON.
 				$schema = $parent_theme_json_data['$schema'];
+				if( array_key_exists( 'schema', $parent_theme_json_data ) ) {
+					$schema = $parent_theme_json_data['$schema'];
+				}
+
 				if ( class_exists( 'WP_Theme_JSON_Gutenberg' ) ) {
 					$parent_theme = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
 				} else {
@@ -41,7 +47,12 @@ function augment_resolver_with_utilities() {
 			if ( $content === 'all' || $content === 'current' ) {
 				$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
 				$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-				$schema = $theme_json_data['$schema'];
+
+				// Get the schema from the parent JSON.
+				if( array_key_exists( 'schema', $theme_json_data ) ) {
+					$schema = $theme_json_data['$schema'];
+				}
+
 				if ( class_exists( 'WP_Theme_JSON_Gutenberg' ) ) {
 					$theme_theme = new WP_Theme_JSON_Gutenberg( $theme_json_data );
 				} else {
@@ -55,6 +66,9 @@ function augment_resolver_with_utilities() {
 			$data = $theme->get_data();
 
 			// Add the schema.
+			if ( empty( $schema ) ) {
+				$schema = 'https://schemas.wp.org/trunk/theme.json';
+			}
 			$data['$schema'] = $schema;
 			$theme_json = wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 			return preg_replace ( '~(?:^|\G)\h{4}~m', "\t", $theme_json );

--- a/admin/resolver_additions.php
+++ b/admin/resolver_additions.php
@@ -19,20 +19,34 @@ function augment_resolver_with_utilities() {
 		 * 'all' will include settings from the current theme as well as the parent theme (if it has one)
 		 */
 		public static function export_theme_data( $content ) {
-			$theme = new WP_Theme_JSON();
+			if ( class_exists( 'WP_Theme_JSON_Gutenberg' ) ) {
+				$theme = new WP_Theme_JSON_Gutenberg();
+			} else {
+				$theme = new WP_Theme_JSON();
+			}
 
 			if ( $content === 'all' && wp_get_theme()->parent() ) {
 				// Get parent theme.json.
 				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
 				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
-				$parent_theme           = new WP_Theme_JSON( $parent_theme_json_data );
-				$theme->merge ($parent_theme);
+				$schema = $parent_theme_json_data['$schema'];
+				if ( class_exists( 'WP_Theme_JSON_Gutenberg' ) ) {
+					$parent_theme = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
+				} else {
+					$parent_theme = new WP_Theme_JSON( $parent_theme_json_data );
+				}
+				$theme->merge($parent_theme);
 			}
 
 			if ( $content === 'all' || $content === 'current' ) {
 				$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
 				$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-				$theme_theme     = new WP_Theme_JSON( $theme_json_data );
+				$schema = $theme_json_data['$schema'];
+				if ( class_exists( 'WP_Theme_JSON_Gutenberg' ) ) {
+					$theme_theme = new WP_Theme_JSON_Gutenberg( $theme_json_data );
+				} else {
+					$theme_theme = new WP_Theme_JSON( $theme_json_data );
+				}
  				$theme->merge( $theme_theme );
 			}
 
@@ -40,6 +54,8 @@ function augment_resolver_with_utilities() {
 
 			$data = $theme->get_data();
 
+			// Add the schema.
+			$data['$schema'] = $schema;
 			$theme_json = wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 			return preg_replace ( '~(?:^|\G)\h{4}~m', "\t", $theme_json );
 


### PR DESCRIPTION
This adds the $schema key when overwriting and exporting themes. It also uses the WP_Theme_JSON_Gutenberg class if it's available, so that the latest features of the plugin are included.

To test, try exporting/overwriting a block theme and check that the $schema key still exists. Also check that button elements aren't wiped. You can see an example here: https://github.com/Automattic/themes/pull/5708

Fixes #81