### PR TITLE
Export style variations just with the changes made by the user

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -48,7 +48,7 @@ class Create_Block_Theme_Admin {
 	}
 
 	function save_variation( $export_type, $theme ) {
-		Theme_Json::add_theme_json_variation_to_local( $export_type, $theme );
+		Theme_Json::add_theme_json_variation_to_local( 'variation', $theme );
 	}
 
 	/**

--- a/admin/create-theme/theme-json.php
+++ b/admin/create-theme/theme-json.php
@@ -27,9 +27,16 @@ class Theme_Json {
 
 		$_POST['theme']['variation_slug'] = $variation_slug;
 
+		$extra_theme_data = array(
+			'version' => WP_Theme_JSON::LATEST_SCHEMA,
+			'title'   => $theme['variation'],
+		);
+
+		$variation_theme_json = MY_Theme_JSON_Resolver::export_theme_data( $export_type, $extra_theme_data );
+
 		file_put_contents(
 			$variation_path . $variation_slug . '.json',
-			MY_Theme_JSON_Resolver::export_theme_data( $export_type )
+			$variation_theme_json
 		);
 	}
 }

--- a/admin/resolver_additions.php
+++ b/admin/resolver_additions.php
@@ -14,11 +14,13 @@ function augment_resolver_with_utilities() {
 		 * Export the combined (and flattened) THEME and CUSTOM data.
 		 *
 		 * @param string $content ['all', 'current', 'user'] Determines which settings content to include in the export.
+		 * @param array $extra_theme_data Any theme json extra data to be included in the export.
 		 * All options include user settings.
 		 * 'current' will include settings from the currently installed theme but NOT from the parent theme.
 		 * 'all' will include settings from the current theme as well as the parent theme (if it has one)
+		 * 'variation' will include just the user custom styles and settings.
 		 */
-		public static function export_theme_data( $content ) {
+		public static function export_theme_data( $content, $extra_theme_data ) {
 			if ( class_exists( 'WP_Theme_JSON_Gutenberg' ) ) {
 				$theme = new WP_Theme_JSON_Gutenberg();
 			} else {
@@ -65,6 +67,16 @@ function augment_resolver_with_utilities() {
 				$theme->merge( WP_Theme_JSON_Resolver_Gutenberg::get_user_data() );
 			} else {
 				$theme->merge( static::get_user_data() );
+			}
+
+			// Merge the extra theme data received as a parameter
+			if ( ! empty( $extra_theme_data ) ) {
+				if ( class_exists( 'WP_Theme_JSON_Gutenberg' ) ) {
+					$extra_data = new WP_Theme_JSON_Gutenberg( $extra_theme_data );
+				} else {
+					$extra_data = new WP_Theme_JSON( $extra_theme_data );
+				}
+				$theme->merge( $extra_data );
 			}
 
 			$data = $theme->get_data();


### PR DESCRIPTION
## What ?
- Export a style variation with just the changes made by the user instead of a full copy of the theme.json
- Add the variation title to the variation json.

## Why ?
Because without this change:
- A full copy of theme.json is exported as a variation.
- Variation title is not added to the variant json

Fixes: #150 