### PR TITLE
Font families collapsed by default

### DIFF
--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -5,10 +5,10 @@ require_once (__DIR__ . '/font-helpers.php');
 class Manage_Fonts_Admin {
 
 	public function __construct() {
-        add_action( 'admin_menu', [ $this, 'create_admin_menu' ] );
+        add_action( 'init', [ $this, 'save_manage_fonts_changes' ], 1 ); // <- High priority to run before the theme.json data is loaded
         add_action( 'admin_init', [ $this, 'save_google_fonts_to_theme' ] );
         add_action( 'admin_init', [ $this, 'save_local_fonts_to_theme' ] );
-        add_action( 'admin_init', [ $this, 'save_manage_fonts_changes' ] );
+        add_action( 'admin_menu', [ $this, 'create_admin_menu' ] );
 	}
 
     const ALLOWED_FONT_MIME_TYPES = array(
@@ -119,10 +119,6 @@ class Manage_Fonts_Admin {
             wp_register_style( 'theme-font-families', false );
             wp_add_inline_style( 'theme-font-families', $font_assets_stylesheet );
             wp_enqueue_style( 'theme-font-families' );
-        }
-
-        if ( ! empty( $_POST['new-theme-fonts-json'] ) ) {
-            $theme_font_families = json_decode( stripslashes( $_POST['new-theme-fonts-json'] ), true );
         }
 
         $fonts_json = wp_json_encode( $theme_font_families );

--- a/src/fonts-context.js
+++ b/src/fonts-context.js
@@ -68,6 +68,20 @@ export function ManageFontsProvider( { children } ) {
         handleDemoFontSizeChange( DEMO_DEFAULTS[ newDemoType || demoType ][ "size" ] );
     }
 
+    // The list of families that are open (showing the list of font faces) in the font manager.
+    const [ familiesOpen, setFamiliesOpen ] = useState( JSON.parse( localStorage.getItem( "cbt_families-open" )) || [] );
+    
+    const handleToggleFamily = ( familyName ) => {
+        let newFamiliesOpen = [];
+        if  ( familiesOpen.includes( familyName ) ) {
+            newFamiliesOpen = familiesOpen.filter( ( name ) => name !== familyName );
+        } else {
+            newFamiliesOpen = [ ...familiesOpen, familyName ];
+        }
+        setFamiliesOpen( newFamiliesOpen );
+        localStorage.setItem( "cbt_families-open", JSON.stringify( newFamiliesOpen ) );
+    };
+
     return (
         <ManageFontsContext.Provider value={{
             demoText,
@@ -77,6 +91,8 @@ export function ManageFontsProvider( { children } ) {
             handleDemoTypeChange,
             demoFontSize,
             handleDemoFontSizeChange,
+            familiesOpen,
+            handleToggleFamily,
         }}>
             { children }
         </ManageFontsContext.Provider>

--- a/src/manage-fonts/font-face.js
+++ b/src/manage-fonts/font-face.js
@@ -9,7 +9,8 @@ function FontFace ( {
     fontWeight,
     fontStyle,
     deleteFontFace,
-    shouldBeRemoved
+    shouldBeRemoved,
+    isFamilyOpen
 } ) {
     const { demoText, handleDemoTextChange, resetDefaults } = useContext( ManageFontsContext );
 
@@ -37,7 +38,17 @@ function FontFace ( {
                 {/* <input style={ demoStyles } onChange={ handleChange } value={ demoText }/> */}
                 <Demo style={ demoStyles } />
             </td>
-            { deleteFontFace && <td><Button variant="tertiary" onClick={deleteFontFace}>{__('Remove', 'create-block-theme')}</Button></td> }
+            { deleteFontFace && (
+                <td>
+                    <Button
+                        variant="tertiary"
+                        onClick={deleteFontFace}
+                        tabindex={isFamilyOpen ? 0 : -1}
+                    >
+                        {__('Remove', 'create-block-theme')}
+                    </Button>
+                </td>
+            )}
         </tr>
     );
 }

--- a/src/manage-fonts/font-face.js
+++ b/src/manage-fonts/font-face.js
@@ -1,6 +1,4 @@
 import { Button } from '@wordpress/components'; 
-import { useContext } from '@wordpress/element';
-import { ManageFontsContext } from '../fonts-context';
 import Demo from "../demo-text-input/demo";
 const { __ } = wp.i18n;
 
@@ -12,8 +10,6 @@ function FontFace ( {
     shouldBeRemoved,
     isFamilyOpen
 } ) {
-    const { demoText, handleDemoTextChange, resetDefaults } = useContext( ManageFontsContext );
-
     const demoStyles = {
         fontFamily,
         fontStyle,
@@ -21,11 +17,6 @@ function FontFace ( {
         fontWeight: fontWeight ? String(fontWeight).split(' ')[0] : "normal",
     };
     
-    const handleChange = ( event ) => {
-        const newDemoText = event.target.value;
-        handleDemoTextChange( newDemoText );
-    }
-
     if ( shouldBeRemoved ) {
         return null;
     }
@@ -35,7 +26,6 @@ function FontFace ( {
             <td>{fontStyle}</td>
             <td>{fontWeight}</td>
             <td className="demo-cell">
-                {/* <input style={ demoStyles } onChange={ handleChange } value={ demoText }/> */}
                 <Demo style={ demoStyles } />
             </td>
             { deleteFontFace && (

--- a/src/manage-fonts/font-family.js
+++ b/src/manage-fonts/font-family.js
@@ -67,12 +67,14 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                                         deleteFontFace={
                                             () => deleteFontFace(fontFamilyIndex, i)
                                         }
+                                        isFamilyOpen={isOpen}
                                     />
                                 )) }
                                 {
                                     ! hasFontFaces && fontFamily.fontFamily &&
                                     <FontFace
                                         { ...fontFamily }
+                                        isFamilyOpen={isOpen}
                                     />
                                 }
                             </tbody>

--- a/src/manage-fonts/font-family.js
+++ b/src/manage-fonts/font-family.js
@@ -13,12 +13,11 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
         handleToggleFamily( fontFamily.name || fontFamily.fontFamily );
     }
 
-    const fontFaces = fontFamily.fontFace.filter( face => !face.shouldBeRemoved );
-    const hasFontFaces = !!fontFaces.length;
-
     if ( fontFamily.shouldBeRemoved ) {
         return null;
     }
+
+    const hasFontFaces = !!fontFamily.fontFace && !!fontFamily.fontFace.length;
 
     return (
         <table className="wp-list-table widefat table-view-list">
@@ -28,7 +27,7 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                         <div>
                             <strong>{fontFamily.name || fontFamily.fontFamily}</strong>
                             { hasFontFaces &&
-                                <span className="variants-count"> ( { fontFaces.length } { _n( "Variant", "Variants",  fontFamily.fontFace.length, "create-block-theme" ) } )</span>
+                                <span className="variants-count"> ( { fontFamily.fontFace.length } { _n( "Variant", "Variants",  fontFamily.fontFace.length, "create-block-theme" ) } )</span>
                             }
                         </div>
                         <div>
@@ -61,18 +60,23 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                                 </tr>
                             </thead>
                             <tbody>
-                                { hasFontFaces && fontFaces.map((fontFace, i) => (
-                                    <FontFace
-                                        { ...fontFace }
-                                        fontFamilyIndex={fontFamilyIndex}
-                                        fontFaceIndex={i}
-                                        key={`fontface${i}`}
-                                        deleteFontFace={
-                                            () => deleteFontFace(fontFamilyIndex, i)
-                                        }
-                                        isFamilyOpen={isOpen}
-                                    />
-                                )) }
+                                { hasFontFaces && fontFamily.fontFace.map((fontFace, i) => {
+                                    if ( fontFace.shouldBeRemoved ) {
+                                        return null;
+                                    }
+                                    return (
+                                        <FontFace
+                                            { ...fontFace }
+                                            fontFamilyIndex={fontFamilyIndex}
+                                            fontFaceIndex={i}
+                                            key={`fontface${i}`}
+                                            deleteFontFace={
+                                                () => deleteFontFace(fontFamilyIndex, i)
+                                            }
+                                            isFamilyOpen={isOpen}
+                                        />
+                                    )
+                                }) }
                                 {
                                     ! hasFontFaces && fontFamily.fontFamily &&
                                     <FontFace

--- a/src/manage-fonts/font-family.js
+++ b/src/manage-fonts/font-family.js
@@ -1,17 +1,20 @@
-import { useState } from 'react';
+import { useContext } from '@wordpress/element';
 import { Button, Icon } from '@wordpress/components';
 import FontFace from "./font-face";
+import { ManageFontsContext } from '../fonts-context';
 
 const { __, _n } = wp.i18n;
 function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFontFace } ) {
 
-    const [isOpen, setIsOpen] = useState(false);
+    const { familiesOpen, handleToggleFamily } = useContext(ManageFontsContext);
+    const isOpen = familiesOpen.includes( fontFamily.name || fontFamily.fontFamily );
 
     const toggleIsOpen = () => {
-        setIsOpen(!isOpen);
+        handleToggleFamily( fontFamily.name || fontFamily.fontFamily );
     }
 
-    const hasFontFaces = !!fontFamily.fontFace && !!fontFamily.fontFace.length;
+    const fontFaces = fontFamily.fontFace.filter( face => !face.shouldBeRemoved );
+    const hasFontFaces = !!fontFaces.length;
 
     if ( fontFamily.shouldBeRemoved ) {
         return null;
@@ -25,7 +28,7 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                         <div>
                             <strong>{fontFamily.name || fontFamily.fontFamily}</strong>
                             { hasFontFaces &&
-                                <span className="variants-count"> ( { fontFamily.fontFace.length } { _n( "Variant", "Variants",  fontFamily.fontFace.length, "create-block-theme" ) } )</span>
+                                <span className="variants-count"> ( { fontFaces.length } { _n( "Variant", "Variants",  fontFamily.fontFace.length, "create-block-theme" ) } )</span>
                             }
                         </div>
                         <div>
@@ -58,7 +61,7 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
                                 </tr>
                             </thead>
                             <tbody>
-                                { hasFontFaces && fontFamily.fontFace.map((fontFace, i) => (
+                                { hasFontFaces && fontFaces.map((fontFace, i) => (
                                     <FontFace
                                         { ...fontFace }
                                         fontFamilyIndex={fontFamilyIndex}

--- a/src/manage-fonts/font-family.js
+++ b/src/manage-fonts/font-family.js
@@ -2,10 +2,10 @@ import { useState } from 'react';
 import { Button, Icon } from '@wordpress/components';
 import FontFace from "./font-face";
 
-const { __ } = wp.i18n;
+const { __, _n } = wp.i18n;
 function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFontFace } ) {
 
-    const [isOpen, setIsOpen] = useState(true);
+    const [isOpen, setIsOpen] = useState(false);
 
     const toggleIsOpen = () => {
         setIsOpen(!isOpen);
@@ -19,10 +19,15 @@ function FontFamily ( { fontFamily, fontFamilyIndex, deleteFontFamily, deleteFon
 
     return (
         <table className="wp-list-table widefat table-view-list">
-            <thead>
+            <thead onClick={toggleIsOpen}>
                 <tr>
                     <td className="font-family-head">
-                        <div><strong>{fontFamily.name || fontFamily.fontFamily}</strong></div>
+                        <div>
+                            <strong>{fontFamily.name || fontFamily.fontFamily}</strong>
+                            { hasFontFaces &&
+                                <span className="variants-count"> ( { fontFamily.fontFace.length } { _n( "Variant", "Variants",  fontFamily.fontFace.length, "create-block-theme" ) } )</span>
+                            }
+                        </div>
                         <div>
                             <Button
                                 variant="tertiary"

--- a/src/manage-fonts/manage-fonts.css
+++ b/src/manage-fonts/manage-fonts.css
@@ -11,6 +11,23 @@
 
 .font-families > table {
     margin-bottom: 2rem;
+    overflow: hidden;
+}
+
+.font-families > table > tbody {
+    position: relative;
+    z-index: 1;
+}
+
+.font-families > table > thead {
+    cursor: pointer;
+    position: relative;
+    z-index: 2;
+}
+
+.font-families > table > thead .variants-count {
+    font-size: 0.8rem;
+    font-weight: 400;
 }
 
 .font-families > table > thead td {
@@ -38,9 +55,10 @@
 }
 
 .font-family-contents .slide.close {
-    transform: translateY(-80%);
+    transform: translateY(-50%);
     opacity: 0;
     max-height: 0px;
+    pointer-events: none;
 }
 
 .font-family-contents table {


### PR DESCRIPTION
This PR adds:
- Font families are collapsed by default
- Adds a variant count at the side of the family name
- Fixes the collapse/open transition broken in a previous PR.
- Fixes outdated theme json data in some cases

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1310626/219591496-a8da74bb-a2a9-4712-a2e1-fdeac231df5a.png) | ![image](https://user-images.githubusercontent.com/1310626/219591324-31a17e48-f513-4e77-9a20-5f93671700de.png) |


Part of: https://github.com/WordPress/create-block-theme/issues/227