### PR TITLE
(Fix refactor regression) Remove white spaces from theme slug

### DIFF
--- a/admin/create-theme/theme-blocks.php
+++ b/admin/create-theme/theme-blocks.php
@@ -34,9 +34,6 @@ class Theme_Blocks {
 				case 'core/media-text':
 					$block = self::make_mediatext_block_local( $block );
 					break;
-				case 'core/template-part':
-					$block = self::add_theme_attr_to_template_part_block( $block );
-					break;
 			}
 			// recursive call for inner blocks
 			if ( ! empty( $block['innerBlocks'] ) ) {
@@ -91,16 +88,6 @@ class Theme_Blocks {
 			if ( isset( $block['attrs']['mediaLink'] ) && Theme_Utils::is_absolute_url( $block['attrs']['mediaLink'] ) ) {
 				$block['attrs']['mediaLink'] = Theme_Media::make_relative_media_url( $block['attrs']['mediaLink'] );
 			}
-		}
-		return $block;
-	}
-
-	static function add_theme_attr_to_template_part_block( $block ) {
-		// The template parts included in the patterns need to indicate the theme they belong to
-		if ( 'core/template-part' === $block['blockName'] ) {
-			$block['attrs']['theme'] = ( 'export' === $_POST['theme']['type'] || 'save' === $_POST['theme']['type'] )
-			? strtolower( wp_get_theme()->get( 'Name' ) )
-			: $_POST['theme']['name'];
 		}
 		return $block;
 	}

--- a/admin/create-theme/theme-templates.php
+++ b/admin/create-theme/theme-templates.php
@@ -71,8 +71,6 @@ class Theme_Templates {
 			return false;
 		}
 
-		$template->content = _remove_theme_attribute_in_block_template_content( $template->content );
-
 		// NOTE: Dashes are encoded as \u002d in the content that we get (noteably in things like css variables used in templates)
 		// This replaces that with dashes again. We should consider decoding the entire string but that is proving difficult.
 		$template->content = str_replace( '\u002d', '-', $template->content );

--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -15,6 +15,7 @@ class Theme_Utils {
 
 		$old_slug = wp_get_theme()->get( 'TextDomain' );
 		$new_slug = sanitize_title( $new_theme_name );
+		$new_slug = preg_replace( '/\s+/', '', $new_slug ); // Remove spaces
 
 		if ( ! str_contains( $old_slug, '-' ) && str_contains( $new_slug, '-' ) ) {
 			return str_replace( '-', '', $new_slug );


### PR DESCRIPTION
This PR is the same as #244.

I'm submitting these changes again because the ones introduced by #244 were wiped by this recent code refactor: https://github.com/WordPress/create-block-theme/pull/237