### PR TITLE
Add current WordPress version to style.css and readme.txt

### DIFF
--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -12,6 +12,7 @@ class Theme_Readme {
 		$author                 = $theme['author'];
 		$author_uri             = $theme['author_uri'];
 		$copy_year              = gmdate( 'Y' );
+		$wp_version             = get_bloginfo( 'version' );
 		$original_theme         = $theme['original_theme'] ?? '';
 		$original_theme_credits = $original_theme ? self::original_theme_credits( $name ) : '';
 
@@ -24,7 +25,7 @@ class Theme_Readme {
 		return "=== {$name} ===
 Contributors: {$author}
 Requires at least: 5.8
-Tested up to: 5.9
+Tested up to: {$wp_version}
 Requires PHP: 5.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -13,6 +13,7 @@ class Theme_Styles {
 		$uri         = $theme['uri'];
 		$author      = $theme['author'];
 		$author_uri  = $theme['author_uri'];
+		$wp_version  = get_bloginfo( 'version' );
 		$template    = $theme['template'];
 		$tags        = Theme_Tags::theme_tags_list( $theme );
 		return "/*
@@ -22,7 +23,7 @@ Author: {$author}
 Author URI: {$author_uri}
 Description: {$description}
 Requires at least: 5.8
-Tested up to: 5.9
+Tested up to: {$wp_version}
 Requires PHP: 5.7
 Version: 0.0.1
 License: GNU General Public License v2 or later


### PR DESCRIPTION
The plugin currently uses a static version of WordPress in the style.css and readme.txt files for the "Tested up to" version. This PR changes this so the current WordPress version is used instead.

I've used [`get_bloginfo( 'version' )`](https://developer.wordpress.org/reference/functions/get_bloginfo/) to grab the current version.