### PR TITLE
Fix Depreciation Warning

### DIFF
--- a/includes/class-create-block-theme.php
+++ b/includes/class-create-block-theme.php
@@ -8,6 +8,7 @@
  * @subpackage Create_Block_Theme/includes
  * @author     WordPress.org
  */
+#[AllowDynamicProperties]
 class Create_Block_Theme {
 
 	/**


### PR DESCRIPTION
This depreciation warning is really driving me crazy:

```
PHP Deprecated:  Creation of dynamic property Create_Block_Theme::$loader is deprecated in ... class-create-block-theme.php on line 49
```

This is just a quick fix.