### PR TITLE
Fix: Adding or removing fonts fails in some Windows environments

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -240,7 +240,7 @@ class Create_Block_Theme_Admin {
 			'style.css',
 			$this->build_child_style_css( $theme )
 		);
-		
+
 		// Add / replace screenshot.
 		if ( $this->is_valid_screenshot( $screenshot ) ){
 			$zip->addFile(
@@ -299,8 +299,8 @@ class Create_Block_Theme_Admin {
 		if ( ! file_exists( $blank_theme_path ) ) {
 			mkdir( $blank_theme_path, 0755 );
 			// Add readme.txt.
-			file_put_contents( 
-				$blank_theme_path . DIRECTORY_SEPARATOR . 'readme.txt', 
+			file_put_contents(
+				$blank_theme_path . DIRECTORY_SEPARATOR . 'readme.txt',
 				$this->build_readme_txt( $theme )
 			);
 
@@ -316,8 +316,8 @@ class Create_Block_Theme_Admin {
 			}
 
 			// Add style.css.
-			file_put_contents( 
-				$blank_theme_path . DIRECTORY_SEPARATOR . 'style.css', 
+			file_put_contents(
+				$blank_theme_path . DIRECTORY_SEPARATOR . 'style.css',
 				$css_contents
 			);
 
@@ -369,7 +369,7 @@ class Create_Block_Theme_Admin {
 		if ( ! file_exists( $variation_path ) ) {
 			mkdir( $variation_path, 0755, true );
 		}
-		
+
 		if ( file_exists( $variation_path . $variation_slug . '.json' ) ) {
 			$file_counter++;
 			while ( file_exists( $variation_path . $variation_slug . '_' . $file_counter . '.json' ) ) {
@@ -379,7 +379,7 @@ class Create_Block_Theme_Admin {
 		}
 
 		$_POST['theme']['variation_slug'] = $variation_slug;
-		
+
 		file_put_contents(
 			$variation_path . $variation_slug . '.json',
 			MY_Theme_JSON_Resolver::export_theme_data( $export_type )
@@ -887,7 +887,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 
 			if ( $_POST['theme']['type'] === 'save' ) {
 				// Avoid running if WordPress dosn't have permission to overwrite the theme folder
-				if ( ! is_writable( get_stylesheet_directory() ) ) {
+				if ( ! wp_is_writable( get_stylesheet_directory() ) ) {
 					return add_action( 'admin_notices', [ $this, 'admin_notice_error_theme_file_permissions' ] );
 				}
 
@@ -909,7 +909,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 				}
 
 				// Avoid running if WordPress dosn't have permission to write the theme folder
-				if ( ! is_writable ( get_stylesheet_directory() ) ) {
+				if ( ! wp_is_writable ( get_stylesheet_directory() ) ) {
 					return add_action( 'admin_notices', [ $this, 'admin_notice_error_theme_file_permissions' ] );
 				}
 
@@ -926,7 +926,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 
 			else if ( $_POST['theme']['type'] === 'blank' ) {
 				// Avoid running if WordPress dosn't have permission to write the themes folder
-				if ( ! is_writable ( get_theme_root() ) ) {
+				if ( ! wp_is_writable ( get_theme_root() ) ) {
 					return add_action( 'admin_notices', [ $this, 'admin_notice_error_themes_file_permissions' ] );
 				}
 

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -240,7 +240,7 @@ class Create_Block_Theme_Admin {
 			'style.css',
 			$this->build_child_style_css( $theme )
 		);
-
+		
 		// Add / replace screenshot.
 		if ( $this->is_valid_screenshot( $screenshot ) ){
 			$zip->addFile(
@@ -299,8 +299,8 @@ class Create_Block_Theme_Admin {
 		if ( ! file_exists( $blank_theme_path ) ) {
 			mkdir( $blank_theme_path, 0755 );
 			// Add readme.txt.
-			file_put_contents(
-				$blank_theme_path . DIRECTORY_SEPARATOR . 'readme.txt',
+			file_put_contents( 
+				$blank_theme_path . DIRECTORY_SEPARATOR . 'readme.txt', 
 				$this->build_readme_txt( $theme )
 			);
 
@@ -316,8 +316,8 @@ class Create_Block_Theme_Admin {
 			}
 
 			// Add style.css.
-			file_put_contents(
-				$blank_theme_path . DIRECTORY_SEPARATOR . 'style.css',
+			file_put_contents( 
+				$blank_theme_path . DIRECTORY_SEPARATOR . 'style.css', 
 				$css_contents
 			);
 
@@ -369,7 +369,7 @@ class Create_Block_Theme_Admin {
 		if ( ! file_exists( $variation_path ) ) {
 			mkdir( $variation_path, 0755, true );
 		}
-
+		
 		if ( file_exists( $variation_path . $variation_slug . '.json' ) ) {
 			$file_counter++;
 			while ( file_exists( $variation_path . $variation_slug . '_' . $file_counter . '.json' ) ) {
@@ -379,7 +379,7 @@ class Create_Block_Theme_Admin {
 		}
 
 		$_POST['theme']['variation_slug'] = $variation_slug;
-
+		
 		file_put_contents(
 			$variation_path . $variation_slug . '.json',
 			MY_Theme_JSON_Resolver::export_theme_data( $export_type )

--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -20,7 +20,7 @@ class Manage_Fonts_Admin {
     function has_font_mime_type( $file ) {
         $filetype = wp_check_filetype( $file, self::ALLOWED_FONT_MIME_TYPES );
         return in_array( $filetype['type'], self::ALLOWED_FONT_MIME_TYPES );
-    }    
+    }
 
     function create_admin_menu() {
 		if ( ! wp_is_block_theme() ) {
@@ -53,7 +53,7 @@ class Manage_Fonts_Admin {
 		}
 
 		// If the font asset folder can't be written return an error
-		if ( ! is_writable( $font_assets_path ) || ! is_readable( $font_assets_path ) || !is_writable  ( $temp_dir ) ) {
+		if ( ! wp_is_writable( $font_assets_path ) || ! is_readable( $font_assets_path ) || ! wp_is_writable( $temp_dir ) ) {
             return false;
 		}
         return true;
@@ -64,12 +64,12 @@ class Manage_Fonts_Admin {
         // Load the required WordPress packages.
         // Automatically load imported dependencies and assets version.
         $asset_file = include plugin_dir_path( __DIR__ ) . 'build/index.asset.php';
-     
+
         // Enqueue CSS dependencies.
         foreach ( $asset_file['dependencies'] as $style ) {
             wp_enqueue_style( $style );
         }
-     
+
         // Load our app.js.
         array_push( $asset_file['dependencies'], 'wp-i18n' );
         wp_enqueue_script( 'create-block-theme-app', plugins_url( 'build/index.js', __DIR__ ), $asset_file['dependencies'], $asset_file['version'] );
@@ -98,7 +98,7 @@ class Manage_Fonts_Admin {
 
         $fonts_json = wp_json_encode( $theme_font_families );
         $fonts_json_string = preg_replace ( '~(?:^|\G)\h{4}~m', "\t", $fonts_json );
-        
+
     ?>
     <div class="wrap">
         <h1 class="wp-heading-inline"><?php _e('Manage Theme Fonts', 'create-block-theme'); ?></h1>
@@ -106,7 +106,7 @@ class Manage_Fonts_Admin {
         <a href="<?php echo admin_url( 'themes.php?page=add-local-font-to-theme-json' ); ?>" class="page-title-action"><?php _e('Add Local Font', 'create-block-theme'); ?></a>
         <hr class="wp-header-end" />
         <p name="theme-fonts-json" id="theme-fonts-json" class="hidden"><?php echo $fonts_json_string;  ?></p>
-        
+
         <form method="POST"  id="manage-fonts-form">
             <div id="manage-fonts"></div>
             <input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_block_theme' ); ?>" />
@@ -237,14 +237,14 @@ class Manage_Fonts_Admin {
 
         $font_asset_path = $theme_folder . DIRECTORY_SEPARATOR . $font_dir . DIRECTORY_SEPARATOR . $font_path['basename'];
 
-        if ( ! is_writable( $theme_folder . DIRECTORY_SEPARATOR . $font_dir ) ) {
+        if ( ! wp_is_writable( $theme_folder . DIRECTORY_SEPARATOR . $font_dir ) ) {
             return add_action( 'admin_notices', [ $this, 'admin_notice_font_asset_removal_error' ] );
         }
 
         if ( file_exists( $font_asset_path ) ) {
             return unlink( $font_asset_path );
         }
-        
+
         return false;
 	}
 
@@ -268,7 +268,7 @@ class Manage_Fonts_Admin {
 			if ( ! isset ( $font_family[ 'shouldBeRemoved' ] ) ) {
 				$prepared_font_families[] = $font_family;
 			}
-			
+
 		}
 
 		return $prepared_font_families;
@@ -285,7 +285,7 @@ class Manage_Fonts_Admin {
                 return add_action( 'admin_notices', [ $this, 'admin_notice_manage_fonts_permission_error' ] );
             }
 
-            // parse json from form 
+            // parse json from form
             $new_theme_fonts_json = json_decode( stripslashes( $_POST['new-theme-fonts-json'] ), true );
             $new_font_families = $this->prepare_font_families_for_database( $new_theme_fonts_json );
 

--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -20,7 +20,7 @@ class Manage_Fonts_Admin {
     function has_font_mime_type( $file ) {
         $filetype = wp_check_filetype( $file, self::ALLOWED_FONT_MIME_TYPES );
         return in_array( $filetype['type'], self::ALLOWED_FONT_MIME_TYPES );
-    }
+    }    
 
     function create_admin_menu() {
 		if ( ! wp_is_block_theme() ) {
@@ -64,12 +64,12 @@ class Manage_Fonts_Admin {
         // Load the required WordPress packages.
         // Automatically load imported dependencies and assets version.
         $asset_file = include plugin_dir_path( __DIR__ ) . 'build/index.asset.php';
-
+     
         // Enqueue CSS dependencies.
         foreach ( $asset_file['dependencies'] as $style ) {
             wp_enqueue_style( $style );
         }
-
+     
         // Load our app.js.
         array_push( $asset_file['dependencies'], 'wp-i18n' );
         wp_enqueue_script( 'create-block-theme-app', plugins_url( 'build/index.js', __DIR__ ), $asset_file['dependencies'], $asset_file['version'] );
@@ -98,7 +98,7 @@ class Manage_Fonts_Admin {
 
         $fonts_json = wp_json_encode( $theme_font_families );
         $fonts_json_string = preg_replace ( '~(?:^|\G)\h{4}~m', "\t", $fonts_json );
-
+        
     ?>
     <div class="wrap">
         <h1 class="wp-heading-inline"><?php _e('Manage Theme Fonts', 'create-block-theme'); ?></h1>
@@ -106,7 +106,7 @@ class Manage_Fonts_Admin {
         <a href="<?php echo admin_url( 'themes.php?page=add-local-font-to-theme-json' ); ?>" class="page-title-action"><?php _e('Add Local Font', 'create-block-theme'); ?></a>
         <hr class="wp-header-end" />
         <p name="theme-fonts-json" id="theme-fonts-json" class="hidden"><?php echo $fonts_json_string;  ?></p>
-
+        
         <form method="POST"  id="manage-fonts-form">
             <div id="manage-fonts"></div>
             <input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_block_theme' ); ?>" />
@@ -244,7 +244,7 @@ class Manage_Fonts_Admin {
         if ( file_exists( $font_asset_path ) ) {
             return unlink( $font_asset_path );
         }
-
+        
         return false;
 	}
 
@@ -268,7 +268,7 @@ class Manage_Fonts_Admin {
 			if ( ! isset ( $font_family[ 'shouldBeRemoved' ] ) ) {
 				$prepared_font_families[] = $font_family;
 			}
-
+			
 		}
 
 		return $prepared_font_families;
@@ -285,7 +285,7 @@ class Manage_Fonts_Admin {
                 return add_action( 'admin_notices', [ $this, 'admin_notice_manage_fonts_permission_error' ] );
             }
 
-            // parse json from form
+            // parse json from form 
             $new_theme_fonts_json = json_decode( stripslashes( $_POST['new-theme-fonts-json'] ), true );
             $new_font_families = $this->prepare_font_families_for_database( $new_theme_fonts_json );
 


### PR DESCRIPTION
This PR solves the problem of not being able to add or remove fonts in a Windows environment.

https://user-images.githubusercontent.com/54422211/216050896-f7335d09-aa1a-4810-a085-e87cb61860a3.mp4

The PHP core function `is_writable()` may return invalid values in Windows environments, as mentioned in [this Trac ticket](https://core.trac.wordpress.org/ticket/22900). This causes an error that the permissions are incorrect in some Windows environments, when adding or removing fonts.

I have replaced this function with `wp_is_writable()`, an OS-aware WordPress function.

The removal of spaces was done automatically by my code editor, so don't worry about it 🙂