### PR TITLE
Add spinner while google fonts load instead of showing a blank page

### DIFF
--- a/src/google-fonts/index.js
+++ b/src/google-fonts/index.js
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
-import { SelectControl } from '@wordpress/components';
+import { SelectControl, Spinner } from '@wordpress/components';
 
 import FontVariant from './font-variant';
 import { getWeightFromGoogleVariant, getStyleFromGoogleVariant, forceHttps } from './utils';
@@ -80,72 +80,79 @@ function GoogleFonts () {
         setSelectedFont( googleFontsData.items[ value ] ) ;
     }
 
-    if ( ! googleFontsData?.items ) {
-        return null;
-    }
-
     return (
         <div className="wrap google-fonts-page">
 			<h1 className="wp-heading-inline">{ __('Add Google fonts to your theme', 'create-block-theme') }</h1>
             <h3>{ __('Add Google fonts assets and font face definitions to your currently active theme', 'create-block-theme')} ({ theme?.name.rendered })</h3>
 
-            <div className="select-font">
-                <SelectControl
-                        label={ __('Select Font', 'create-block-theme') }
-                        name="google-font"
-                        onChange={ handleSelectChange }
-                    >
-                        <option value={null}>{ __('Select a font...', 'create-block-theme') }</option>
-                        { googleFontsData.items.map( ( font, index ) => (
-                                <option value={ index }>{ font.family }</option>
-                        ))}
-                </SelectControl>
-            </div>
-
-            <DemoTextInput />
-
-            { selectedFont && <p>{ __('Select the font variants you want to include:', 'create-block-theme') }</p> }
-
-            { selectedFont && (
-                <table className="wp-list-table widefat striped table-view-list" id="google-fonts-table">
-                    <thead>
-                        <tr>
-                            <td className="">
-                                <input
-                                    type="checkbox"
-                                    onClick={ handleToggleAllVariants }
-                                    checked={ selectedVariants.length === selectedFont?.variants.length }
-                                />
-                            </td>
-                            <td className="">{ __('Weight', 'create-block-theme') }</td>
-                            <td className="">{ __('Style', 'create-block-theme') }</td>
-                            <td className="">{ __('Preview', 'create-block-theme') }</td>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {selectedFont.variants.map( ( variant, i ) => (
-                            <FontVariant
-                                font={ selectedFont }
-                                variant={ variant }
-                                key={`font-variant-${i}`}
-                                isSelected={ selectedVariants.includes( variant ) }
-                                handleToggle={ () => handleToggleVariant( variant ) }
-                            />
-                        ))}
-                    </tbody>
-                </table>
+            { ! googleFontsData?.items && (
+                <p>
+                    <Spinner />
+                    <span>{ __('Loading Google fonts data...', 'create-block-theme') }</span>
+                </p>
             ) }
-            
-            <form enctype="multipart/form-data" action="" method="POST">
-                <input type="hidden" name="selection-data" value={ selectionData } />
-                <input
-                    type="submit"
-                    value={ __('Add google fonts to your theme', 'create-block-theme') }
-                    className="button button-primary"
-                    disabled={ selectedVariants.length === 0 }
-                />
-                <input type="hidden" name="nonce" value={ nonce } />
-            </form>
+
+            { googleFontsData?.items && (
+                <>
+                    <div className="select-font">
+                        <SelectControl
+                                label={ __('Select Font', 'create-block-theme') }
+                                name="google-font"
+                                onChange={ handleSelectChange }
+                            >
+                                <option value={null}>{ __('Select a font...', 'create-block-theme') }</option>
+                                { googleFontsData.items.map( ( font, index ) => (
+                                        <option value={ index }>{ font.family }</option>
+                                ))}
+                        </SelectControl>
+                    </div>
+
+                    <DemoTextInput />
+
+                    { selectedFont && <p>{ __('Select the font variants you want to include:', 'create-block-theme') }</p> }
+
+                    { selectedFont && (
+                        <table className="wp-list-table widefat striped table-view-list" id="google-fonts-table">
+                            <thead>
+                                <tr>
+                                    <td className="">
+                                        <input
+                                            type="checkbox"
+                                            onClick={ handleToggleAllVariants }
+                                            checked={ selectedVariants.length === selectedFont?.variants.length }
+                                        />
+                                    </td>
+                                    <td className="">{ __('Weight', 'create-block-theme') }</td>
+                                    <td className="">{ __('Style', 'create-block-theme') }</td>
+                                    <td className="">{ __('Preview', 'create-block-theme') }</td>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {selectedFont.variants.map( ( variant, i ) => (
+                                    <FontVariant
+                                        font={ selectedFont }
+                                        variant={ variant }
+                                        key={`font-variant-${i}`}
+                                        isSelected={ selectedVariants.includes( variant ) }
+                                        handleToggle={ () => handleToggleVariant( variant ) }
+                                    />
+                                ))}
+                            </tbody>
+                        </table>
+                    ) }
+                    
+                    <form enctype="multipart/form-data" action="" method="POST">
+                        <input type="hidden" name="selection-data" value={ selectionData } />
+                        <input
+                            type="submit"
+                            value={ __('Add google fonts to your theme', 'create-block-theme') }
+                            className="button button-primary"
+                            disabled={ selectedVariants.length === 0 }
+                        />
+                        <input type="hidden" name="nonce" value={ nonce } />
+                    </form>
+                </>
+            ) }
 		</div>
     )
 }


### PR DESCRIPTION
This PR adds a spinner while the google fonts data load (which can take some time in slow connections because it is a big file).
Instead of showing a blank screen, we can show part of the interface with a spinner and some text saying it is loading.

## Before: 
[Screencast from 09-02-23 00:09:40.webm](https://user-images.githubusercontent.com/1310626/217603063-80fda2ce-640e-4954-a2f8-a61c95817228.webm)


## After:
[Screencast from 09-02-23 00:05:52.webm](https://user-images.githubusercontent.com/1310626/217603189-5c02fe68-adad-42f8-bb53-5b352908e806.webm)
