### PR TITLE
Adding default value to an to avoid error when calling export_theme_data()

### DIFF
--- a/admin/resolver_additions.php
+++ b/admin/resolver_additions.php
@@ -20,7 +20,7 @@ function augment_resolver_with_utilities() {
 		 * 'all' will include settings from the current theme as well as the parent theme (if it has one)
 		 * 'variation' will include just the user custom styles and settings.
 		 */
-		public static function export_theme_data( $content, $extra_theme_data ) {
+		public static function export_theme_data( $content, $extra_theme_data = null ) {
 			if ( class_exists( 'WP_Theme_JSON_Gutenberg' ) ) {
 				$theme = new WP_Theme_JSON_Gutenberg();
 			} else {


### PR DESCRIPTION
Adding default value to an argument to avoid error when calling  `export_theme_data` the function with only one parameter instead of 2.

This error was introduced here: https://github.com/WordPress/create-block-theme/pull/283
The error is only on `trunk`, and it is not been released publicly.

