### PR TITLE
Load google fonts data from url

### DIFF
--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -75,6 +75,11 @@ class Manage_Fonts_Admin {
         // Load our app.js.
         array_push( $asset_file['dependencies'], 'wp-i18n' );
         wp_enqueue_script( 'create-block-theme-app', plugins_url( 'build/index.js', __DIR__ ), $asset_file['dependencies'], $asset_file['version'] );
+
+        // Set google fonts json file url.
+        wp_localize_script('create-block-theme-app', 'createBlockTheme', array(
+            'googleFontsDataUrl' => plugins_url( 'assets/google-fonts/fallback-fonts-list.json', __DIR__ ),
+        ));
     }
 
     function manage_fonts_admin_page () {

--- a/src/google-fonts/index.js
+++ b/src/google-fonts/index.js
@@ -5,7 +5,6 @@ import { store as coreDataStore } from '@wordpress/core-data';
 import { SelectControl } from '@wordpress/components';
 
 import FontVariant from './font-variant';
-import googleFontsData from "../../assets/google-fonts/fallback-fonts-list.json";
 import { getWeightFromGoogleVariant, getStyleFromGoogleVariant, forceHttps } from './utils';
 import DemoTextInput from "../demo-text-input";
 import "./google-fonts.css";
@@ -13,6 +12,7 @@ import "./google-fonts.css";
 const EMPTY_SELECTION_DATA = JSON.stringify( {} );
 
 function GoogleFonts () {
+    const [ googleFontsData, setGoogleFontsData ] = useState( {} );
     const [ selectedFont, setSelectedFont ] = useState( null );
     const [ selectedVariants, setSelectedVariants ] = useState( [] );
     const [ selectionData, setSelectionData ] = useState( EMPTY_SELECTION_DATA );
@@ -35,6 +35,15 @@ function GoogleFonts () {
             setSelectedVariants( [ ...selectedVariants, variant ] );
         }
     }
+
+    // Load google fonts data
+    useEffect(() => {
+        (async () => {
+            const responseData = await fetch( createBlockTheme.googleFontsDataUrl );
+            const parsedData = await responseData.json();
+            setGoogleFontsData( parsedData );
+        })();
+    }, []);
 
     // Reset selected variants when the selected font changes
     useEffect( () => {
@@ -69,6 +78,10 @@ function GoogleFonts () {
 
     const handleSelectChange = ( value ) => {
         setSelectedFont( googleFontsData.items[ value ] ) ;
+    }
+
+    if ( ! googleFontsData?.items ) {
+        return null;
     }
 
     return (


### PR DESCRIPTION
Closes: #205

This PR obtains Google Web font data by fetching URLs.

The current implementation imports font data directly in JavaScript. This results in slow builds and large build sizes. To solve these problems, this PR gets the font when rendering the React app and treats it as a state. Since the React app does not know at which URL the font data resides, it uses `wp_localize_script()` and passes the asset URL generated by PHP.

As a result, the size of the build folder could be reduced from 872KB to 14.7KB.

I hope this PR helps.
