### PR TITLE
Force https to load Google fonts preview

### DIFF
--- a/admin/js/google-fonts.js
+++ b/admin/js/google-fonts.js
@@ -56,7 +56,9 @@ function displayFontOptions () {
         // Loads the selected font to create the previews
         const style = variant.includes('italic') ? 'italic' : 'normal';
         const weight = variant === 'regular' || variant === 'italic' ? '400' : variant.replace('italic', '');
-        const newFont = new FontFace(fontSelected['family'], `url(${fontSelected['files'][variant]})`, { style: style, weight: weight });
+        // Force https because sometimes Google Fonts API returns http instead of https
+        const variantUrl = fontSelected['files'][variant].replace("http://", "https://");
+        const newFont = new FontFace(fontSelected['family'], `url(${variantUrl})`, { style: style, weight: weight });
         newFont.load().then(function(loaded_face) {
             document.fonts.add(loaded_face);
         }).catch(function(error) {


### PR DESCRIPTION
## What?
Force https to load Google fonts preview

## Why?

For some mysterious reason the Google Fonts API gives us the URL address of the fonts assets using http instead of https.

It seems like a Google Fonts API bug, because I don't see why they still use http instead of https when they mark all sites using http as insecure. But, anyway, we can add a quick workaround in the plugin code.

Why this problem didn't appear before? Because I think we were testing it in the local dev env using just http. When it is used in a prod site as now, the pages are loaded with https so the browser avoids mixing contents loaded using https (as the site) and http as the Google font asset files. 