### PR TITLE
Remove white spaces from theme slugs

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -644,8 +644,7 @@ class Create_Block_Theme_Admin {
 				if ( $style ) {
 					preg_match_all('#\bhttps?://[^,\s()<>]+(?:\([\w\d]+\)|([^,[:punct:]\s]|/))#', $style, $match);
 					$urls = $match[0];
-		$template_content = $template->content;
-		foreach ( $urls as $url ) {
+					foreach ( $urls as $url ) {
 						if ( $this->is_absolute_url( $url ) ) {
 							$html = str_replace( $url, $this->make_relative_media_url( $url ), $html );
 						}

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -469,6 +469,7 @@ class Create_Block_Theme_Admin {
 
 		$old_slug = wp_get_theme()->get( 'TextDomain' );
  		$new_slug = sanitize_title( $new_theme_name );
+		$new_slug = preg_replace('/\s+/', '', $new_slug); // Remove spaces
 
 		if( ! str_contains( $old_slug , '-') && str_contains( $new_slug, '-' ) ) {
 			return str_replace( '-', '', $new_slug );
@@ -494,7 +495,6 @@ class Create_Block_Theme_Admin {
 			return false;
 		}
 
-		$template->content = _remove_theme_attribute_in_block_template_content( $template->content );
 
 		// NOTE: Dashes are encoded as \u002d in the content that we get (noteably in things like css variables used in templates)
 		// This replaces that with dashes again. We should consider decoding the entire string but that is proving difficult.
@@ -644,7 +644,8 @@ class Create_Block_Theme_Admin {
 				if ( $style ) {
 					preg_match_all('#\bhttps?://[^,\s()<>]+(?:\([\w\d]+\)|([^,[:punct:]\s]|/))#', $style, $match);
 					$urls = $match[0];
-					foreach ( $urls as $url ) {
+		$template_content = $template->content;
+		foreach ( $urls as $url ) {
 						if ( $this->is_absolute_url( $url ) ) {
 							$html = str_replace( $url, $this->make_relative_media_url( $url ), $html );
 						}
@@ -704,15 +705,6 @@ class Create_Block_Theme_Admin {
 		return $block;
 	}
 
-	function add_theme_attr_to_template_part_block ( $block ) {
-		// The template parts included in the patterns need to indicate the theme they belong to
-		if ( 'core/template-part' === $block[ 'blockName' ] ) {
-			$block['attrs']['theme'] = ( $_POST['theme']['type'] === "export" || $_POST['theme']['type'] === "save" )
-			? strtolower( wp_get_theme()->get( 'Name' ) )
-			: $_POST['theme']['name'];
-		}
-		return $block;
-	}
 
 	function make_media_blocks_local ( $nested_blocks ) {
 		$new_blocks = [];
@@ -728,9 +720,6 @@ class Create_Block_Theme_Admin {
 					break;
 				case 'core/media-text':
 					$block = $this->make_mediatext_block_local( $block );
-					break;
-				case 'core/template-part':
-					$block = $this->add_theme_attr_to_template_part_block( $block );
 					break;
 			}
 			// recursive call for inner blocks


### PR DESCRIPTION
## What?
- Remove white spaces from the theme slug
- Removing the removal of the key in the template parts links in templates because this is not necessary.

## How to test?
Follow the steps detailed in the description of: #242

Fixes: https://github.com/WordPress/create-block-theme/issues/242
