### PR TITLE
Prototype: Add custom templates

### DIFF
--- a/create-block-theme.php
+++ b/create-block-theme.php
@@ -40,18 +40,30 @@ function run_create_block_theme() {
 }
 run_create_block_theme();
 
+function replace_between($str, $needle_start, $needle_end, $replacement) {
+    $pos = strpos($str, $needle_start);
+    $start = $pos === false ? 0 : $pos;
+
+    $pos = strpos($str, $needle_end, $start);
+    $end = $pos === false ? strlen($str) : $pos + strlen( $needle_end );
+
+    return substr_replace($str, $replacement, $start, $end - $start);
+}
+
 function get_custom_template() {
 	$plugin = 'plugin-name';
 	$slug = 'custom-template';
 	$template_id = $plugin . '//' . $slug;
 	$title = 'template-title';
 	$description = 'description';
-	$content = '<!-- wp:template-part {"slug":"header","tagName":"header"} /--><!-- wp:group {"layout":{"inherit":true}} --><div class="wp-block-group"><!-- wp:woocommerce/legacy-template {"template":"single-product"} /--></div><!-- /wp:group --><!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer-container"} /-->';
+	$custom_content = '<!-- wp:woocommerce/legacy-template {"template":"single-product"} /-->';
+	$index_template = wp_get_theme()->get_file_path( '/templates/index.html' );
+	$index_template_content = replace_between( file_get_contents( $index_template ), '<!-- wp:query', '<!-- /wp:query -->', $custom_content );
 
 	$template                 = new WP_Block_Template();
 	$template->id             = $template_id;
 	$template->theme          = $plugin;
-	$template->content        = $content;
+	$template->content        = $index_template_content;
 	$template->slug           = $slug;
 	$template->source         = 'plugin';
 	$template->type           = 'wp_template';

--- a/create-block-theme.php
+++ b/create-block-theme.php
@@ -39,3 +39,46 @@ function run_create_block_theme() {
 
 }
 run_create_block_theme();
+
+function get_custom_template() {
+	$plugin = 'plugin-name';
+	$slug = 'custom-template';
+	$template_id = $plugin . '//' . $slug;
+	$title = 'template-title';
+	$description = 'description';
+	$content = '<!-- wp:template-part {"slug":"header","tagName":"header"} /--><!-- wp:group {"layout":{"inherit":true}} --><div class="wp-block-group"><!-- wp:woocommerce/legacy-template {"template":"single-product"} /--></div><!-- /wp:group --><!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer-container"} /-->';
+
+	$template                 = new WP_Block_Template();
+	$template->id             = $template_id;
+	$template->theme          = $plugin;
+	$template->content        = $content;
+	$template->slug           = $slug;
+	$template->source         = 'plugin';
+	$template->type           = 'wp_template';
+	$template->title          = $title;
+	$template->status         = 'publish';
+	$template->has_theme_file = false;
+	$template->is_custom      = true;
+	$template->description    = $description;
+	return $template;
+}
+
+function add_block_templates( $query_result, $query, $template_type ) {
+	if ( empty( $query ) && $template_type === 'wp_template' ) {
+		$query_result[] = get_custom_template();
+	}
+	return $query_result;
+}
+add_filter( 'get_block_templates', 'add_block_templates', 10, 3 );
+
+function add_block_template( $block_template, $id, $template_type ) {
+	$custom_template = get_custom_template();
+
+	if ( empty( $block_template ) && $template_type === 'wp_template' && $id === $custom_template->id ) {
+		$block_template = $custom_template;
+	}
+
+	return $block_template;
+}
+
+add_filter( 'get_block_template', 'add_block_template', 10, 3 );


### PR DESCRIPTION
This is a prototype of how plugins might want to add custom templates to a theme without needing to modify the theme itself. 

This works by attaching to two filters: `get_block_template` and `get_block_templates`. The new custom template is added programatically to the theme using these filters.

This approach could be used by plugins who require themes to have specific templates in order to function, without having to actually add the files to the theme.

One problem with this approach is that it makes some assumptions about the base template of the theme.
