### PR TITLE
Fonts: remove font files from theme assets folder if the font face/family is removed.

### DIFF
--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -527,7 +527,7 @@ class Manage_Fonts_Admin {
 		$theme_name = wp_get_theme()->get( 'Name' );
 		?>
 			<div class="notice notice-error is-dismissible">
-				<p><?php printf( esc_html__( 'Error removing font asset. WordPress lack permissions to remove these font assets.', 'create-block-theme' ), esc_html( $theme_name ) ); ?></p>
+				<p><?php printf( esc_html__( 'Error removing font asset. WordPress lacks permissions to remove these font assets.', 'create-block-theme' ), esc_html( $theme_name ) ); ?></p>
 			</div>
 		<?php
 	}

--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -239,10 +239,10 @@ class Manage_Fonts_Admin {
 
         if ( ! is_writable( $theme_folder . DIRECTORY_SEPARATOR . $font_dir ) ) {
             return add_action( 'admin_notices', [ $this, 'admin_notice_font_asset_removal_error' ] );
+        }
 
-            if ( file_exists( $font_asset_path ) ) {
-                return unlink( $font_asset_path );
-            }
+        if ( file_exists( $font_asset_path ) ) {
+            return unlink( $font_asset_path );
         }
         
         return false;

--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -256,7 +256,7 @@ class Manage_Fonts_Admin {
 				$new_font_faces = array();
 				foreach ( $font_family['fontFace'] as $font_face ) {
 					$updated_font_face = $font_face;
-					if ( !isset ( $font_face['shouldBeRemoved'] ) ) {
+					if ( !isset ( $font_face['shouldBeRemoved'] ) && ! isset ( $font_family[ 'shouldBeRemoved' ] ) ) {
 						$new_font_faces[] = $updated_font_face;
 					} else {
 						$this->delete_font_asset( $font_face );

--- a/src/font-face.js
+++ b/src/font-face.js
@@ -7,7 +7,8 @@ function FontFace ( {
     fontWeight,
     fontStyle,
     demoText,
-    deleteFontFace
+    deleteFontFace,
+    shouldBeRemoved,
 } ) {
     
     const demoStyles = {
@@ -16,6 +17,10 @@ function FontFace ( {
         // Handle cases like fontWeight is a number instead of a string or when the fontweight is a 'range', a string like "800 900".
         fontWeight: fontWeight ? String(fontWeight).split(' ')[0] : "normal",
     };
+
+    if ( shouldBeRemoved ) {
+        return null;
+    }
 
     return (
         <tr className="font-face">

--- a/src/font-family.js
+++ b/src/font-family.js
@@ -11,7 +11,11 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
         setIsOpen(!isOpen);
     }
 
-    const hasFontFaces = fontFamily.fontFace && fontFamily.fontFace.length;
+    const hasFontFaces = !!fontFamily.fontFace && !!fontFamily.fontFace.length;
+
+    if ( fontFamily.shouldBeRemoved ) {
+        return null;
+    }
 
     return (
         <table className="wp-list-table widefat table-view-list">

--- a/src/manage-fonts.js
+++ b/src/manage-fonts.js
@@ -65,29 +65,45 @@ function ManageFonts () {
     }
 
     function deleteFontFamily (fontFamilyIndex) {
-        const updatedFonts = newThemeFonts.filter((_, index) => index !== fontFamilyIndex);
+        const updatedFonts = newThemeFonts.map((family, index) => {
+            if ( index === fontFamilyIndex ) {
+                return {
+                    ...family,
+                    shouldBeRemoved: true
+                }
+            }
+            return family;
+        });
+        console.log(updatedFonts);
         setNewThemeFonts(updatedFonts);
     }
 
     function deleteFontFace () {
         const { fontFamilyIndex, fontFaceIndex } = fontToDelete;
         const updatedFonts = newThemeFonts.reduce((acc, fontFamily, index) => {
-            if (index === fontFamilyIndex && fontFamily.fontFace.length > 1) {
-                const {fontFace, ...updatedFontFamily} = fontFamily;
-                updatedFontFamily.fontFace = fontFamily.fontFace.filter((_, index) => index !== fontFaceIndex);
+                const {fontFace=[], ...updatedFontFamily} = fontFamily;
+
+                if ( fontFace.filter( face => !face.shouldBeRemoved ).length === 1 ) {
+                    updatedFontFamily.shouldBeRemoved = true;
+                }
+
+                updatedFontFamily.fontFace = fontFace.map(
+                    (face, i) => {
+                        if ( fontFamilyIndex == index && fontFaceIndex === i ) {
+                            return {
+                                ...face,
+                                shouldBeRemoved: true
+                            }
+                        }
+                        return face;
+                    }
+                );
                 return [
                     ...acc,
                     updatedFontFamily
                 ];
-            }
-            
-            if (fontFamily?.fontFace?.length == 1 && index === fontFamilyIndex) {
-                return acc;
-            }
 
-            return [...acc, fontFamily];
         }, []);
-
         setNewThemeFonts(updatedFonts);
     }
 


### PR DESCRIPTION
## What?
This PR allows the plugin to remove the font file assets from the theme folder when a font face or family is removed from the theme using the plugin font management tool.

## How?
The font face/family selected to be removed is marked with the `shouldBeRemoved: true` property in the frontend and sent to the backend. The backend code understands that it needs to remove the font face/family definition from the JSON and also removes the font files from the theme folder.

## Why? 
Fixes: https://github.com/WordPress/create-block-theme/issues/164