### PR TITLE
fix package lock sync issue

### DIFF
--- a/.github/workflows/deploy-to-dotorg.yml
+++ b/.github/workflows/deploy-to-dotorg.yml
@@ -3,60 +3,60 @@ name: Deploy to WordPress.org
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.
 on:
-  workflow_dispatch:
-    inputs:
-      release_type:
-        description: 'Release type'
-        required: true
-        type: choice
-        options:
-        - major
-        - minor
-        - patch
+    workflow_dispatch:
+        inputs:
+            release_type:
+                description: 'Release type'
+                required: true
+                type: choice
+                options:
+                    - major
+                    - minor
+                    - patch
 jobs:
-  tag:
-    name: Checkout repo
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18
-      
-    - name: Install node dependencies
-      run: npm install
+    tag:
+        name: Checkout repo
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
 
-    - name: Compile Javascript App
-      run: npm run build
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 18
 
-    - name: Update version and changelog
-      id: update-version
-      env:
-        RELEASE_TYPE: ${{ github.event.inputs.release_type }}
-      run: npm run update-version
+            - name: Install node dependencies
+              run: npm install
 
-    - name: Create Relase
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git config --global --add --bool push.autoSetupRemote true
-        git diff-index --quiet HEAD -- || ( git add package.json readme.txt create-block-theme.php && git commit -m "Version bump & changelog update" --no-verify && git push )
-        gh release create ${{steps.update-version.outputs.NEW_TAG }} --generate-notes
+            - name: Compile Javascript App
+              run: npm run build
 
-    - name: Create Block Theme Plugin Deploy to WordPress.org
-      uses: 10up/action-wordpress-plugin-deploy@stable
-      env:
-        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        VERSION: ${{ steps.update-version.outputs.NEW_VERSION }}
-        
-    - name: WordPress.org plugin asset/readme update
-      uses: 10up/action-wordpress-plugin-asset-update@stable
-      env:
-        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+            - name: Update version and changelog
+              id: update-version
+              env:
+                  RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+              run: npm run update-version
+
+            - name: Create Release
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  git config user.name github-actions
+                  git config user.email github-actions@github.com
+                  git config --global --add --bool push.autoSetupRemote true
+                  git diff-index --quiet HEAD -- || ( git add package.json package-lock.json readme.txt create-block-theme.php && git commit -m "Version bump & changelog update" --no-verify && git push )
+                  gh release create ${{steps.update-version.outputs.NEW_TAG }} --generate-notes
+
+            - name: Create Block Theme Plugin Deploy to WordPress.org
+              uses: 10up/action-wordpress-plugin-deploy@stable
+              env:
+                  SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+                  SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+                  VERSION: ${{ steps.update-version.outputs.NEW_VERSION }}
+
+            - name: WordPress.org plugin asset/readme update
+              uses: 10up/action-wordpress-plugin-asset-update@stable
+              env:
+                  SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+                  SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/update-google-fonts-data.yml
+++ b/.github/workflows/update-google-fonts-data.yml
@@ -5,41 +5,40 @@ name: Update Google Fonts JSON
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.
 on:
-  schedule:
-    - cron: '0 0 * * TUE' # Runs weekly, every Tuesday.
-  workflow_dispatch:
+    schedule:
+        - cron: '0 0 * * TUE' # Runs weekly, every Tuesday.
+    workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "update-google-fonts-json"
-  update-google-fonts-json:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    # This workflow contains a single job called "update-google-fonts-json"
+    update-google-fonts-json:
+        # The type of runner that the job will run on
+        runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18
+        # Steps represent a sequence of tasks that will be executed as part of the job
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 18
 
-    - name: Get current date
-      id: date
-      run: echo "{date}={$(date +'%Y-%m-%d')}" >> $GITHUB_OUTPUT
+            - name: Get current date
+              id: date
+              run: echo "{date}={$(date +'%Y-%m-%d')}" >> $GITHUB_OUTPUT
 
-    # Runs a single command using the runners shell
-    # This script fetchs the Goolgle Fonts API data and creates a PR if new data is available
-    - name: Update Google Fonts JSON
-      env:
-        GOOGLE_FONTS_API_KEY: ${{ secrets.GOOGLE_FONTS_API_KEY }}
-        BRANCH_NAME: update/google-fonts-json-${{ steps.date.outputs.date }}_${{ github.run_id }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        echo "Updating Google fonts JSON"
-        node ./update-google-fonts-json-file.js
-        git config user.name 'github-actions[bot]'
-        git config user.email 'github-actions[bot]@users.noreply.github.com'
-        git config --global --add --bool push.autoSetupRemote true
-        
-        git diff-index --quiet HEAD -- || ( git add assets/google-fonts/fallback-fonts-list.json && git checkout -b ${{ env.BRANCH_NAME }} && git commit -m "Updating file" --no-verify && git push && gh pr create -B trunk -H ${{ env.BRANCH_NAME }} --title "Update Google Fonts JSON data from API" --body "Created by Update Google Fonts JSON Github action" )
-        
+            # Runs a single command using the runners shell
+            # This script fetchs the Goolgle Fonts API data and creates a PR if new data is available
+            - name: Update Google Fonts JSON
+              env:
+                  GOOGLE_FONTS_API_KEY: ${{ secrets.GOOGLE_FONTS_API_KEY }}
+                  BRANCH_NAME: update/google-fonts-json-${{ steps.date.outputs.date }}_${{ github.run_id }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  echo "Updating Google fonts JSON"
+                  node ./update-google-fonts-json-file.js
+                  git config user.name 'github-actions[bot]'
+                  git config user.email 'github-actions[bot]@users.noreply.github.com'
+                  git config --global --add --bool push.autoSetupRemote true
+
+                  git diff-index --quiet HEAD -- || ( git add assets/google-fonts/fallback-fonts-list.json && git checkout -b ${{ env.BRANCH_NAME }} && git commit -m "Updating file" --no-verify && git push && gh pr create -B trunk -H ${{ env.BRANCH_NAME }} --title "Update Google Fonts JSON data from API" --body "Created by Update Google Fonts JSON Github action" )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "create-block-theme",
-	"version": "1.5.0",
+	"version": "1.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "create-block-theme",
-			"version": "1.5.0",
+			"version": "1.6.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/icons": "^9.17.0"


### PR DESCRIPTION
### What is the issue?

Release workflow runs the command `npm run update-version` to bump the version. 
It also updates `package-lock.json` but its is not included in the commit.

### Fix

This change updates the dotOrg release workflow to include package-lock.json in the version bump commit
And updates the package-lock current version