### PR TITLE
Automate release: build, version bump, changelog, deploy to wp.org

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,9 @@
+# Files to be ignored in the plugin release
+
+node_modules/
+.gitignore
+update-google-fonts-json-file.js
+update-version-and-changelog.js
+package.json
+src/
+.github/

--- a/.github/workflows/deploy-to-dotorg.yml
+++ b/.github/workflows/deploy-to-dotorg.yml
@@ -1,15 +1,53 @@
 name: Deploy to WordPress.org
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
 on:
-  push:
-    tags:
-    - "*"
   workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+        - major
+        - minor
+        - patch
 jobs:
   tag:
-    name: New tag
+    name: Checkout repo
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+      
+    - name: Install node dependencies
+      run: npm install
+
+    - name: Compile Javascript App
+      run: npm run build
+
+    - name: Update version and changelog
+      id: update-version
+      env:
+        RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+      run: npm run update-version
+
+    - name: Create Relase
+      env:
+        GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git config --global --add --bool push.autoSetupRemote true
+        git diff-index --quiet HEAD -- || ( git add package.json readme.txt && git commit -m "Version bump & changelog update" && git push )
+        gh release create ${{steps.update-version.outputs.NEW_TAG }} --notes "${{steps.update-version.outputs.CHANGELOG }}"
+
     - name: Create Block Theme Plugin Deploy to WordPress.org
       uses: 10up/action-wordpress-plugin-deploy@stable
       env:

--- a/.github/workflows/deploy-to-dotorg.yml
+++ b/.github/workflows/deploy-to-dotorg.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Create Relase
       env:
-        GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-block-theme",
-    "version": "1.3.0",
+    "version": "1.2.3",
     "private": true,
     "description": "Create a block-based theme",
     "author": "The WordPress Contributors",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,17 @@
     },
     "main": "build/index.js",
     "devDependencies": {
-        "@wordpress/scripts": "^18.0.1"
+        "@wordpress/scripts": "^18.0.1",
+        "@actions/core": "^1.10.0",
+        "semver": "^7.3.8",
+        "simple-git": "^3.14.1"
     },
     "scripts": {
         "build": "wp-scripts build",
         "format": "wp-scripts format",
         "lint:js": "wp-scripts lint-js",
         "packages-update": "wp-scripts packages-update",
-        "start": "wp-scripts start"
+        "start": "wp-scripts start",
+        "update-version": "node update-version-and-changelog.js"
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://automattic.com/
 Tags: themes, theme, block-theme
 Requires at least: 6.0
 Tested up to: 6.0
-Stable tag: 1.3.0
+Stable tag: 1.2.3
 Requires PHP: 7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -36,9 +36,6 @@ Make changes to your site styles and templates using the Site Editor. You can al
 Still in the WordPress dashboard, navigate to "Appearance" -> "Create Block Theme" section. Select one of the available options and then, if necessary, add the details for the theme here. These details will be used in the style.css file. Click "Generate” button, to save the theme.
 
 == Changelog ==
-
-= 1.3.0 = 
-Manage theme fonts (#126)
 
 = 1.2.3 = 
 Add translation domain (#121)

--- a/readme.txt
+++ b/readme.txt
@@ -38,37 +38,37 @@ Still in the WordPress dashboard, navigate to "Appearance" -> "Create Block Them
 == Changelog ==
 
 = 1.2.3 = 
-Add translation domain (#121)
-Check for nonce index (#120)
-Validating mime type of font file on server side (#119)
+* Add translation domain (#121)
+* Check for nonce index (#120)
+* Validating mime type of font file on server side (#119)
 
 = 1.2.2 = 
-Add capabilities and nonce checks (#118)
+* Add capabilities and nonce checks (#118)
 
 = 1.2.1 = 
-Correcting version number
+* Correcting version number
 
 = 1.2.0 = 
-Embed Google fonts and local font files in theme (#113)
-Change button text (#112)
-Add check and directory creation for template and parts folders. (#110)
-Change theme.json schema of blank theme if Gutenberg isn't installed. (#107)
+* Embed Google fonts and local font files in theme (#113)
+* Change button text (#112)
+* Add check and directory creation for template and parts folders. (#110)
+* Change theme.json schema of blank theme if Gutenberg isn't installed. (#107)
 
 = 1.1.3 = 
-update links, screenshots of the new changes (#97)
-Add $schema and use Gutenberg classes (#99)
-Update readme to include latest features (#100)
-Generate $schema URL in the same way as core. (#105)
+* update links, screenshots of the new changes (#97)
+* Add $schema and use Gutenberg classes (#99)
+* Update readme to include latest features (#100)
+* Generate $schema URL in the same way as core. (#105)
 
 = 1.1.2 =
-Save a theme variation (#90)
-Make UI string 'Create Block Theme' can be translatable (#92)
+* Save a theme variation (#90)
+* Make UI string 'Create Block Theme' can be translatable (#92)
 
 = 1.0.1 = 
-Add option to create blank theme. (#70)
-Improve form instructions (#76)
-Form cleanup and Theme name check (#77) 
-Get the correct merged theme.json data (#88)
+* Add option to create blank theme. (#70)
+* Improve form instructions (#76)
+* Form cleanup and Theme name check (#77) 
+* Get the correct merged theme.json data (#88)
 
 = 1.0 =
 * Initial version.

--- a/update-version-and-changelog.js
+++ b/update-version-and-changelog.js
@@ -30,8 +30,10 @@ async function updateVersion () {
     }
 
     const package = require('./package.json');
-    const currentTag = package.version;
-    const newTag = semver.inc(currentTag, releaseType);
+    const currentVersion = package.version;
+    const newVersion = semver.inc(currentTag, releaseType);
+    const currentTag = `v${currentVersion}`;
+    const newTag = `v${newVersion}`;
 
     if (!semver.valid(currentTag)) {
         console.error(`❎  Error: current tag ( ${ currentTag } ) is not a valid semver version."`);
@@ -48,17 +50,17 @@ async function updateVersion () {
     }
 
     // update package.json version
-    package.version = newTag;
+    package.version = newVersion;
     fs.writeFileSync('./package.json', JSON.stringify(package, null, 2));
     console.info('✅ Version updated', currentTag, '=>', newTag);
     
     // update readme.txt version with the new changelog
     const readme = fs.readFileSync('./readme.txt', 'utf8');
     const changelogChanges = changes.all.map(change => `* ${ change.message }`).join('\n');
-    const newChangelog = `== Changelog ==\n\n= ${ newTag } =\n\n${ changelogChanges }`;
+    const newChangelog = `== Changelog ==\n\n= ${ newVersion } =\n\n${ changelogChanges }`;
     let newReadme = readme.replace("== Changelog ==", newChangelog);
     // update version in readme.txt
-    newReadme = newReadme.replace(/Stable tag: (.*)/, `Stable tag: ${ newTag }`);
+    newReadme = newReadme.replace(/Stable tag: (.*)/, `Stable tag: ${ newVersion }`);
     fs.writeFileSync('./readme.txt', newReadme);
     console.info('✅  Readme version updated', currentTag, '=>', newTag);
 

--- a/update-version-and-changelog.js
+++ b/update-version-and-changelog.js
@@ -67,7 +67,7 @@ async function updateVersion () {
     // update readme.txt version with the new changelog
     const readme = fs.readFileSync('./readme.txt', 'utf8');
     const changelogChanges = changes.all.map(change => `* ${ change.body || change.message }`).join('\n');
-    const newChangelog = `== Changelog ==\n\n= ${ newVersion } =\n\n${ changelogChanges }`;
+    const newChangelog = `== Changelog ==\n\n= ${ newVersion } =\n${ changelogChanges }`;
     let newReadme = readme.replace("== Changelog ==", newChangelog);
     // update version in readme.txt
     newReadme = newReadme.replace(/Stable tag: (.*)/, `Stable tag: ${ newVersion }`);

--- a/update-version-and-changelog.js
+++ b/update-version-and-changelog.js
@@ -31,7 +31,7 @@ async function updateVersion () {
 
     const package = require('./package.json');
     const currentVersion = package.version;
-    const newVersion = semver.inc(currentTag, releaseType);
+    const newVersion = semver.inc(currentVersion, releaseType);
     const currentTag = `v${currentVersion}`;
     const newTag = `v${newVersion}`;
 

--- a/update-version-and-changelog.js
+++ b/update-version-and-changelog.js
@@ -9,7 +9,7 @@ const releaseType = process.env.RELEASE_TYPE;
 const VALID_RELEASE_TYPES = ['major', 'minor', 'patch'];
 
 async function getChangesSinceGitTag (tag) {
-    const changes = await git.log(["--reverse", `HEAD...${tag}`]);
+    const changes = await git.log(["--reverse", "--merges", `HEAD...${tag}`]);
     return changes;
 }
 
@@ -56,7 +56,7 @@ async function updateVersion () {
     
     // update readme.txt version with the new changelog
     const readme = fs.readFileSync('./readme.txt', 'utf8');
-    const changelogChanges = changes.all.map(change => `* ${ change.message }`).join('\n');
+    const changelogChanges = changes.all.map(change => `* ${ change.body || change.message }`).join('\n');
     const newChangelog = `== Changelog ==\n\n= ${ newVersion } =\n\n${ changelogChanges }`;
     let newReadme = readme.replace("== Changelog ==", newChangelog);
     // update version in readme.txt

--- a/update-version-and-changelog.js
+++ b/update-version-and-changelog.js
@@ -1,0 +1,72 @@
+const semver = require('semver');
+const fs = require('fs');
+const core = require('@actions/core');
+const simpleGit = require('simple-git');
+
+const git = simpleGit.default();
+
+const releaseType = process.env.RELEASE_TYPE;
+const VALID_RELEASE_TYPES = ['major', 'minor', 'patch'];
+
+async function getChangesSinceGitTag (tag) {
+    const changes = await git.log(["--reverse", `HEAD...${tag}`]);
+    return changes;
+}
+
+async function updateVersion () {
+    if ( !VALID_RELEASE_TYPES.includes(releaseType) ) {
+        console.error("❎  Error: Release type is not valid. Valid release types are: major, minor, patch.");
+        process.exit(1);
+    }
+
+    if (!fs.existsSync('./package.json')) {
+        console.error("❎  Error: package.json file not found.");
+        process.exit(1);
+    }
+
+    if (!fs.existsSync('./readme.txt')) {
+        console.error("❎  Error: readme.txt file not found.");
+        process.exit(1);
+    }
+
+    const package = require('./package.json');
+    const currentTag = package.version;
+    const newTag = semver.inc(currentTag, releaseType);
+
+    if (!semver.valid(currentTag)) {
+        console.error(`❎  Error: current tag ( ${ currentTag } ) is not a valid semver version."`);
+        process.exit(1);
+    }
+
+    // get changes since last tag
+    const changes = await getChangesSinceGitTag(currentTag);
+
+    // check if there are any changes
+    if (!changes || changes.total === 0) {
+        console.error("❎  No changes since last tag. There is nothing to release.");
+        process.exit(1);
+    }
+
+    // update package.json version
+    package.version = newTag;
+    fs.writeFileSync('./package.json', JSON.stringify(package, null, 2));
+    console.info('✅ Version updated', currentTag, '=>', newTag);
+    
+    // update readme.txt version with the new changelog
+    const readme = fs.readFileSync('./readme.txt', 'utf8');
+    const changelogChanges = changes.all.map(change => `* ${ change.message }`).join('\n');
+    const newChangelog = `== Changelog ==\n\n= ${ newTag } =\n\n${ changelogChanges }`;
+    let newReadme = readme.replace("== Changelog ==", newChangelog);
+    // update version in readme.txt
+    newReadme = newReadme.replace(/Stable tag: (.*)/, `Stable tag: ${ newTag }`);
+    fs.writeFileSync('./readme.txt', newReadme);
+    console.info('✅  Readme version updated', currentTag, '=>', newTag);
+
+    // output data to be used by the next steps of the github action
+    core.setOutput('NEW_TAG', newTag);
+    core.setOutput('CHANGELOG', changelogChanges);
+}
+
+updateVersion();
+
+


### PR DESCRIPTION
## What?

Currently to make a release of the plugin we need:
1. Build the Javascript app
2. Check the latest version number released
3. Think which is the next version number
4. Update the version number in readme.txt file
5. Write the changelog in the readme.txt file
6. Update the version number in package.json file
7. Manually create a release in the repo indicating the right version number.

With the new approach we need to:
1. Click the button "Run workflow" to select the type of release you are doing (patch, minor, major). 

That's it. The action will take care of building the JS app, bumping to the right semantic version, writing the changelog and submitting it to wporg.



## How?
This PR adds functionality to the release GitHub action. This action now will do all the steps that are currently a manual process.

## Demo
I tried all this code in [another repo](https://github.com/matiasbenedetto/testing-actions) to avoid polluting the history of this one. 

![image](https://user-images.githubusercontent.com/1310626/197773930-b1b0d50e-2648-493a-97c6-d72b080073bb.png)

Here you can see it in action:

[Screencast from 25-10-22 08:53:26.webm](https://user-images.githubusercontent.com/1310626/197774048-95f6e52c-6239-4815-93cf-791536c9d7bc.webm)

