### PR TITLE
Update google fonts JSON data automatically using a repo action

### DIFF
--- a/.github/workflows/update-google-fons-data.yml
+++ b/.github/workflows/update-google-fons-data.yml
@@ -36,8 +36,8 @@ jobs:
       run: |
         echo "Updating Google fonts JSON"
         node ./update-google-fonts-json-file.js
-        git config user.name 'Matias Benedetto'
-        git config user.email 'matias.benedetto@gmail.com'
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
         git config --global --add --bool push.autoSetupRemote true
         
         git diff-index --quiet HEAD -- || ( git add assets/google-fonts/fallback-fonts-list.json && git checkout -b ${{ env.BRANCH_NAME }} && git commit -m "Updating file" && git push && gh pr create -B trunk -H ${{ env.BRANCH_NAME }} --title "Update Google Fonts JSON data from API" --body "Created by Update Google Fonts JSON Github action" )

--- a/.github/workflows/update-google-fons-data.yml
+++ b/.github/workflows/update-google-fons-data.yml
@@ -1,0 +1,44 @@
+# This is a basic workflow that is manually triggered
+
+name: Update Google Fonts JSON
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  schedule:
+    - cron: '0 0 1,7,14,21,28 * *' # Runs weekly, more precisely at 00:00 on day-of-month 1, 7, 14, 21, and 28.
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "update-google-fonts-json"
+  update-google-fonts-json:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+    # Runs a single command using the runners shell
+    # This script fetchs the Goolgle Fonts API data and creates a PR if new data is available
+    - name: Update Google Fonts JSON
+      env:
+        GOOGLE_FONTS_API_KEY: ${{ secrets.GOOGLE_FONTS_API_KEY }}
+        BRANCH_NAME: update/google-fonts-json-${{ steps.date.outputs.date }}_${{ github.run_id }}
+        GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+      run: |
+        echo "Updating Google fonts JSON"
+        node ./update-google-fonts-json-file.js
+        git config user.name 'Matias Benedetto'
+        git config user.email 'matias.benedetto@gmail.com'
+        git config --global --add --bool push.autoSetupRemote true
+        
+        git diff-index --quiet HEAD -- || ( git add assets/google-fonts/fallback-fonts-list.json && git checkout -b ${{ env.BRANCH_NAME }} && git commit -m "Updating file" && git push && gh pr create -B trunk -H ${{ env.BRANCH_NAME }} --title "Update Google Fonts JSON data from API" --body "Created by Update Google Fonts JSON Github action" )
+        

--- a/.github/workflows/update-google-fons-data.yml
+++ b/.github/workflows/update-google-fons-data.yml
@@ -6,7 +6,7 @@ name: Update Google Fonts JSON
 # or API.
 on:
   schedule:
-    - cron: '0 0 1,7,14,21,28 * *' # Runs weekly, more precisely at 00:00 on day-of-month 1, 7, 14, 21, and 28.
+    - cron: '0 0 * * TUE' # Runs weekly, every Tuesday.
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/update-google-fons-data.yml
+++ b/.github/workflows/update-google-fons-data.yml
@@ -32,7 +32,7 @@ jobs:
       env:
         GOOGLE_FONTS_API_KEY: ${{ secrets.GOOGLE_FONTS_API_KEY }}
         BRANCH_NAME: update/google-fonts-json-${{ steps.date.outputs.date }}_${{ github.run_id }}
-        GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         echo "Updating Google fonts JSON"
         node ./update-google-fonts-json-file.js

--- a/update-google-fonts-json-file.js
+++ b/update-google-fonts-json-file.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const crypto = require('crypto');
+
+const API_URL = "https://www.googleapis.com/webfonts/v1/webfonts?key=";
+const API_KEY = process.env.GOOGLE_FONTS_API_KEY;
+
+function calculateHash (somestring){
+    return crypto.createHash('md5').update(somestring).digest('hex').toString();
+};
+
+async function updateFiles () {
+    let newApiData;
+    let newData;
+
+    try {
+        newApiData = await fetch(`${API_URL}${API_KEY}`);
+        newData = await newApiData.json();
+    } catch (error) {
+        console.error("❎  Error fetching the Google Fonts API:", error);
+        return;
+    }
+
+    if ( newData.items ) {
+        const newDataString = JSON.stringify(newData, null, 2);
+
+        const oldFileData = fs.readFileSync('./assets/google-fonts/fallback-fonts-list.json', 'utf8');
+        const oldData = JSON.parse(oldFileData);
+        const oldDataString = JSON.stringify(oldData, null, 2);
+
+        if ( calculateHash(newDataString) !== calculateHash(oldDataString) ) {
+            fs.writeFileSync('./assets/google-fonts/fallback-fonts-list.json', newDataString);
+            console.info("✅  Google Fonts JSON file updated");
+        } else {
+            console.info("ℹ️  Google Fonts JSON file is up to date");
+        }
+
+    } else {
+        console.error("❎  No new data to check. Check the Google Fonts API key.");
+    }
+}
+
+
+updateFiles ();

--- a/update-google-fonts-json-file.js
+++ b/update-google-fonts-json-file.js
@@ -17,7 +17,7 @@ async function updateFiles () {
         newData = await newApiData.json();
     } catch (error) {
         console.error("❎  Error fetching the Google Fonts API:", error);
-        return;
+        process.exit(1);
     }
 
     if ( newData.items ) {
@@ -36,6 +36,7 @@ async function updateFiles () {
 
     } else {
         console.error("❎  No new data to check. Check the Google Fonts API key.");
+        process.exit(1);
     }
 }
 


### PR DESCRIPTION
## What ?
Automated update of the Google fonts JSON data using a Github action that checks Google Fonts API and creates a new PR  with the update if there is new data.

##  Why ? 
Because we need to keep the Google fonts data up to date and we can data automatically without sharing the Google Fonts API key.

## How ?

This Github action will check every week if there is new data coming from the Google fonts API. If there is new data the Github action will:
- Create a new branch in the repo
- Update the JSON that contains the google fonts data
- Add and commit the JSON file
- Push the file to the new branch
- Create a PR with the updates.


## Requirements
We need to include 2 keys a GitHub repo secrets:
- GOOGLE_FONTS_API_KEY (to fetch the Google API)



## Screncast:
[I tried these changes on a test repo](https://github.com/matiasbenedetto/testing-actions) to be able to use secrets and avoid polluting this repo with test changes. Here is a demonstration of the action running triggered manually instead of using a cron expression.


[Screencast from 03-10-22 11:56:54.webm](https://user-images.githubusercontent.com/1310626/193622711-2c84f797-c141-4382-be5a-d8ae68e36ed0.webm)
