### PR TITLE
Add the ability to select/unselect all google font variants

### DIFF
--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -210,7 +210,7 @@ class Manage_Fonts_Admin {
 				<table class="wp-list-table widefat fixed striped table-view-list" id="google-fonts-table">
 					<thead>
 						<tr>
-							<td class=""></td>
+							<td class=""><input type="checkbox" id="select-all-variants" /></td>
 							<td class=""><?php printf( esc_html__('Variant', 'create-block-theme')); ?></td>
 							<td class=""><?php printf( esc_html__('Preview', 'create-block-theme')); ?></td>
 						</tr>

--- a/admin/js/google-fonts.js
+++ b/admin/js/google-fonts.js
@@ -9,10 +9,11 @@ function prepareToggleSelectAllVariants () {
 }
 
 function toggleSelectAllVariants () {
-    const checkboxes = document.querySelectorAll('#font-options input[type="checkbox"]');
-    checkboxes.forEach(checkbox => {
+    const variantCheckboxes = document.querySelectorAll('#font-options input[type="checkbox"]');
+    variantCheckboxes.forEach(checkbox => {
         checkbox.checked = this.checked;
     });
+    checkIfFormIsAbleToSubmit();
 }
 
 async function get_google_fonts() {
@@ -106,14 +107,19 @@ function displayFontOptions () {
 
 function onFontVariantChange () {
     const googleFontsSelectedElement = document.getElementById('google-font-variants');
-    const submitElement = document.getElementById('google-fonts-submit');
     if (this.checked) {
         variantsSelected[this.id] = fontSelected['files'][this.id];
     } else {
         delete variantsSelected[this.id];
     }
     googleFontsSelectedElement.value = Object.keys(variantsSelected).map(key => `${key}::${variantsSelected[key]}`).join(',');
-    submitElement.disabled = !googleFontsSelectedElement.value;
+    checkIfFormIsAbleToSubmit();
+}
+
+function checkIfFormIsAbleToSubmit () {
+    const variantCheckboxes = document.querySelectorAll('#font-options input[type="checkbox"]');
+    const submitElement = document.getElementById('google-fonts-submit');
+    submitElement.disabled = ! Array.from(variantCheckboxes).find(checkbox => checkbox.checked);
 }
 
 function emptyFontOptions () {

--- a/admin/js/google-fonts.js
+++ b/admin/js/google-fonts.js
@@ -4,8 +4,8 @@ let fontSelected = null;
 let variantsSelected = {};
 
 function prepareToggleSelectAllVariants () {
-    const element = document.getElementById('select-all-variants');
-    element.addEventListener('click', toggleSelectAllVariants);
+    const selectAllVariantsElement = document.getElementById('select-all-variants');
+    selectAllVariantsElement.addEventListener('click', toggleSelectAllVariants);
 }
 
 function toggleSelectAllVariants () {
@@ -124,6 +124,8 @@ function emptyFontOptions () {
     const submitElement = document.getElementById('google-fonts-submit');
     submitElement.disabled = true;
     variantsSelected = {};
+    const selectAllVariantsElement = document.getElementById('select-all-variants');
+    selectAllVariantsElement.checked = false;
 }
 
 function init () {

--- a/admin/js/google-fonts.js
+++ b/admin/js/google-fonts.js
@@ -3,6 +3,18 @@ let fonts = [];
 let fontSelected = null;
 let variantsSelected = {};
 
+function prepareToggleSelectAllVariants () {
+    const element = document.getElementById('select-all-variants');
+    element.addEventListener('click', toggleSelectAllVariants);
+}
+
+function toggleSelectAllVariants () {
+    const checkboxes = document.querySelectorAll('#font-options input[type="checkbox"]');
+    checkboxes.forEach(checkbox => {
+        checkbox.checked = this.checked;
+    });
+}
+
 async function get_google_fonts() {
         const currentUrl = new URL(document.getElementById('google-fonts-script-js').src);
         const fallbackURL = currentUrl.origin + currentUrl.pathname.replace('admin/js/google-fonts.js', 'assets/google-fonts/fallback-fonts-list.json');
@@ -117,6 +129,7 @@ function emptyFontOptions () {
 function init () {
     fillFontSelect();
     prepareSelectElement();
+    prepareToggleSelectAllVariants();
 }
 
 init();

--- a/admin/js/google-fonts.js
+++ b/admin/js/google-fonts.js
@@ -13,6 +13,7 @@ function toggleSelectAllVariants () {
     variantCheckboxes.forEach(checkbox => {
         checkbox.checked = this.checked;
     });
+    onFontVariantChange();
     checkIfFormIsAbleToSubmit();
 }
 
@@ -106,13 +107,22 @@ function displayFontOptions () {
 }
 
 function onFontVariantChange () {
-    const googleFontsSelectedElement = document.getElementById('google-font-variants');
-    if (this.checked) {
-        variantsSelected[this.id] = fontSelected['files'][this.id];
-    } else {
-        delete variantsSelected[this.id];
+    const variantCheckboxes = document.querySelectorAll('#font-options input[type="checkbox"]');
+
+    // updates the variantsSelected object with the selected variants
+    for (const checkbox of variantCheckboxes) {
+        if (checkbox.checked) {
+            variantsSelected[checkbox.id] = fontSelected['files'][checkbox.id];
+        } else {
+            delete variantsSelected[checkbox.id];
+        }
     }
+
+    // write the input that will be submitted to the server
+    const googleFontsSelectedElement = document.getElementById('google-font-variants');
     googleFontsSelectedElement.value = Object.keys(variantsSelected).map(key => `${key}::${variantsSelected[key]}`).join(',');
+    
+    // enable/disable the form submit button
     checkIfFormIsAbleToSubmit();
 }
 

--- a/admin/js/google-fonts.js
+++ b/admin/js/google-fonts.js
@@ -45,20 +45,20 @@ function onGoogleFontNameChange() {
     const fontsTableElement = document.getElementById("google-fonts-table");
     const hintElements = document.querySelector('.hint');
 
+    emptyFontOptions();
+
     if(this.value) {
         fontNameElement.value = fonts[this.value]['family'];
         fontSelected = fonts[this.value];
         fontsTableElement.style.display = "block";
         hintElements.style.display = "block";
+        displayFontOptions();
     } else {
         fontNameElement.value = "";
         fontSelected = null;
         fontsTableElement.style.display = "none";
         hintElements.style.display = "none";
     }
-
-    emptyFontOptions();
-    displayFontOptions();
 }
 
 function displayFontOptions () {

--- a/css/google-fonts.css
+++ b/css/google-fonts.css
@@ -2,6 +2,10 @@
     display: none;
 }
 
+#google-fonts-table.widefat thead td input {
+    margin: 0;
+}
+
 #google-fonts-table tbody tr td:nth-of-type(3) {
     width: 100%;
 }


### PR DESCRIPTION
## What?
Add the ability to select/unselect all google font variants

## Why?
To speed up the selection of font faces variants.

### Note:
I'm submitting this PR with `try/manage-fonts` as the branch base because on that branch we made several changes that would make it easier to merge both branches in this way.

## Screenshot

![image](https://user-images.githubusercontent.com/1310626/197270028-a9e5c32e-a40e-4185-80ee-ed22a08cb271.png)

