### PR TITLE
Fix: Unexpected action when clicking Collapse chevron

### DIFF
--- a/src/manage-fonts/manage-fonts.css
+++ b/src/manage-fonts/manage-fonts.css
@@ -26,6 +26,7 @@
 
 .font-family-contents .container {
     overflow: hidden;
+    display: block;
 }
 
 .font-family-contents .slide {


### PR DESCRIPTION
Fixes: #231

**Note**: I added the --no-verify option on commit to prevent the large number of diffs created by lint-staged.

I think the problem is probably due to the fact that the `tr` element did not have `overflow:hidden` in effect by default. Thus, the content of the closed font will overshadow the next element while remaining invisible.

![close](https://user-images.githubusercontent.com/54422211/219856060-c61230b9-9c4d-4beb-8299-2217cdb2c6cc.png)
