### PR TITLE
Improve accesibility for Manage theme fonts page

### DIFF
--- a/src/demo-text-input/demo-text-input.css
+++ b/src/demo-text-input/demo-text-input.css
@@ -25,3 +25,17 @@
 	margin-left: unset !important;
 	margin-right: 1rem;
 }
+
+.font-size-input {
+	display: flex;
+}
+
+.font-size-input .components-number-control {
+	flex: 2;
+}
+
+.font-size-input .components-range-control {
+	flex: 3;
+	align-self: flex-end;
+	padding-left: 5px;
+}

--- a/src/demo-text-input/index.js
+++ b/src/demo-text-input/index.js
@@ -3,6 +3,8 @@ import {
 	RangeControl,
 	SelectControl,
 	// eslint-disable-next-line
+	__experimentalNumberControl as NumberControl,
+	// eslint-disable-next-line
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -47,14 +49,30 @@ function DemoTextInput() {
 					onChange={ handleDemoTextChange }
 				/>
 
-				<div>
-					<RangeControl
+				<div className="font-size-input">
+					<NumberControl
 						label={ __( 'Font size (px)', 'create-block-theme' ) }
+						aria-label={ __(
+							'Font size (px)',
+							'create-block-theme'
+						) }
+						inputMode="decimal"
+						max={ 140 }
+						min={ 8 }
+						onChange={ handleDemoFontSizeChange }
+						shiftStep={ 1 }
+						value={ demoFontSize }
+					/>
+					<RangeControl
+						aria-label={ __(
+							'Font size (px)',
+							'create-block-theme'
+						) }
 						value={ demoFontSize }
 						onChange={ handleDemoFontSizeChange }
 						min={ 8 }
 						max={ 140 }
-						withInputField={ true }
+						withInputField={ false }
 					/>
 				</div>
 

--- a/src/manage-fonts/font-face.js
+++ b/src/manage-fonts/font-face.js
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import Demo from '../demo-text-input/demo';
-const { __ } = wp.i18n;
+const { __, sprintf } = wp.i18n;
 
 function FontFace( {
 	fontFamily,
@@ -36,6 +36,13 @@ function FontFace( {
 						variant="tertiary"
 						onClick={ deleteFontFace }
 						tabindex={ isFamilyOpen ? 0 : -1 }
+						aria-label={ sprintf(
+							/* translators: %1$s: Font Family name, %2$s: Font style name, %3$s: Font weight name. */
+							__( 'Remove %1$s style %2$s weight %3$s variant' ),
+							fontFamily,
+							fontStyle,
+							fontWeight
+						) }
 					>
 						{ __( 'Remove', 'create-block-theme' ) }
 					</Button>

--- a/src/manage-fonts/font-family.js
+++ b/src/manage-fonts/font-family.js
@@ -3,7 +3,7 @@ import { Button, Icon } from '@wordpress/components';
 import FontFace from './font-face';
 import { ManageFontsContext } from '../fonts-context';
 
-const { __, _n } = wp.i18n;
+const { __, _n, sprintf } = wp.i18n;
 function FontFamily( {
 	fontFamily,
 	fontFamilyIndex,
@@ -59,20 +59,41 @@ function FontFamily( {
 									e.stopPropagation();
 									deleteFontFamily( fontFamilyIndex );
 								} }
+								aria-label={ sprintf(
+									/* translators: %s: Font Family. */
+									__( 'Remove %s Font Family' ),
+									fontFamily.name || fontFamily.fontFamily
+								) }
 							>
 								{ __(
 									'Remove Font Family',
 									'create-block-theme'
 								) }
 							</Button>
-							<Button onClick={ toggleIsOpen }>
+							<Button
+								variant="tertiary"
+								onClick={ toggleIsOpen }
+								aria-expanded={ isOpen }
+							>
 								<Icon
 									icon={
 										isOpen
 											? 'arrow-up-alt2'
 											: 'arrow-down-alt2'
 									}
+									aria-hidden="true"
 								/>
+								<span className="screen-reader-text">
+									{ isOpen
+										? __(
+												'Collapse Fonts',
+												'create-block-theme'
+										  )
+										: __(
+												'Expands Fonts',
+												'create-block-theme'
+										  ) }
+								</span>
 							</Button>
 						</div>
 					</td>

--- a/src/manage-fonts/font-family.js
+++ b/src/manage-fonts/font-family.js
@@ -74,6 +74,17 @@ function FontFamily( {
 								variant="tertiary"
 								onClick={ toggleIsOpen }
 								aria-expanded={ isOpen }
+								aria-label={
+									isOpen
+										? __(
+												'Collapse Font Family',
+												'create-block-theme'
+										  )
+										: __(
+												'Expand Font Family',
+												'create-block-theme'
+										  )
+								}
 							>
 								<Icon
 									icon={
@@ -83,17 +94,6 @@ function FontFamily( {
 									}
 									aria-hidden="true"
 								/>
-								<span className="screen-reader-text">
-									{ isOpen
-										? __(
-												'Collapse Fonts',
-												'create-block-theme'
-										  )
-										: __(
-												'Expands Fonts',
-												'create-block-theme'
-										  ) }
-								</span>
 							</Button>
 						</div>
 					</td>

--- a/src/manage-fonts/index.js
+++ b/src/manage-fonts/index.js
@@ -193,7 +193,10 @@ function ManageFonts() {
 						onClick={ toggleIsHelpOpen }
 						style={ { padding: '0', height: '1rem' } }
 					>
-						<Icon icon={ 'info' } />
+						<Icon icon={ 'info' } aria-hidden="true" />
+						<span className="screen-reader-text">
+							{ __( 'Alert Popup', 'create-block-theme' ) }
+						</span>
 					</Button>
 				</p>
 

--- a/src/manage-fonts/index.js
+++ b/src/manage-fonts/index.js
@@ -192,11 +192,9 @@ function ManageFonts() {
 					<Button
 						onClick={ toggleIsHelpOpen }
 						style={ { padding: '0', height: '1rem' } }
+						aria-label={ __( 'Alert Popup', 'create-block-theme' ) }
 					>
 						<Icon icon={ 'info' } aria-hidden="true" />
-						<span className="screen-reader-text">
-							{ __( 'Alert Popup', 'create-block-theme' ) }
-						</span>
 					</Button>
 				</p>
 


### PR DESCRIPTION
Issue: #230 

- [x] The expand/collapse icon on each font family heading is missing a label. I think we should add a label based on [these best practices](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#icon_buttons).
 -> Add `aria-expands: true/false` based on the user action, Also added `aria-label` to the button and `aria-hidden: true` for icon.

- [x] It would be good to add the name of the font family in each remove button, so it's clear which font family they are linked to. For example, add an aria-label with the contents, "Remove DM Sans font family".
  -> Add `aria-label` for button and `aria-hidden: true` for icon.

- [x]  Similar to above, it would be good to add an aria-label to the font face buttons too.
  -> Similarlly, Adds `aria-label` for button and `aria-hidden: true` for icon.

- [ ]  The tab order of the font size range control is reversed because the flex-direction is set to row-reverse. This is probably because the RangeControl component only allows for the input to be shown on the right, and in this case, it works better on the left. I'm not sure what's possible here but thought it was worth mentioning. Maybe we could look into changing the tab order somehow.

All checked item has been improved, the last one is pending. Last item needs discussion, how we can improve that? Needs 
 you opinion.