### PR TITLE
Fix: browser console errors

### DIFF
--- a/css/manage-fonts.css
+++ b/css/manage-fonts.css
@@ -13,13 +13,15 @@
     margin-bottom: 2rem;
 }
 
-.font-families > table > thead > td {
+.font-families > table > thead td {
     font-size: 1.1rem;
 }
 
 .font-family-contents .slide {
     border-bottom-left-radius: 15px;
     margin: 0 0 0 1.5rem;
+    display: block;
+    padding: 0;
 }
 
 .font-family-contents .container {

--- a/src/font-family.js
+++ b/src/font-family.js
@@ -20,34 +20,38 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
     return (
         <table className="wp-list-table widefat table-view-list">
             <thead>
-                <td class="font-family-head">
-                    <div><strong>{fontFamily.name || fontFamily.fontFamily}</strong></div>
-                    <div>
-                        <Button
-                            variant="tertiary"
-                            isDestructive={true}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                deleteFontFamily(fontFamilyIndex)
-                            }}
-                        >
-                            {__('Remove Font Family', 'create-block-theme')}
-                        </Button>
-                        <Button onClick={toggleIsOpen}>
-                            <Icon icon={isOpen ? 'arrow-up-alt2' : 'arrow-down-alt2'} />
-                        </Button>
-                    </div>
-                </td>
+                <tr>
+                    <td className="font-family-head">
+                        <div><strong>{fontFamily.name || fontFamily.fontFamily}</strong></div>
+                        <div>
+                            <Button
+                                variant="tertiary"
+                                isDestructive={true}
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    deleteFontFamily(fontFamilyIndex)
+                                }}
+                            >
+                                {__('Remove Font Family', 'create-block-theme')}
+                            </Button>
+                            <Button onClick={toggleIsOpen}>
+                                <Icon icon={isOpen ? 'arrow-up-alt2' : 'arrow-down-alt2'} />
+                            </Button>
+                        </div>
+                    </td>
+                </tr>
             </thead>
             <tbody className="font-family-contents">
-                <div className="container">
-                    <div className={` slide ${isOpen ? "open" : "close"}`}>
+                <tr className="container">
+                    <td className={` slide ${isOpen ? "open" : "close"}`}>
                         <table className="wp-list-table widefat striped table-view-list">
                             <thead>
-                                <td>{__('Style', 'create-block-theme')}</td>
-                                <td>{__('Weight', 'create-block-theme')}</td>
-                                <td class="preview-head">{__('Preview', 'create-block-theme')}</td>
-                                { hasFontFaces && <td></td> }
+                                <tr>
+                                    <td>{__('Style', 'create-block-theme')}</td>
+                                    <td>{__('Weight', 'create-block-theme')}</td>
+                                    <td className="preview-head">{__('Preview', 'create-block-theme')}</td>
+                                    { hasFontFaces && <td></td> }
+                                </tr>
                             </thead>
                             <tbody>
                                 { hasFontFaces && fontFamily.fontFace.map((fontFace, i) => (
@@ -69,8 +73,8 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                                 }
                             </tbody>
                         </table>
-                    </div>
-                </div>
+                    </td>
+                </tr>
             </tbody>
         </table>
     )

--- a/src/manage-fonts.js
+++ b/src/manage-fonts.js
@@ -30,7 +30,7 @@ function ManageFonts () {
     // When client side font list changes, we update the server side font list
     useEffect( () => {
         // Avoids running this effect on the first render
-        if (
+        if ( 
             fontToDelete.fontFamilyIndex !== undefined ||
             fontToDelete.fontFaceIndex !== undefined
         ) {
@@ -113,7 +113,7 @@ function ManageFonts () {
     return (
         <>
             { isHelpOpen && (
-                <Modal
+                <Modal 
                     title={<><Icon icon={"info"}/> {__("Info", "create-block-theme")}</>}
                     onRequestClose={toggleIsHelpOpen}
                 >

--- a/src/manage-fonts.js
+++ b/src/manage-fonts.js
@@ -30,7 +30,7 @@ function ManageFonts () {
     // When client side font list changes, we update the server side font list
     useEffect( () => {
         // Avoids running this effect on the first render
-        if ( 
+        if (
             fontToDelete.fontFamilyIndex !== undefined ||
             fontToDelete.fontFaceIndex !== undefined
         ) {
@@ -113,7 +113,7 @@ function ManageFonts () {
     return (
         <>
             { isHelpOpen && (
-                <Modal 
+                <Modal
                     title={<><Icon icon={"info"}/> {__("Info", "create-block-theme")}</>}
                     onRequestClose={toggleIsHelpOpen}
                 >
@@ -125,7 +125,7 @@ function ManageFonts () {
                     </p>
                 </Modal>
             ) }
-            <p class="help">
+            <p className="help">
                 {__("These are the fonts currently embedded in your theme ", "create-block-theme")}
                 <Button onClick={toggleIsHelpOpen} style={{padding:"0", height:"1rem"}}>
                     <Icon icon={"info"}/>


### PR DESCRIPTION
This PR fixes the following error output to the browser console on the "Manage Theme Fonts" page:

```
Warning: Invalid DOM property `class`. Did you mean `className`?
```

```
Warning: validateDOMNesting(...): <td> cannot appear as a child of <thead>.
```

```
Warning: validateDOMNesting(...): <div> cannot appear as a child of <tbody>.
```

![warning](https://user-images.githubusercontent.com/54422211/216039482-b6143f9a-c3c4-4b8b-8f3b-420c5d3167fc.png)

## How ?

Changed to correct JSX markup. I have also made slight CSS adjustments to ensure that the previous layout is not broken. Confirm that no warning errors appear in the browser console when this PR is applied.

