### PR TITLE
Update GitHub action to avoid deprecation warning

### DIFF
--- a/.github/workflows/update-google-fons-data.yml
+++ b/.github/workflows/update-google-fons-data.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      run: echo "{date}={$(date +'%Y-%m-%d')}" >> $GITHUB_OUTPUT
 
     # Runs a single command using the runners shell
     # This script fetchs the Goolgle Fonts API data and creates a PR if new data is available


### PR DESCRIPTION
Update action following: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
to avoid deprecation warning on action run as here: https://github.com/WordPress/create-block-theme/actions/runs/3365744627

Fixes: https://github.com/WordPress/create-block-theme/issues/141