### PR TITLE
Add phpcs exception to avoid PHP8.0 incompatibility errors

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -68,4 +68,10 @@
 	<rule ref="WordPress.Files.FileName">
 		<exclude-pattern>*</exclude-pattern>
 	</rule>
+
+	<!--
+	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
+	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
+	-->
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
 </ruleset>


### PR DESCRIPTION
The last WPCS release does not support PHP 8.0 or 8.1. This PR allows the phpcs to run without error on PHP 8.0+. 

To test, run `npm run lint:php:fix`. Verify the runtime error is avoided. Note that this PR does not actually commit the resulting fixes.

Fixes #246