### PR TITLE
Manage fonts: Demo text editable

### DIFF
--- a/css/manage-fonts.css
+++ b/css/manage-fonts.css
@@ -47,11 +47,23 @@
     border-top: none;
 }
 
-.font-face .demo-cell p {
+.font-family-contents .preview-head {
+    width: 100%;
+}
+
+.font-face td {
+    white-space: nowrap;
+    text-align: center;
+}
+
+.font-face .demo-cell input {
     font-size: 1.7rem;
     line-height: 1.5;
     margin: 0;
-    padding: 0;
+    padding: 0.1em;
+    border: none;
+    background: none;
+    width: 100%;
 }
 
 .font-family-contents tbody td {

--- a/src/font-face.js
+++ b/src/font-face.js
@@ -1,22 +1,34 @@
 import { Button } from '@wordpress/components'; 
-
+import { useContext } from '@wordpress/element';
+import { ManageFontsContext } from './fonts-context';
 const { __ } = wp.i18n;
 
 function FontFace ( {
     fontFamily,
     fontWeight,
     fontStyle,
-    demoText,
     deleteFontFace,
-    shouldBeRemoved,
+    shouldBeRemoved
 } ) {
-    
+    const { demoText, handleDemoTextChange, resetDemoText } = useContext(ManageFontsContext);
+
     const demoStyles = {
         fontFamily,
         fontStyle,
         // Handle cases like fontWeight is a number instead of a string or when the fontweight is a 'range', a string like "800 900".
         fontWeight: fontWeight ? String(fontWeight).split(' ')[0] : "normal",
     };
+    
+    const handleChange = ( event ) => {
+        const newDemoText = event.target.value;
+        handleDemoTextChange( newDemoText );
+    }
+
+    const onBlur = ( event ) => {
+        if ( ! event.target.value ) {
+            resetDemoText();
+        }
+    }
 
     if ( shouldBeRemoved ) {
         return null;
@@ -26,14 +38,15 @@ function FontFace ( {
         <tr className="font-face">
             <td>{fontStyle}</td>
             <td>{fontWeight}</td>
-            <td className="demo-cell"><p style={ demoStyles }>{demoText}</p></td>
+            <td className="demo-cell">
+                <input style={ demoStyles } onChange={ handleChange } value={ demoText } onBlur={ onBlur }/>
+            </td>
             { deleteFontFace && <td><Button variant="tertiary" isDestructive={true} onClick={deleteFontFace}>{__('Remove', 'create-block-theme')}</Button></td> }
         </tr>
     );
 }
 
 FontFace.defaultProps = {
-    demoText: __("The quick brown fox jumps over the lazy dog.", "create-block-theme"),
     fontWeight: "normal",
     fontStyle: "normal",
 };

--- a/src/font-family.js
+++ b/src/font-family.js
@@ -3,7 +3,7 @@ import { Button, Icon } from '@wordpress/components';
 import FontFace from "./font-face";
 
 const { __ } = wp.i18n;
-function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFontFace, demoText } ) {
+function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFontFace } ) {
 
     const [isOpen, setIsOpen] = useState(true);
 
@@ -46,7 +46,7 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                             <thead>
                                 <td>{__('Style', 'create-block-theme')}</td>
                                 <td>{__('Weight', 'create-block-theme')}</td>
-                                <td>{__('Preview', 'create-block-theme')}</td>
+                                <td class="preview-head">{__('Preview', 'create-block-theme')}</td>
                                 { hasFontFaces && <td></td> }
                             </thead>
                             <tbody>
@@ -55,7 +55,6 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                                         { ...fontFace }
                                         fontFamilyIndex={fontFamilyIndex}
                                         fontFaceIndex={i}
-                                        demoText={demoText}
                                         key={`fontface${i}`}
                                         deleteFontFace={
                                             () => deleteFontFace(fontFamilyIndex, i)
@@ -66,7 +65,6 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                                     ! hasFontFaces && fontFamily.fontFamily &&
                                     <FontFace
                                         { ...fontFamily }
-                                        demoText={ demoText }
                                     />
                                 }
                             </tbody>
@@ -77,9 +75,5 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
         </table>
     )
 }
-
-FontFamily.defaultProps = {
-    demoText: __("The quick brown fox jumps over the lazy dog.", "create-block-theme"),
-};
 
 export default FontFamily;

--- a/src/fonts-context.js
+++ b/src/fonts-context.js
@@ -1,0 +1,25 @@
+import { useState, createContext } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+export const ManageFontsContext = createContext();
+export const DEFAULT_DEMO_TEXT = __( "The quick brown fox jumps over the lazy dog.", "create-block-theme" );
+
+
+export function ManageFontsProvider( { children } ) {
+    const [ demoText, setDemoText ] = useState( localStorage.getItem( "create-block-theme_default-demo-text" ) || DEFAULT_DEMO_TEXT );
+
+    const handleDemoTextChange = ( newDemoText ) => {
+        setDemoText( newDemoText );
+        localStorage.setItem( "create-block-theme_default-demo-text", newDemoText );
+    }
+
+    const resetDemoText = () => {
+        setDemoText( DEFAULT_DEMO_TEXT );
+    }
+
+    return (
+        <ManageFontsContext.Provider value={{ demoText, handleDemoTextChange, resetDemoText }}>
+            { children }
+        </ManageFontsContext.Provider>
+    );
+}

--- a/src/manage-fonts.js
+++ b/src/manage-fonts.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import FontFamily from "./font-family";
 import { __experimentalConfirmDialog as ConfirmDialog, Modal, Icon, Button } from '@wordpress/components';
+import { ManageFontsProvider } from "./fonts-context";
 
 const { __ } = wp.i18n;
 
@@ -158,4 +159,8 @@ function ManageFonts () {
     );
 }
 
-export default ManageFonts;
+export default () =>  (
+    <ManageFontsProvider>
+        <ManageFonts />
+    </ManageFontsProvider>
+);


### PR DESCRIPTION
This PR makes the demo text editable.

:warning: This functionality is not yet available for the "Add Google font" section because that section was implemented before the React app. We need to add this functionality there, too, but I think we should refactor that section in React before. 

## Screencast

[Screencast from 23-01-23 18:05:03.webm](https://user-images.githubusercontent.com/1310626/214058309-16d8cf37-a6ba-4d28-af8d-8c829195abb0.webm)

