### PR TITLE
Add labels around Google font family checkbox controls

### DIFF
--- a/src/google-fonts/font-variant.js
+++ b/src/google-fonts/font-variant.js
@@ -32,21 +32,31 @@ function FontVariant( { font, variant, isSelected, handleToggle } ) {
 			} );
 	}, [ font, variant ] );
 
+	const formattedFontFamily = font.family.toLowerCase().replace( ' ', '-' );
+	const fontId = `${ formattedFontFamily }-${ variant }`;
+
 	return (
 		<tr>
 			<td className="">
 				<input
 					type="checkbox"
 					name="google-font-variant"
+					id={ fontId }
 					value={ variant }
 					checked={ isSelected }
 					onClick={ handleToggle }
 				/>
 			</td>
-			<td className="">{ weight }</td>
-			<td className="">{ style }</td>
+			<td className="">
+				<label htmlFor={ fontId }>{ weight }</label>
+			</td>
+			<td className="">
+				<label htmlFor={ fontId }>{ style }</label>
+			</td>
 			<td className="demo-cell">
-				<Demo style={ previewStyles } />
+				<label htmlFor={ fontId }>
+					<Demo style={ previewStyles } />
+				</label>
 			</td>
 		</tr>
 	);

--- a/src/google-fonts/index.js
+++ b/src/google-fonts/index.js
@@ -156,6 +156,13 @@ function GoogleFonts() {
 		setSelectedFont( googleFontsData.items[ value ] );
 	};
 
+	let selectedFontFamilyId = '';
+	if ( selectedFont ) {
+		selectedFontFamilyId = selectedFont.family
+			.toLowerCase()
+			.replace( ' ', '-' );
+	}
+
 	return (
 		<FontsPageLayout>
 			<main>
@@ -235,6 +242,7 @@ function GoogleFonts() {
 										<td className="">
 											<input
 												type="checkbox"
+												id={ `select-all-${ selectedFontFamilyId }` }
 												onClick={ () =>
 													handleToggleAllVariants(
 														selectedFont.family
@@ -250,22 +258,34 @@ function GoogleFonts() {
 											/>
 										</td>
 										<td className="">
-											{ __(
-												'Weight',
-												'create-block-theme'
-											) }
+											<label
+												htmlFor={ `select-all-${ selectedFontFamilyId }` }
+											>
+												{ __(
+													'Weight',
+													'create-block-theme'
+												) }
+											</label>
 										</td>
 										<td className="">
-											{ __(
-												'Style',
-												'create-block-theme'
-											) }
+											<label
+												htmlFor={ `select-all-${ selectedFontFamilyId }` }
+											>
+												{ __(
+													'Style',
+													'create-block-theme'
+												) }
+											</label>
 										</td>
 										<td className="">
-											{ __(
-												'Preview',
-												'create-block-theme'
-											) }
+											<label
+												htmlFor={ `select-all-${ selectedFontFamilyId }` }
+											>
+												{ __(
+													'Preview',
+													'create-block-theme'
+												) }
+											</label>
 										</td>
 									</tr>
 								</thead>


### PR DESCRIPTION
This adds labels around the text related to the Google font checkboxes when adding Google fonts to a theme. This makes the options slightly easier to select, as you can now click any text in the corresponding table row to select a font family or variant.

### Video
https://user-images.githubusercontent.com/1645628/229313331-e5539554-45e4-4c7d-bf5d-c3fe5a30d9c9.mov

