### PR TITLE
Replace "current theme" with "active theme" (or "currently active theme")

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This feature can be used in six ways:
 Export the activated theme including the user changes.
 
 ### 2. Create a child theme
-Creates a new child theme with the currently activated theme as a parent.
+Creates a new child theme with the currently active theme as a parent.
 
-### 3. Clone the current theme
+### 3. Clone the active theme
 Creates a new theme by cloning the activated theme. The resulting theme will have all of the assets of the activated theme combined with the user's changes.
 
 ### 4. Overwrite theme files
@@ -26,12 +26,12 @@ Saves user's changes to the theme files and deletes the user's changes.
 Generate a boilerplate "empty" theme inside of current site's themes directory.
 
 ### 6. Create a style variation
-Saves user's changes as a [style variation](https://developer.wordpress.org/themes/advanced-topics/theme-json/#global-styles-variations) of the current theme.
+Saves user's changes as a [style variation](https://developer.wordpress.org/themes/advanced-topics/theme-json/#global-styles-variations) of the currently active theme.
 
 
 ## Embed Google Fonts or local font files
 
-This feature allows you to embed fonts into your current theme. You can embed Google Fonts and local font assets.
+This feature allows you to embed fonts into your active theme. You can embed Google Fonts and local font assets.
 
 When you add a font the plugin will add to your theme:
 - The font files to your theme's file structure under this path `./assets/fonts`.
@@ -47,7 +47,7 @@ Install and activate the [Create Block Theme](https://wordpress.org/plugins/crea
 
 In the WordPress Admin Dashboard, under Appearance there will be three new pages called:
 - Create Block Theme
-- Embed Google font in your current theme
+- Embed Google font in your active theme
 - Embed local font file assets
 
 ### Step 2 – Fonts, styles and templates customizations

--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -31,12 +31,12 @@ class Manage_Fonts_Admin {
         $manage_fonts_menu_title=_x('Manage theme fonts', 'UI String', 'create-block-theme');
         add_theme_page( $manage_fonts_page_title, $manage_fonts_menu_title, 'edit_theme_options', 'manage-fonts', [ $this, 'manage_fonts_admin_page' ] );
 
-        $google_fonts_page_title=_x('Embed Google font in current Theme', 'UI String', 'create-block-theme');
-		$google_fonts_menu_title=_x('Embed Google font in current Theme', 'UI String', 'create-block-theme');
+        $google_fonts_page_title=_x('Embed Google font in the active theme', 'UI String', 'create-block-theme');
+		$google_fonts_menu_title=_x('Embed Google font in the active theme', 'UI String', 'create-block-theme');
         add_submenu_page(null, $google_fonts_page_title, $google_fonts_menu_title, 'edit_theme_options', 'add-google-font-to-theme-json', [ $this, 'google_fonts_admin_page' ] );
 
-		$local_fonts_page_title=_x('Embed local font in current Theme', 'UI String', 'create-block-theme');
-		$local_fonts_menu_title=_x('Embed local font in current Theme', 'UI String', 'create-block-theme');
+		$local_fonts_page_title=_x('Embed local font in the active theme', 'UI String', 'create-block-theme');
+		$local_fonts_menu_title=_x('Embed local font in the active theme', 'UI String', 'create-block-theme');
 		add_submenu_page(null, $local_fonts_page_title, $local_fonts_menu_title, 'edit_theme_options', 'add-local-font-to-theme-json', [ $this, 'local_fonts_admin_page' ] );
 	}
 
@@ -137,7 +137,7 @@ class Manage_Fonts_Admin {
         ?>
         <div class="wrap local-fonts-page">
             <h2><?php _ex('Add local fonts to your theme', 'UI String', 'create-block-theme'); ?></h2>
-            <h3><?php printf( esc_html__('Add local fonts assets and font face definitions to your current active theme (%1$s)', 'create-block-theme'),  esc_html( wp_get_theme()->get('Name') ) ); ?></h3>
+            <h3><?php printf( esc_html__('Add local fonts assets and font face definitions to your currently active theme (%1$s)', 'create-block-theme'),  esc_html( wp_get_theme()->get('Name') ) ); ?></h3>
             <form enctype="multipart/form-data" action="" method="POST">
                 <table class="form-table">
                     <tbody>
@@ -201,7 +201,7 @@ class Manage_Fonts_Admin {
 		<div class="wrap google-fonts-page">
 			<h2><?php _ex('Add Google fonts to your theme', 'UI String', 'create-block-theme'); ?></h2>
 			<form enctype="multipart/form-data" action="" method="POST">
-				<h3><?php printf( esc_html__('Add Google fonts assets and font face definitions to your current active theme (%1$s)', 'create-block-theme'),  esc_html( wp_get_theme()->get('Name') ) ); ?></h3>
+				<h3><?php printf( esc_html__('Add Google fonts assets and font face definitions to your currently active theme (%1$s)', 'create-block-theme'),  esc_html( wp_get_theme()->get('Name') ) ); ?></h3>
 				<label for="google-font-id"><?php printf( esc_html__('Select Font', 'create-block-theme')); ?></label>
 				<select name="google-font" id="google-font-id">
                     <option value=""><?php _e('Select a font...', 'create-block-theme'); ?></option>


### PR DESCRIPTION
This brings consistency with WordPress Core.
See https://core.trac.wordpress.org/ticket/54831