### PR TITLE
Allow otf font file upload

### DIFF
--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -16,6 +16,7 @@ class Manage_Fonts_Admin {
 	}
 
 	const ALLOWED_FONT_MIME_TYPES = array(
+		'otf'   => 'font/otf',
 		'ttf'   => 'font/ttf',
 		'woff'  => 'font/woff',
 		'woff2' => 'font/woff2',

--- a/admin/manage-fonts/local-fonts-page.php
+++ b/admin/manage-fonts/local-fonts-page.php
@@ -37,10 +37,10 @@ class Local_Fonts {
 							<th scope="row">
 								<label for="font-file"><?php _e( 'Font file', 'create-block-theme' ); ?></label>
 								<br>
-								<small style="font-weight:normal;"><?php _e( '.ttf, .woff, .woff2 file extensions supported', 'create-block-theme' ); ?></small>
+								<small style="font-weight:normal;"><?php _e( '.otf, .ttf, .woff, .woff2 file extensions supported', 'create-block-theme' ); ?></small>
 							</th>
 							<td>
-								<input type="file" accept=".ttf, .woff, .woff2"  name="font-file" id="font-file" class="upload" required/>
+								<input type="file" accept=".otf, .ttf, .woff, .woff2"  name="font-file" id="font-file" class="upload" required/>
 							</td>
 						</tr>
 						<tr>


### PR DESCRIPTION
## What? 
Allows uploading OTF font files 

## Why? 
Because it is a valid font file supported widely by browsers.
https://caniuse.com/ttf
https://www.w3schools.com/css/css3_fonts.asp

It was requested by a user here:
https://wordpress.org/support/topic/font-loading-not-working/?view=all#post-16550790