### PR TITLE
Use Gutenberg Theme JSON resolver if its available

### DIFF
--- a/admin/resolver_additions.php
+++ b/admin/resolver_additions.php
@@ -61,7 +61,11 @@ function augment_resolver_with_utilities() {
  				$theme->merge( $theme_theme );
 			}
 
-			$theme->merge( static::get_user_data() );
+			if ( class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
+				$theme->merge( WP_Theme_JSON_Resolver_Gutenberg::get_user_data() );
+			} else {
+				$theme->merge( static::get_user_data() );
+			}
 
 			$data = $theme->get_data();
 


### PR DESCRIPTION
## What?
Use Gutenberg Theme JSON resolver to get user config if it's available.

## Why?
There are certain new features as the custom CSS in global styles that depends on the Gutenberg resolver because they are not coming from the core resolver.

Fixes: #240

