### PR TITLE
Cloned themes: Add original theme name to readme.txt and style.css

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -165,6 +165,7 @@ class Create_Block_Theme_Admin {
 		$theme['author_uri'] = sanitize_text_field( $theme['author_uri'] );
 		$theme['slug'] = $this->get_theme_slug( $theme['name'] );
 		$theme['template'] = wp_get_theme()->get( 'Template' );
+		$theme['original_theme'] = wp_get_theme()->get( 'Name' );
 
 		// Create ZIP file in the temporary directory.
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
@@ -1152,6 +1153,19 @@ class Create_Block_Theme_Admin {
 		$author = $theme['author'];
 		$author_uri = $theme['author_uri'];
 		$copyYear = date('Y');
+		$theme_credit = $theme['original_theme'] ?? '';
+
+		if ( $theme_credit ) {
+			$theme_credit_content = sprintf(
+				/* translators: Original Theme Name. */
+				__('Based on %s theme.', 'create-block-theme'),
+				$theme['original_theme']
+			);
+
+			$description .= "
+
+{$theme_credit_content}";
+		}
 
 		return "=== {$name} ===
 Contributors: {$author}

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -1160,7 +1160,7 @@ class Create_Block_Theme_Admin {
 		$original_readme      = get_stylesheet_directory() . '/readme.txt' ?? '';
 		$original_license     = '';
 		$original_license_uri = '';
-		$readme_content       = file_get_contents( $original_readme ) ?? '';
+		$readme_content       = file_exists( $original_readme ) ? file_get_contents( $original_readme ) : '';
 
 		if ( ! $readme_content ) {
 			return;
@@ -1210,10 +1210,11 @@ class Create_Block_Theme_Admin {
 		$author_uri = $theme['author_uri'];
 		$copyYear = date('Y');
 		$original_theme = $theme['original_theme'] ?? '';
-		$original_theme_credits = '';
+		$original_theme_credits = $original_theme ? $this->original_theme_credits( $name ) : '';
 
-		if ( $original_theme ) {
-			$original_theme_credits = "{$this->original_theme_credits( $name )}
+		if ( $original_theme_credits ) {
+			// Add a new line to the original theme credits
+			$original_theme_credits = "{$original_theme_credits}
 ";
 		}
 

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -1144,20 +1144,55 @@ class Create_Block_Theme_Admin {
 
 	/**
 	 * Build string for original theme credits.
-	 * Used in style.css and readme.txt of cloned themes.
+	 * Used in readme.txt of cloned themes.
 	 *
-	 * @param string $original_theme Original theme name.
+	 * @param string $new_name New theme name.
 	 * @return string
 	 */
-	function original_theme_credits( $original_theme ) {
-		if ( ! $original_theme ) {
+	function original_theme_credits( $new_name ) {
+		if ( ! $new_name ) {
+			return;
+		}
+
+		$original_name        = wp_get_theme()->get( 'Name' ) ?? '';
+		$original_uri         = wp_get_theme()->get( 'ThemeURI' ) ?? '';
+		$original_author      = wp_get_theme()->get( 'Author' ) ?? '';
+		$original_readme      = get_stylesheet_directory() . '/readme.txt' ?? '';
+		$original_license     = '';
+		$original_license_uri = '';
+		$readme_content       = file_get_contents( $original_readme ) ?? '';
+
+		if ( ! $readme_content ) {
+			return;
+		}
+
+		// Get license from original theme readme.txt
+		if ( str_contains( $readme_content, 'License:' ) ) {
+			$starts           = strpos( $readme_content, 'License:' ) + strlen( 'License:' );
+			$ends             = strpos( $readme_content, 'License URI:', $starts );
+			$original_license = trim( substr( $readme_content, $starts, $ends - $starts ) );
+		}
+
+		// Get license URI from original theme readme.txt
+		if ( str_contains( $readme_content, 'License URI:' ) ) {
+			$starts               = strpos( $readme_content, 'License URI:' ) + strlen( 'License URI:' );
+			$ends                 = strpos( $readme_content, '== Description ==', $starts );
+			$original_license_uri = trim( substr( $readme_content, $starts, $ends - $starts ) );
+		}
+
+		if ( empty( $original_license ) || empty( $original_license_uri ) ) {
 			return;
 		}
 
 		$theme_credit_content = sprintf(
-			/* translators: Original Theme Name. */
-			__('Based on %s theme.', 'create-block-theme'),
-			$original_theme
+			__( '%1$s is based on %2$s (%3$s), (C) %4$s, [%5$s](%6$s)', 'create-block-theme' ),
+			/* translators: 1: New Theme name, 2: Original Theme Name. 3. Original Theme URI. 4. Original Theme Author. 5. Original Theme License. 6. Original Theme License URI. */
+			$new_name,
+			$original_name,
+			$original_uri,
+			$original_author,
+			$original_license,
+			$original_license_uri
 		);
 
 		return $theme_credit_content;
@@ -1175,13 +1210,11 @@ class Create_Block_Theme_Admin {
 		$author_uri = $theme['author_uri'];
 		$copyYear = date('Y');
 		$original_theme = $theme['original_theme'] ?? '';
+		$original_theme_credits = '';
 
 		if ( $original_theme ) {
-			$theme_credit_content = $this->original_theme_credits( $original_theme );
-			$whitespace = $description ? '
-
-' : '';
-			$description .= $whitespace . $theme_credit_content;
+			$original_theme_credits = "{$this->original_theme_credits( $name )}
+";
 		}
 
 		return "=== {$name} ===
@@ -1205,7 +1238,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 {$name} WordPress Theme, (C) {$copyYear} {$author}
 {$name} is distributed under the terms of the GNU GPL.
-
+{$original_theme_credits}
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 of the License, or
@@ -1229,14 +1262,6 @@ GNU General Public License for more details.
 		$author = $theme['author'];
 		$author_uri = $theme['author_uri'];
 		$template = $theme['template'];
-		$original_theme = $theme['original_theme'] ?? '';
-
-		if ( $original_theme ) {
-			$theme_credit_content = $this->original_theme_credits( $original_theme );
-			$whitespace = $description ? ' ' : '';
-			$description .= $whitespace . $theme_credit_content;
-		}
-
 		return "/*
 Theme Name: {$name}
 Theme URI: {$uri}

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -1143,6 +1143,27 @@ class Create_Block_Theme_Admin {
 	}
 
 	/**
+	 * Build string for original theme credits.
+	 * Used in style.css and readme.txt of cloned themes.
+	 *
+	 * @param string $original_theme Original theme name.
+	 * @return string
+	 */
+	function original_theme_credits( $original_theme ) {
+		if ( ! $original_theme ) {
+			return;
+		}
+
+		$theme_credit_content = sprintf(
+			/* translators: Original Theme Name. */
+			__('Based on %s theme.', 'create-block-theme'),
+			$original_theme
+		);
+
+		return $theme_credit_content;
+	}
+
+	/**
 	 * Build a readme.txt file for CHILD/GRANDCHILD themes.
 	 */
 	function build_readme_txt( $theme ) {
@@ -1153,18 +1174,14 @@ class Create_Block_Theme_Admin {
 		$author = $theme['author'];
 		$author_uri = $theme['author_uri'];
 		$copyYear = date('Y');
-		$theme_credit = $theme['original_theme'] ?? '';
+		$original_theme = $theme['original_theme'] ?? '';
 
-		if ( $theme_credit ) {
-			$theme_credit_content = sprintf(
-				/* translators: Original Theme Name. */
-				__('Based on %s theme.', 'create-block-theme'),
-				$theme['original_theme']
-			);
+		if ( $original_theme ) {
+			$theme_credit_content = $this->original_theme_credits( $original_theme );
+			$whitespace = $description ? '
 
-			$description .= "
-
-{$theme_credit_content}";
+' : '';
+			$description .= $whitespace . $theme_credit_content;
 		}
 
 		return "=== {$name} ===
@@ -1212,6 +1229,14 @@ GNU General Public License for more details.
 		$author = $theme['author'];
 		$author_uri = $theme['author_uri'];
 		$template = $theme['template'];
+		$original_theme = $theme['original_theme'] ?? '';
+
+		if ( $original_theme ) {
+			$theme_credit_content = $this->original_theme_credits( $original_theme );
+			$whitespace = $description ? ' ' : '';
+			$description .= $whitespace . $theme_credit_content;
+		}
+
 		return "/*
 Theme Name: {$name}
 Theme URI: {$uri}


### PR DESCRIPTION
Resolves https://github.com/WordPress/create-block-theme/issues/223.

This adds the original theme name to the output readme.txt of a cloned theme.

It uses the following text: "[New Theme] is based on [Original Theme] ([Original Theme URL), (C) [Original Theme Author], [Original Theme License]([Original Theme License URL)"

readme.txt:
<img width="905" alt="image" src="https://user-images.githubusercontent.com/1645628/220165147-b4137850-6028-4010-bf0d-db40e251ec70.png">