### PR TITLE
Fix theme slug and textdomain for cloned, child and sibling themes.

### DIFF
--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -71,14 +71,14 @@ class Create_Block_Theme_Admin {
 	 * Export activated child theme
 	 */
 	function export_child_theme( $theme ) {
-		$theme['slug'] = wp_get_theme()->get( 'TextDomain' );
+		$theme['slug'] = Theme_Utils::get_theme_slug( $theme['name'] );
 
 		// Create ZIP file in the temporary directory.
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
 		$zip      = Theme_Zip::create_zip( $filename );
 
 		$zip = Theme_Zip::copy_theme_to_zip( $zip, null, null );
-		$zip = Theme_Zip::add_templates_to_zip( $zip, 'current', null );
+		$zip = Theme_Zip::add_templates_to_zip( $zip, 'current', $theme['slug'] );
 		$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'current' );
 
 		$zip->close();
@@ -262,7 +262,7 @@ class Create_Block_Theme_Admin {
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
 		$zip      = Theme_Zip::create_zip( $filename );
 
-		$zip = Theme_Zip::add_templates_to_zip( $zip, 'user', null );
+		$zip = Theme_Zip::add_templates_to_zip( $zip, 'user', $theme['slug'] );
 		$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'user' );
 
 		// Add readme.txt.

--- a/admin/class-create-block-theme-admin.php
+++ b/admin/class-create-block-theme-admin.php
@@ -95,6 +95,8 @@ class Create_Block_Theme_Admin {
 	 * Create a sibling theme of the activated theme
 	 */
 	function create_sibling_theme( $theme, $screenshot ) {
+		$theme_slug = Theme_Utils::get_theme_slug( $theme['name'] );
+
 		// Sanitize inputs.
 		$theme['name']        = sanitize_text_field( $theme['name'] );
 		$theme['description'] = sanitize_text_field( $theme['description'] );
@@ -102,8 +104,9 @@ class Create_Block_Theme_Admin {
 		$theme['author']      = sanitize_text_field( $theme['author'] );
 		$theme['author_uri']  = sanitize_text_field( $theme['author_uri'] );
 		$theme['tags_custom'] = sanitize_text_field( $theme['tags_custom'] );
-		$theme['slug']        = Theme_Utils::get_theme_slug( $theme['name'] );
+		$theme['slug']        = $theme_slug;
 		$theme['template']    = wp_get_theme()->get( 'Template' );
+		$theme['text_domain'] = $theme_slug;
 
 		// Create ZIP file in the temporary directory.
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
@@ -152,6 +155,8 @@ class Create_Block_Theme_Admin {
 	 * Clone the activated theme to create a new theme
 	 */
 	function clone_theme( $theme, $screenshot ) {
+		$theme_slug = Theme_Utils::get_theme_slug( $theme['name'] );
+
 		// Sanitize inputs.
 		$theme['name']           = sanitize_text_field( $theme['name'] );
 		$theme['description']    = sanitize_text_field( $theme['description'] );
@@ -159,9 +164,10 @@ class Create_Block_Theme_Admin {
 		$theme['author']         = sanitize_text_field( $theme['author'] );
 		$theme['author_uri']     = sanitize_text_field( $theme['author_uri'] );
 		$theme['tags_custom']    = sanitize_text_field( $theme['tags_custom'] );
-		$theme['slug']           = Theme_Utils::get_theme_slug( $theme['name'] );
-		$theme['template']       = wp_get_theme()->get( 'Template' );
+		$theme['slug']           = $theme_slug;
+		$theme['template']       = '';
 		$theme['original_theme'] = wp_get_theme()->get( 'Name' );
+		$theme['text_domain']    = $theme_slug;
 
 		// Use previous theme's tags if custom tags are empty.
 		if ( empty( $theme['tags_custom'] ) ) {
@@ -236,6 +242,10 @@ class Create_Block_Theme_Admin {
 	 * Create a child theme of the activated theme
 	 */
 	function create_child_theme( $theme, $screenshot ) {
+
+		$parent_theme_slug = Theme_Utils::get_theme_slug( wp_get_theme()->get( 'Name' ) );
+		$child_theme_slug  = Theme_Utils::get_theme_slug( $theme['name'] );
+
 		// Sanitize inputs.
 		$theme['name']        = sanitize_text_field( $theme['name'] );
 		$theme['description'] = sanitize_text_field( $theme['description'] );
@@ -243,8 +253,10 @@ class Create_Block_Theme_Admin {
 		$theme['author']      = sanitize_text_field( $theme['author'] );
 		$theme['author_uri']  = sanitize_text_field( $theme['author_uri'] );
 		$theme['tags_custom'] = sanitize_text_field( $theme['tags_custom'] );
-		$theme['slug']        = Theme_Utils::get_theme_slug( $theme['name'] );
-		$theme['template']    = wp_get_theme()->get( 'TextDomain' );
+
+		$theme['text_domain'] = $child_theme_slug;
+		$theme['template']    = $parent_theme_slug;
+		$theme['slug']        = $child_theme_slug;
 
 		// Create ZIP file in the temporary directory.
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
@@ -308,6 +320,8 @@ class Create_Block_Theme_Admin {
 	}
 
 	function create_blank_theme( $theme, $screenshot ) {
+		$theme_slug = Theme_Utils::get_theme_slug( $theme['name'] );
+
 		// Sanitize inputs.
 		$theme['name']        = sanitize_text_field( $theme['name'] );
 		$theme['description'] = sanitize_text_field( $theme['description'] );
@@ -316,7 +330,8 @@ class Create_Block_Theme_Admin {
 		$theme['author_uri']  = sanitize_text_field( $theme['author_uri'] );
 		$theme['tags_custom'] = sanitize_text_field( $theme['tags_custom'] );
 		$theme['template']    = '';
-		$theme['slug']        = Theme_Utils::get_theme_slug( $theme['name'] );
+		$theme['slug']        = $theme_slug;
+		$theme['text_domain'] = $theme_slug;
 
 		// Create theme directory.
 		$source           = plugin_dir_path( __DIR__ ) . 'assets/boilerplate';

--- a/admin/create-theme/theme-blocks.php
+++ b/admin/create-theme/theme-blocks.php
@@ -189,45 +189,4 @@ class Theme_Blocks {
 		return $markup;
 	}
 
-	// update pattern and template-parts theme attribute
-	public static function update_patterns_and_templates_theme_attribute( $template, $theme_slug ) {
-		$new_content     = $template->content;
-		$template_blocks = parse_blocks( $template->content );
-
-		$blocks = self::update_blocks_theme_attribute( $template_blocks, $theme_slug );
-		$blocks = serialize_blocks( $blocks );
-
-		$template->content = self::clean_serialized_markup( $blocks );
-		return $template;
-	}
-
-	static function update_blocks_theme_attribute( $nested_blocks, $theme_slug ) {
-		$new_blocks = array();
-		foreach ( $nested_blocks as $block ) {
-			$inner_blocks = $block['innerBlocks'];
-			switch ( $block['blockName'] ) {
-				case 'core/pattern':
-				case 'core/template-part':
-					$block = self::update_block_theme_attribute( $block, $theme_slug );
-					break;
-			}
-			// recursive call for inner blocks
-			if ( ! empty( $block['innerBlocks'] ) ) {
-				$block['innerBlocks'] = self::update_blocks_theme_attribute( $inner_blocks, $theme_slug );
-			}
-			$new_blocks[] = $block;
-		}
-		return $new_blocks;
-	}
-
-	static function update_block_theme_attribute( $block, $theme_slug ) {
-		if ( 'core/pattern' === $block['blockName'] || 'core/template-part' === $block['blockName'] ) {
-			// Adds the theme attribute to the block only if is set, otherwise it won't be added
-			if ( ! empty( $block['attrs']['theme'] ) ) {
-				$block['attrs']['theme'] = $theme_slug;
-			}
-		}
-		return $block;
-	}
-
 }

--- a/admin/create-theme/theme-blocks.php
+++ b/admin/create-theme/theme-blocks.php
@@ -188,4 +188,46 @@ class Theme_Blocks {
 		$markup = html_entity_decode( $markup, ENT_QUOTES | ENT_XML1, 'UTF-8' );
 		return $markup;
 	}
+
+	// update pattern and template-parts theme attribute
+	public static function update_patterns_and_templates_theme_attribute( $template, $theme_slug ) {
+		$new_content     = $template->content;
+		$template_blocks = parse_blocks( $template->content );
+
+		$blocks = self::update_blocks_theme_attribute( $template_blocks, $theme_slug );
+		$blocks = serialize_blocks( $blocks );
+
+		$template->content = self::clean_serialized_markup( $blocks );
+		return $template;
+	}
+
+	static function update_blocks_theme_attribute( $nested_blocks, $theme_slug ) {
+		$new_blocks = array();
+		foreach ( $nested_blocks as $block ) {
+			$inner_blocks = $block['innerBlocks'];
+			switch ( $block['blockName'] ) {
+				case 'core/pattern':
+				case 'core/template-part':
+					$block = self::update_block_theme_attribute( $block, $theme_slug );
+					break;
+			}
+			// recursive call for inner blocks
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$block['innerBlocks'] = self::update_blocks_theme_attribute( $inner_blocks, $theme_slug );
+			}
+			$new_blocks[] = $block;
+		}
+		return $new_blocks;
+	}
+
+	static function update_block_theme_attribute( $block, $theme_slug ) {
+		if ( 'core/pattern' === $block['blockName'] || 'core/template-part' === $block['blockName'] ) {
+			// Adds the theme attribute to the block only if is set, otherwise it won't be added
+			if ( ! empty( $block['attrs']['theme'] ) ) {
+				$block['attrs']['theme'] = $theme_slug;
+			}
+		}
+		return $block;
+	}
+
 }

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -53,8 +53,7 @@ class Theme_Form {
 								</label>
 								<br />
 								<?php _e( '[Create a new theme cloning the activated child theme.  The parent theme will be the same as the parent of the currently activated theme. The resulting theme will have all of the assets of the activated theme, none of the assets provided by the parent theme, as well as user changes.]', 'create-block-theme' ); ?>
-								<p><b><?php _e( 'NOTE: Sibling themes created from this theme will have the original namespacing. This should be changed manually once the theme has been created.', 'create-block-theme' ); ?></b></p>
-								<br />
+								<br /><br />
 							<?php else : ?>
 								<label>
 									<input value="child" type="radio" name="theme[type]" class="regular-text code" onchange="toggleForm( this );"/>

--- a/admin/create-theme/theme-patterns.php
+++ b/admin/create-theme/theme-patterns.php
@@ -1,8 +1,8 @@
 <?php
 
 class Theme_Patterns {
-	public static function pattern_from_template( $template ) {
-		$theme_slug      = wp_get_theme()->get( 'TextDomain' );
+	public static function pattern_from_template( $template, $new_slug = null ) {
+		$theme_slug      = $new_slug ? $new_slug : wp_get_theme()->get( 'TextDomain' );
 		$pattern_slug    = $theme_slug . '/' . $template->slug;
 		$pattern_content = (
 		'<?php
@@ -64,7 +64,7 @@ class Theme_Patterns {
 
 	public static function create_pattern_link( $attributes ) {
 		$block_attributes = array_filter( $attributes );
-		$attributes_json  = json_encode( $block_attributes );
+		$attributes_json  = json_encode( $block_attributes, JSON_UNESCAPED_SLASHES );
 		return '<!-- wp:pattern ' . $attributes_json . ' /-->';
 	}
 }

--- a/admin/create-theme/theme-patterns.php
+++ b/admin/create-theme/theme-patterns.php
@@ -61,4 +61,10 @@ class Theme_Patterns {
 			return "<?php echo esc_attr_e( '" . $text . "', '" . wp_get_theme()->get( 'Name' ) . "' ); ?>";
 		}
 	}
+
+	public static function create_pattern_link( $attributes ) {
+		$block_attributes = array_filter( $attributes );
+		$attributes_json  = json_encode( $block_attributes );
+		return '<!-- wp:pattern ' . $attributes_json . ' /-->';
+	}
 }

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -14,6 +14,7 @@ class Theme_Styles {
 		$author      = $theme['author'];
 		$author_uri  = $theme['author_uri'];
 		$template    = $theme['template'];
+		$text_domain = $theme['text_domain'];
 		$tags        = Theme_Tags::theme_tags_list( $theme );
 		return "/*
 Theme Name: {$name}
@@ -28,7 +29,7 @@ Version: 0.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: {$template}
-Text Domain: {$slug}
+Text Domain: {$text_domain}
 Tags: {$tags}
 */";
 	}

--- a/admin/create-theme/theme-templates.php
+++ b/admin/create-theme/theme-templates.php
@@ -113,6 +113,7 @@ class Theme_Templates {
 
 		foreach ( $theme_templates->templates as $template ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template );
+			$template_data = Theme_Blocks::update_patterns_and_templates_theme_attribute( $template_data, $theme_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( ! empty( $template_data->media ) ) {
@@ -122,8 +123,12 @@ class Theme_Templates {
 				}
 
 				// If there are external images, add it as a pattern
-				$pattern                = Theme_Patterns::pattern_from_template( $template_data );
-				$template_data->content = '<!-- wp:pattern {"slug":"' . $pattern['slug'] . '"} /-->';
+				$pattern                 = Theme_Patterns::pattern_from_template( $template_data );
+				$pattern_link_attributes = array(
+					'slug'  => $pattern['slug'],
+					'theme' => $new_slug,
+				);
+				$template_data->content  = Theme_Patterns::create_pattern_link( $pattern_link_attributes );
 
 				// Write the pattern
 				file_put_contents(
@@ -150,6 +155,7 @@ class Theme_Templates {
 
 		foreach ( $theme_templates->parts as $template_part ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template_part );
+			$template_data = Theme_Blocks::update_patterns_and_templates_theme_attribute( $template_data, $theme_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( ! empty( $template_data->media ) ) {
@@ -159,8 +165,12 @@ class Theme_Templates {
 				}
 
 				// If there are external images, add it as a pattern
-				$pattern                = Theme_Patterns::pattern_from_template( $template_data );
-				$template_data->content = '<!-- wp:pattern {"slug":"' . $pattern['slug'] . '"} /-->';
+				$pattern                 = Theme_Patterns::pattern_from_template( $template_data );
+				$pattern_link_attributes = array(
+					'slug'  => $pattern['slug'],
+					'theme' => $new_slug,
+				);
+				$template_data->content  = Theme_Patterns::create_pattern_link( $pattern_link_attributes );
 
 				// Write the pattern
 				file_put_contents(

--- a/admin/create-theme/theme-templates.php
+++ b/admin/create-theme/theme-templates.php
@@ -113,7 +113,6 @@ class Theme_Templates {
 
 		foreach ( $theme_templates->templates as $template ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template );
-			$template_data = Theme_Blocks::update_patterns_and_templates_theme_attribute( $template_data, $theme_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( ! empty( $template_data->media ) ) {
@@ -125,8 +124,7 @@ class Theme_Templates {
 				// If there are external images, add it as a pattern
 				$pattern                 = Theme_Patterns::pattern_from_template( $template_data );
 				$pattern_link_attributes = array(
-					'slug'  => $pattern['slug'],
-					'theme' => $new_slug,
+					'slug' => $pattern['slug'],
 				);
 				$template_data->content  = Theme_Patterns::create_pattern_link( $pattern_link_attributes );
 
@@ -155,7 +153,6 @@ class Theme_Templates {
 
 		foreach ( $theme_templates->parts as $template_part ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template_part );
-			$template_data = Theme_Blocks::update_patterns_and_templates_theme_attribute( $template_data, $theme_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( ! empty( $template_data->media ) ) {
@@ -167,8 +164,7 @@ class Theme_Templates {
 				// If there are external images, add it as a pattern
 				$pattern                 = Theme_Patterns::pattern_from_template( $template_data );
 				$pattern_link_attributes = array(
-					'slug'  => $pattern['slug'],
-					'theme' => $new_slug,
+					'slug' => $pattern['slug'],
 				);
 				$template_data->content  = Theme_Patterns::create_pattern_link( $pattern_link_attributes );
 

--- a/admin/create-theme/theme-zip.php
+++ b/admin/create-theme/theme-zip.php
@@ -101,14 +101,12 @@ class Theme_Zip {
 
 		foreach ( $theme_templates->templates as $template ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template );
-			$template_data = Theme_Blocks::update_patterns_and_templates_theme_attribute( $template_data, $new_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( count( $template_data->media ) > 0 ) {
-				$pattern                 = Theme_Patterns::pattern_from_template( $template_data );
+				$pattern                 = Theme_Patterns::pattern_from_template( $template_data, $new_slug );
 				$pattern_link_attributes = array(
-					'slug'  => $pattern['slug'],
-					'theme' => $new_slug,
+					'slug' => $pattern['slug'],
 				);
 				$template_data->content  = Theme_Patterns::create_pattern_link( $pattern_link_attributes );
 
@@ -132,14 +130,12 @@ class Theme_Zip {
 
 		foreach ( $theme_templates->parts as $template_part ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template_part );
-			$template_data = Theme_Blocks::update_patterns_and_templates_theme_attribute( $template_data, $new_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( count( $template_data->media ) > 0 ) {
-				$pattern                 = Theme_Patterns::pattern_from_template( $template_data );
+				$pattern                 = Theme_Patterns::pattern_from_template( $template_data, $new_slug );
 				$pattern_link_attributes = array(
-					'slug'  => $pattern['slug'],
-					'theme' => $new_slug,
+					'slug' => $pattern['slug'],
 				);
 				$template_data->content  = Theme_Patterns::create_pattern_link( $pattern_link_attributes );
 

--- a/admin/create-theme/theme-zip.php
+++ b/admin/create-theme/theme-zip.php
@@ -101,11 +101,16 @@ class Theme_Zip {
 
 		foreach ( $theme_templates->templates as $template ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template );
+			$template_data = Theme_Blocks::update_patterns_and_templates_theme_attribute( $template_data, $new_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( count( $template_data->media ) > 0 ) {
-				$pattern                = Theme_Patterns::pattern_from_template( $template_data );
-				$template_data->content = '<!-- wp:pattern {"slug":"' . $pattern['slug'] . '"} /-->';
+				$pattern                 = Theme_Patterns::pattern_from_template( $template_data );
+				$pattern_link_attributes = array(
+					'slug'  => $pattern['slug'],
+					'theme' => $new_slug,
+				);
+				$template_data->content  = Theme_Patterns::create_pattern_link( $pattern_link_attributes );
 
 				// Add pattern to zip
 				$zip->addFromString(
@@ -127,11 +132,16 @@ class Theme_Zip {
 
 		foreach ( $theme_templates->parts as $template_part ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template_part );
+			$template_data = Theme_Blocks::update_patterns_and_templates_theme_attribute( $template_data, $new_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( count( $template_data->media ) > 0 ) {
-				$pattern                = Theme_Patterns::pattern_from_template( $template_data );
-				$template_data->content = '<!-- wp:pattern {"slug":"' . $pattern['slug'] . '"} /-->';
+				$pattern                 = Theme_Patterns::pattern_from_template( $template_data );
+				$pattern_link_attributes = array(
+					'slug'  => $pattern['slug'],
+					'theme' => $new_slug,
+				);
+				$template_data->content  = Theme_Patterns::create_pattern_link( $pattern_link_attributes );
 
 				// Add pattern to zip
 				$zip->addFromString(

--- a/admin/js/form-script.js
+++ b/admin/js/form-script.js
@@ -14,6 +14,7 @@ function toggleForm( element ) {
 		case 'child':
 		case 'clone':
 		case 'blank':
+		case 'sibling':
 			// Show New Theme form
 			document
 				.getElementById( 'new_theme_metadata_form' )


### PR DESCRIPTION
## What?
This PR should fix set correctly the theme `slug`, `textdomain, and 'template` for cloned, child, and sibling themes.

## Why?
Currently, that's not working OK because in some cases the `textdomain` , `slug` and `template` remain unchanged when you create a clone, child or sibling theme using the plugin. 

## How to test
- Create a theme using clone, child, and sibling options.
- Test that the theme `slug`, `textdomain` and `template` for the created theme are updated on every file of the theme (style.css, templates, template parts, and patterns).

- Check that all other options still work as expected.


Fixes: https://github.com/WordPress/create-block-theme/issues/275
Fixes: https://wordpress.org/support/topic/creating-child-theme-forgets-to-replace-parent-theme-references-in-templates/