### PR TITLE
Allow previewing system font

### DIFF
--- a/src/font-face.js
+++ b/src/font-face.js
@@ -2,23 +2,21 @@ import { Button } from '@wordpress/components';
 
 const { __ } = wp.i18n;
 
-function FontFace ( { fontFace, demoText, deleteFontFace } ) {
+function FontFace ( { fontFamily, fontWeight, fontStyle, demoText, deleteFontFace } ) {
 
     // Handle cases like fontWeight is a number instead of a string or when the fontweight is a 'range', a string like "800 900".
-    const fontWeight = fontFace.fontWeight ? String(fontFace.fontWeight).split(' ')[0] : "normal";
-
     const demoStyles = {
-        fontFamily: fontFace.fontFamily,
-        fontStyle: fontFace.fontStyle,
-        fontWeight: fontWeight,
+        fontFamily,
+        fontStyle,
+        fontWeight: fontWeight ? String(fontWeight).split(' ')[0] : "normal",
     };
 
     return (
         <tr className="font-face">
-            <td>{fontFace.fontStyle}</td>
-            <td>{fontFace.fontWeight}</td>
+            <td>{fontStyle}</td>
+            <td>{fontWeight}</td>
             <td className="demo-cell"><p style={ demoStyles }>{demoText}</p></td>
-            <td><Button variant="tertiary" isDestructive={true} onClick={deleteFontFace}>{__('Remove')}</Button></td>
+            { deleteFontFace && <td><Button variant="tertiary" isDestructive={true} onClick={deleteFontFace}>{__('Remove')}</Button></td> }
         </tr>
     );
 }

--- a/src/font-face.js
+++ b/src/font-face.js
@@ -2,12 +2,18 @@ import { Button } from '@wordpress/components';
 
 const { __ } = wp.i18n;
 
-function FontFace ( { fontFamily, fontWeight, fontStyle, demoText, deleteFontFace } ) {
-
-    // Handle cases like fontWeight is a number instead of a string or when the fontweight is a 'range', a string like "800 900".
+function FontFace ( {
+    fontFamily,
+    fontWeight,
+    fontStyle,
+    demoText,
+    deleteFontFace
+} ) {
+    
     const demoStyles = {
         fontFamily,
         fontStyle,
+        // Handle cases like fontWeight is a number instead of a string or when the fontweight is a 'range', a string like "800 900".
         fontWeight: fontWeight ? String(fontWeight).split(' ')[0] : "normal",
     };
 
@@ -20,5 +26,11 @@ function FontFace ( { fontFamily, fontWeight, fontStyle, demoText, deleteFontFac
         </tr>
     );
 }
+
+FontFace.defaultProps = {
+    demoText: __("The quick brown fox jumps over the lazy dog.", "create-block-theme"),
+    fontWeight: "normal",
+    fontStyle: "normal",
+};
 
 export default FontFace;

--- a/src/font-family.js
+++ b/src/font-family.js
@@ -46,10 +46,10 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                                 <td>{__('Style')}</td>
                                 <td>{__('Weight')}</td>
                                 <td>{__('Preview')}</td>
-                                { fontFamily.fontFace && <td></td> }
+                                { hasFontFaces && <td></td> }
                             </thead>
                             <tbody>
-                                { fontFamily.fontFace && fontFamily.fontFace.length && fontFamily.fontFace.map((fontFace, i) => (
+                                { hasFontFaces && fontFamily.fontFace.map((fontFace, i) => (
                                     <FontFace
                                         { ...fontFace }
                                         fontFamilyIndex={fontFamilyIndex}
@@ -62,7 +62,7 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                                     />
                                 )) }
                                 {
-                                    ! fontFamily.fontFace && fontFamily.fontFamily &&
+                                    ! hasFontFaces && fontFamily.fontFamily &&
                                     <FontFace
                                         { ...fontFamily }
                                         demoText={ demoText }

--- a/src/font-family.js
+++ b/src/font-family.js
@@ -11,17 +11,15 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
         setIsOpen(!isOpen);
     }
 
-    // handle font famliy that has no font faces, for example a system font
-    // "-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu..."
     const hasFontFaces = fontFamily.fontFace && fontFamily.fontFace.length;
 
     return (
         <table className="wp-list-table widefat table-view-list">
-            <thead onClick={toggleIsOpen}>
+            <thead>
                 <td class="font-family-head">
                     <div><strong>{fontFamily.name || fontFamily.fontFamily}</strong></div>
                     <div>
-                        <Button
+                        { hasFontFaces && ( <Button
                             variant="tertiary"
                             isDestructive={true}
                             onClick={(e) => {
@@ -31,7 +29,8 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                         >
                             {__('Remove Font Family')}
                         </Button>
-                        {hasFontFaces && (
+                        )}
+                        { hasFontFaces && (
                             <Button onClick={toggleIsOpen}>
                                 <Icon icon={isOpen ? 'arrow-up-alt2' : 'arrow-down-alt2'} />
                             </Button>
@@ -39,36 +38,41 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                     </div>
                 </td>
             </thead>
-            {hasFontFaces && (
-                <tbody className="font-family-contents">
-                    <div className="container">
-                        <div className={` slide ${isOpen ? "open" : "close"}`}>
-                            <table className="wp-list-table widefat striped table-view-list">
-                                <thead>
-                                    <td>{__('Style')}</td>
-                                    <td>{__('Weight')}</td>
-                                    <td>{__('Preview')}</td>
-                                    <td></td>
-                                </thead>
-                                <tbody>
-                                    {hasFontFaces && fontFamily.fontFace.map((fontFace, i) => (
-                                        <FontFace
-                                            fontFace={fontFace}
-                                            fontFamilyIndex={fontFamilyIndex}
-                                            fontFaceIndex={i}
-                                            demoText={demoText}
-                                            key={`fontface${i}`}
-                                            deleteFontFace={
-                                                () => deleteFontFace(fontFamilyIndex, i)
-                                            }                                 
-                                        />
-                                    ))}  
-                                </tbody>  
-                            </table>
-                        </div>
+            <tbody className="font-family-contents">
+                <div className="container">
+                    <div className={` slide ${isOpen ? "open" : "close"}`}>
+                        <table className="wp-list-table widefat striped table-view-list">
+                            <thead>
+                                <td>{__('Style')}</td>
+                                <td>{__('Weight')}</td>
+                                <td>{__('Preview')}</td>
+                                { fontFamily.fontFace && <td></td> }
+                            </thead>
+                            <tbody>
+                                { fontFamily.fontFace && fontFamily.fontFace.length && fontFamily.fontFace.map((fontFace, i) => (
+                                    <FontFace
+                                        { ...fontFace }
+                                        fontFamilyIndex={fontFamilyIndex}
+                                        fontFaceIndex={i}
+                                        demoText={demoText}
+                                        key={`fontface${i}`}
+                                        deleteFontFace={
+                                            () => deleteFontFace(fontFamilyIndex, i)
+                                        }
+                                    />
+                                )) }
+                                {
+                                    ! fontFamily.fontFace && fontFamily.fontFamily &&
+                                    <FontFace
+                                        { ...fontFamily }
+                                        demoText={ demoText }
+                                    />
+                                }
+                            </tbody>
+                        </table>
                     </div>
-                </tbody>
-            )}
+                </div>
+            </tbody>
         </table>
     )
 }

--- a/src/font-family.js
+++ b/src/font-family.js
@@ -19,7 +19,7 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                 <td class="font-family-head">
                     <div><strong>{fontFamily.name || fontFamily.fontFamily}</strong></div>
                     <div>
-                        { hasFontFaces && ( <Button
+                        <Button
                             variant="tertiary"
                             isDestructive={true}
                             onClick={(e) => {
@@ -29,12 +29,9 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                         >
                             {__('Remove Font Family')}
                         </Button>
-                        )}
-                        { hasFontFaces && (
-                            <Button onClick={toggleIsOpen}>
-                                <Icon icon={isOpen ? 'arrow-up-alt2' : 'arrow-down-alt2'} />
-                            </Button>
-                        )}
+                        <Button onClick={toggleIsOpen}>
+                            <Icon icon={isOpen ? 'arrow-up-alt2' : 'arrow-down-alt2'} />
+                        </Button>
                     </div>
                 </td>
             </thead>

--- a/src/manage-fonts.js
+++ b/src/manage-fonts.js
@@ -80,8 +80,8 @@ function ManageFonts () {
                     updatedFontFamily
                 ];
             }
-
-            if (fontFamily.fontFace.length == 1 && index === fontFamilyIndex) {
+            
+            if (fontFamily?.fontFace?.length == 1 && index === fontFamilyIndex) {
                 return acc;
             }
 
@@ -92,7 +92,7 @@ function ManageFonts () {
     }
 
     const fontFamilyToDelete = newThemeFonts[fontToDelete.fontFamilyIndex];
-    const fontFaceToDelete = newThemeFonts[fontToDelete.fontFamilyIndex]?.fontFace[fontToDelete.fontFaceIndex];
+    const fontFaceToDelete = newThemeFonts[fontToDelete.fontFamilyIndex]?.fontFace?.[fontToDelete.fontFaceIndex];
 
     return (
         <>


### PR DESCRIPTION
Fixes #151 . This isn't exactly specific to system fonts, but rather fonts that have a fontFamily definition but no fontFace definition(s).

Using TT3 as an example:

Before | After
--- | ---
<img width="1624" alt="Screen Shot 2022-11-15 at 11 31 21 AM" src="https://user-images.githubusercontent.com/5375500/201976131-dae99419-f6d1-4258-acd0-0067f4060bac.png"> | <img width="1624" alt="Screen Shot 2022-11-15 at 11 31 11 AM" src="https://user-images.githubusercontent.com/5375500/201976195-113d2a6d-dc70-4a51-abaa-103c110ef09f.png">

I'm not sure it makes sense to be able to remove the system font, so I've disabled it for now.  