### PR TITLE
Fixing image downloading not working in some cases

### DIFF
--- a/admin/create-theme/theme-media.php
+++ b/admin/create-theme/theme-media.php
@@ -137,15 +137,12 @@ class Theme_Media {
 
 	public static function add_media_to_local( $media ) {
 		foreach ( $media as $url ) {
-			$download_file = file_get_contents( $url );
+			$download_file = download_url( $url );
 			$media_path    = get_stylesheet_directory() . DIRECTORY_SEPARATOR . self::get_media_folder_path_from_url( $url );
 			if ( ! is_dir( $media_path ) ) {
 				wp_mkdir_p( $media_path );
 			}
-			file_put_contents(
-				$media_path . basename( $url ),
-				$download_file
-			);
+			rename( $download_file, $media_path . basename( $url ) );
 		}
 	}
 }

--- a/admin/create-theme/theme-zip.php
+++ b/admin/create-theme/theme-zip.php
@@ -156,9 +156,12 @@ class Theme_Zip {
 	static function add_media_to_zip( $zip, $media ) {
 		$media = array_unique( $media );
 		foreach ( $media as $url ) {
-			$folder_path   = Theme_Media::get_media_folder_path_from_url( $url );
-			$download_file = file_get_contents( $url );
-			$zip->addFromString( $folder_path . basename( $url ), $download_file );
+			$folder_path    = Theme_Media::get_media_folder_path_from_url( $url );
+			$download_file  = download_url( $url );
+			$content_array  = file( $download_file );
+			$file_as_string = implode( '', $content_array );
+
+			$zip->addFromString( $folder_path . basename( $url ), $file_as_string );
 		}
 	}
 


### PR DESCRIPTION
## What ?
Fixing image downloading and bundling into the theme not working in some cases.

## How ?
Instead of PHP function `file_get_contents()` we are using the WordPress function `download_url()` that seems to be working in most scenarios.


## Why ?
Some users reported this functionality not working in their environments. See #280 as example.


## How to test:
1. Add an image to a template or template part
2. Export / Overwrite the theme
3. See if the image on the assets folder downloaded correctly (not 0-byte size).



Fixes: #280 