### PR TITLE
fix manage theme font menu casing

### DIFF
--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -31,16 +31,16 @@ class Manage_Fonts_Admin {
 			return;
 		}
 
-		$manage_fonts_page_title=_x('Manage theme fonts', 'UI String', 'create-block-theme');
-        $manage_fonts_menu_title=_x('Manage theme fonts', 'UI String', 'create-block-theme');
+		$manage_fonts_page_title = _x('Manage Theme Fonts', 'UI String', 'create-block-theme');
+        $manage_fonts_menu_title = $manage_fonts_page_title;
         add_theme_page( $manage_fonts_page_title, $manage_fonts_menu_title, 'edit_theme_options', 'manage-fonts', [ 'Fonts_Page', 'manage_fonts_admin_page' ] );
 
-        $google_fonts_page_title=_x('Embed Google font in the active theme', 'UI String', 'create-block-theme');
-		$google_fonts_menu_title=_x('Embed Google font in the active theme', 'UI String', 'create-block-theme');
+        $google_fonts_page_title = _x('Embed Google font in the active theme', 'UI String', 'create-block-theme');
+		$google_fonts_menu_title = $google_fonts_page_title;
         add_submenu_page(null, $google_fonts_page_title, $google_fonts_menu_title, 'edit_theme_options', 'add-google-font-to-theme-json', [ 'Google_Fonts', 'google_fonts_admin_page' ] );
 
-		$local_fonts_page_title=_x('Embed local font in the active theme', 'UI String', 'create-block-theme');
-		$local_fonts_menu_title=_x('Embed local font in the active theme', 'UI String', 'create-block-theme');
+		$local_fonts_page_title = _x('Embed local font in the active theme', 'UI String', 'create-block-theme');
+		$local_fonts_menu_title = $local_fonts_page_title;
 		add_submenu_page(null, $local_fonts_page_title, $local_fonts_menu_title, 'edit_theme_options', 'add-local-font-to-theme-json', [ 'Local_Fonts', 'local_fonts_admin_page' ] );
 	}
 


### PR DESCRIPTION
This fixes font casing of the menu to capital case.

Before:

<img width="159" alt="image" src="https://user-images.githubusercontent.com/1935113/220827945-195319e3-f285-415e-bf67-6e7fc745c205.png">

After:

<img width="159" alt="image" src="https://user-images.githubusercontent.com/1935113/220827917-87cf7046-aa0f-4b5c-9b92-6bea4f95facc.png">

Fixes: #243 