### PR TITLE
Fix manage fonts UI and backend when no settings are defined in theme.json

### DIFF
--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -258,7 +258,7 @@ class Manage_Fonts_Admin {
 	function add_or_update_theme_font_faces( $font_name, $font_slug, $font_faces ) {
 		// Get the current theme.json and fontFamilies defined (if any).
 		$theme_json_raw      = json_decode( file_get_contents( get_stylesheet_directory() . '/theme.json' ), true );
-		$theme_font_families = $theme_json_raw['settings']['typography']['fontFamilies'];
+		$theme_font_families = isset( $theme_json_raw['settings']['typography']['fontFamilies'] ) ? $theme_json_raw['settings']['typography']['fontFamilies'] : null;
 
 		$existent_family = $theme_font_families ? array_values(
 			array_filter(

--- a/admin/manage-fonts/fonts-page.php
+++ b/admin/manage-fonts/fonts-page.php
@@ -8,7 +8,7 @@ class Fonts_Page {
 
 		$theme_data          = WP_Theme_JSON_Resolver::get_theme_data();
 		$theme_settings      = $theme_data->get_settings();
-		$theme_font_families = $theme_settings['typography']['fontFamilies']['theme'];
+		$theme_font_families = isset( $theme_settings['typography']['fontFamilies']['theme'] ) ? $theme_settings['typography']['fontFamilies']['theme'] : array();
 
 		// This is only run when Gutenberg is not active because WordPress core does not include WP_Webfonts class yet. So we can't use it to load the font asset styles.
 		// See the comments here: https://github.com/WordPress/WordPress/blob/88cee0d359f743f94597c586febcc5e09830e780/wp-includes/script-loader.php#L3160-L3186

--- a/src/manage-fonts/index.js
+++ b/src/manage-fonts/index.js
@@ -24,7 +24,7 @@ function ManageFonts() {
 	// The theme font list coming from the server as JSON
 	const themeFontsJsonValue = themeFontsJsonElement.innerHTML;
 
-	const themeFontsJson = JSON.parse( themeFontsJsonValue );
+	const themeFontsJson = JSON.parse( themeFontsJsonValue ) || [];
 
 	// The client-side theme font list is initizaliased with the server-side theme font list
 	const [ newThemeFonts, setNewThemeFonts ] = useState( themeFontsJson );
@@ -156,15 +156,24 @@ function ManageFonts() {
 
 					<DemoTextInput />
 
-					<div className="font-families">
-						{ newThemeFonts.map( ( fontFamily, i ) => (
-							<FontFamily
-								fontFamily={ fontFamily }
-								key={ `fontfamily${ i }` }
-								deleteFont={ requestDeleteConfirmation }
-							/>
-						) ) }
-					</div>
+					{ newThemeFonts.length === 0 ? (
+						<p>
+							{ __(
+								'There are no font families defined in your theme.json file.',
+								'create-block-theme'
+							) }
+						</p>
+					) : (
+						<div className="font-families">
+							{ newThemeFonts.map( ( fontFamily, i ) => (
+								<FontFamily
+									fontFamily={ fontFamily }
+									key={ `fontfamily${ i }` }
+									deleteFont={ requestDeleteConfirmation }
+								/>
+							) ) }
+						</div>
+					) }
 
 					<form method="POST" id="manage-fonts-form">
 						<input


### PR DESCRIPTION
## What ?
Fix manage fonts functionality when the `settings` object is not defined by `theme.json`.

If the `settings.typography.fontFamilies` is not defined in theme.json the manage fonts UI fails to render and the PHP backend throws warnings.

With this PR we are fixing both the UI and the backend.


## How to test
- Remove entirely the `settings` key of your `theme.json`.
- Check if the manage fonts screen is rendering ok
- Add google or local fonts
- Navigate the manage fonts screen and check is working as expected.


Fixes: https://wordpress.org/support/topic/found-an-error-2/