### PR TITLE
Variable font weight range

### DIFF
--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -146,6 +146,7 @@ class Manage_Fonts_Admin {
 			wp_verify_nonce( $_POST['nonce'], 'create_block_theme' ) &&
 			! empty( $_FILES['font-file'] ) &&
 			! empty( $_POST['font-name'] ) &&
+			! empty( $_POST['font-weight'] ) &&
 			! empty( $_POST['font-style'] ) &&
 			$this->has_file_and_user_permissions()
 		) {
@@ -161,15 +162,12 @@ class Manage_Fonts_Admin {
 
 				$uploaded_font_face = array(
 					'fontFamily' => $_POST['font-name'],
+					'fontWeight' => $_POST['font-weight'],
 					'fontStyle'  => $_POST['font-style'],
 					'src'        => array(
 						'file:./assets/fonts/' . $file_name,
 					),
 				);
-
-				if ( ! empty( $_POST['font-weight'] ) ) {
-					$uploaded_font_face['fontWeight'] = $_POST['font-weight'];
-				}
 
 				if ( ! empty( $_POST['font-variation-settings'] ) ) {
 					// replace escaped single quotes with single quotes

--- a/src/local-fonts/index.js
+++ b/src/local-fonts/index.js
@@ -34,14 +34,9 @@ function LocalFonts() {
 	};
 
 	const isFormValid = () => {
-		const isValid = formData.file && formData.name && formData.style;
-
-		// if the font is not variable weight, the weight is required
-		if ( ! formData.variableWeight ) {
-			return isValid && formData.weight;
-		}
-
-		return isValid;
+		return (
+			formData.file && formData.name && formData.weight && formData.style
+		);
 	};
 
 	const demoStyle = () => {

--- a/src/local-fonts/upload-font-form.js
+++ b/src/local-fonts/upload-font-form.js
@@ -60,11 +60,14 @@ function UploadFontForm( {
 
 				// Variable fonts info
 				const isVariable = !! font.opentype.tables.fvar;
-				const isVariableWeight =
+				const weightAxis =
 					isVariable &&
-					!! font.opentype.tables.fvar.axes.find(
+					font.opentype.tables.fvar.axes.find(
 						( { tag } ) => tag === 'wght'
 					);
+				const weightRange = !! weightAxis
+					? `${ weightAxis.minValue } ${ weightAxis.maxValue }`
+					: null;
 				const axes = isVariable
 					? font.opentype.tables.fvar.axes.reduce(
 							(
@@ -88,9 +91,8 @@ function UploadFontForm( {
 					file,
 					name: fontName,
 					style: isItalic ? 'italic' : 'normal',
-					...( ! isVariableWeight ? { weight: fontWeight } : {} ),
+					weight: !! weightAxis ? weightRange : fontWeight,
 					variable: isVariable,
-					variableWeight: isVariableWeight,
 				} );
 				setAxes( axes );
 			};
@@ -170,27 +172,16 @@ function UploadFontForm( {
 						type="text"
 						name="font-weight"
 						id="font-weight"
-						placeholder={
-							! formData.variableWeight
-								? __( 'Font weight:', 'create-block-theme' )
-								: ''
-						}
+						placeholder={ __(
+							'Font weight:',
+							'create-block-theme'
+						) }
 						value={ formData.weight || '' }
 						onChange={ ( val ) =>
 							setFormData( { ...formData, weight: val } )
 						}
 						// Disable the input if the font is a variable font with the wght axis
-						disabled={ formData.variableWeight }
 					/>
-					{ formData.variableWeight && (
-						<small>
-							{  }
-							{ __(
-								'This font is a variable font with the wght axis, for this reason the font weight selector is disabled',
-								'create-block-theme'
-							) }
-						</small>
-					) }
 				</div>
 
 				{ formData.variable && (


### PR DESCRIPTION
## What ?
Fonts with variable weight axis will autocomplete a font-weight range instead of nothing.



## Why ?
- To follow css specification: https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-weight
- To avoid the 400 font-weight applied by default by WordPress when the font-weight definition is missing in `theme.json`.


## Screenshot
![image](https://user-images.githubusercontent.com/1310626/225617720-434d7332-7bd8-40ee-9cbe-e3303a98c036.png)

