### PR TITLE
Replacing mkdir() calls with WordPress wp_mkdir_p() function

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -297,7 +297,7 @@ class Create_Block_Theme_Admin {
 		$source = plugin_dir_path( __DIR__ ) . 'assets/boilerplate';
 		$blank_theme_path = get_theme_root() . DIRECTORY_SEPARATOR . $theme['slug'];
 		if ( ! file_exists( $blank_theme_path ) ) {
-			mkdir( $blank_theme_path, 0755 );
+			wp_mkdir_p( $blank_theme_path );
 			// Add readme.txt.
 			file_put_contents( 
 				$blank_theme_path . DIRECTORY_SEPARATOR . 'readme.txt', 
@@ -327,7 +327,7 @@ class Create_Block_Theme_Admin {
 					\RecursiveIteratorIterator::SELF_FIRST) as $item
 				) {
 				if ($item->isDir()) {
-					mkdir( $blank_theme_path . DIRECTORY_SEPARATOR . $iterator->getSubPathname());
+					wp_mkdir_p( $blank_theme_path . DIRECTORY_SEPARATOR . $iterator->getSubPathname());
 				} else {
 					copy($item, $blank_theme_path . DIRECTORY_SEPARATOR . $iterator->getSubPathname());
 				}
@@ -367,7 +367,7 @@ class Create_Block_Theme_Admin {
 		$file_counter = 0;
 
 		if ( ! file_exists( $variation_path ) ) {
-			mkdir( $variation_path, 0755, true );
+			wp_mkdir_p( $variation_path );
 		}
 		
 		if ( file_exists( $variation_path . $variation_slug . '.json' ) ) {

--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -62,15 +62,10 @@ class Manage_Fonts_Admin {
     function can_read_and_write_font_assets_directory () {
 		// Create the font assets folder if it doesn't exist
         $temp_dir = get_temp_dir();
-		$assets_path = get_stylesheet_directory() . '/assets';
-		$font_assets_path = $assets_path . '/fonts';
-		if ( ! is_dir( $assets_path ) ) {
-			mkdir( $assets_path, 0755 );
-		}
-		if ( ! is_dir( $font_assets_path ) ) {
-			mkdir( $font_assets_path, 0755 );
-		}
-
+		$font_assets_path = get_stylesheet_directory() . '/assets/fonts/';
+        if ( ! is_dir( $font_assets_path ) ) {
+            wp_mkdir_p( $font_assets_path );
+        }
 		// If the font asset folder can't be written return an error
 		if ( ! wp_is_writable( $font_assets_path ) || ! is_readable( $font_assets_path ) || ! wp_is_writable( $temp_dir ) ) {
             add_action( 'admin_notices', [ $this, 'admin_notice_manage_fonts_permission_error' ] );


### PR DESCRIPTION
## What?
In this PR we are removing all the remaining calls to PHP's `mkdir()` and replacing them with the WordPress `wp_mkdir_p()` function.

## Why?
To simplify the code and reduce the potential error surface. By leveraging `wp_mkdir_p()` we can remove the permissions parameter and let WordPress take care of that.

This user report seems to be related to that: https://wordpress.org/support/topic/permissions-on-assets-directory/
This PR should fix it.