### PR TITLE
Add theme name validation

### DIFF
--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -131,7 +131,7 @@ class Theme_Form {
 								<p><em><?php _e( 'Items indicated with (*) are required.', 'create-block-theme' ); ?></em></p>
 								<label>
 									<?php _e( 'Theme Name (*):', 'create-block-theme' ); ?><br />
-									<input placeholder="<?php _e( 'Theme Name', 'create-block-theme' ); ?>" type="text" name="theme[name]" class="large-text" />
+									<input placeholder="<?php _e( 'Theme Name', 'create-block-theme' ); ?>" type="text" name="theme[name]" class="large-text" id="theme-name" autocomplete="off" />
 								</label>
 								<br /><br />
 								<label>

--- a/admin/js/form-script.js
+++ b/admin/js/form-script.js
@@ -143,17 +143,10 @@ const ERROR_NAME_CONTAINS_WORDPRESS = __(
 	'Theme name cannot contain the word "WordPress"',
 	'create-block-theme'
 );
-const ERROR_NAME_CONTAINS_MARKUP_WORDS = __(
-	'Theme name cannot contain the words as "HTML", "CSS", or "PHP"',
-	'create-block-theme'
-);
-const ERROR_NAME_CONTAINS_RELATED_WORDS = __(
-	'Theme name cannot contain the words as "Blog", "Web log", "Template", "Skin", etc.'
-);
 
 function isThemeNameValid( themeName ) {
 	// Check the validity of the theme name following the WordPress.org theme directory rules
-	// https://make.wordpress.org/themes/2013/02/26/clarifying-guidelines-for-theme-name/
+	// https://meta.svn.wordpress.org/sites/trunk/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php
 
 	/* eslint-disable @wordpress/no-unused-vars-before-return */
 	const lowerCaseName = themeName.toLowerCase();
@@ -178,30 +171,6 @@ function isThemeNameValid( themeName ) {
 	if ( slugNoDashes.includes( 'wordpress' ) ) {
 		validityStatus.isValid = false;
 		validityStatus.errorMessage = ERROR_NAME_CONTAINS_WORDPRESS;
-		return validityStatus;
-	}
-
-	// Check if the theme name contains markup words
-	const markupWords = [
-		'html',
-		'html5',
-		'css',
-		'css3',
-		'php',
-		'js',
-		'javascript',
-	];
-	if ( markupWords.some( ( w ) => lowerCaseName.includes( w ) ) ) {
-		validityStatus.isValid = false;
-		validityStatus.errorMessage = ERROR_NAME_CONTAINS_MARKUP_WORDS;
-		return validityStatus;
-	}
-
-	// Check if the theme name contains related words
-	const relatedWords = [ 'blog', 'weblog', 'template', 'skin' ];
-	if ( relatedWords.some( ( w ) => lowerCaseName.includes( w ) ) ) {
-		validityStatus.isValid = false;
-		validityStatus.errorMessage = ERROR_NAME_CONTAINS_RELATED_WORDS;
 		return validityStatus;
 	}
 

--- a/admin/js/form-script.js
+++ b/admin/js/form-script.js
@@ -151,11 +151,11 @@ const ERROR_NAME_CONTAINS_RELATED_WORDS = __(
 	'Theme name cannot contain the words as "Blog", "Web log", "Template", "Skin", etc.'
 );
 
-/* eslint-disable @wordpress/no-unused-vars-before-return */
 function isThemeNameValid( themeName ) {
 	// Check the validity of the theme name following the WordPress.org theme directory rules
 	// https://make.wordpress.org/themes/2013/02/26/clarifying-guidelines-for-theme-name/
 
+	/* eslint-disable @wordpress/no-unused-vars-before-return */
 	const lowerCaseName = themeName.toLowerCase();
 	const slug = slugify( themeName );
 	const slugDashes = slugifyUnderscores( themeName );

--- a/admin/js/form-script.js
+++ b/admin/js/form-script.js
@@ -1,3 +1,5 @@
+const { __ } = wp.i18n;
+
 // Toggles the visibility of the forms based on the selected theme type
 // eslint-disable-next-line no-unused-vars
 function toggleForm( element ) {
@@ -9,6 +11,7 @@ function toggleForm( element ) {
 		case 'export':
 		case 'save':
 			// Forms should stay hidden
+			resetThemeName();
 			break;
 
 		case 'child':
@@ -94,11 +97,152 @@ function limitCheckboxSelection( checkboxesSelector, max = 0 ) {
 
 // Store active theme tags when page is loaded
 let activeThemeTags = [];
-window.onload = () => {
+function onWindowLoad() {
 	activeThemeTags = document.querySelectorAll(
 		'.theme-tags input[type="checkbox"]:checked'
 	);
-};
+}
+
+window.addEventListener( 'load', onWindowLoad );
+window.addEventListener( 'load', prepareThemeNameValidation );
+
+function prepareThemeNameValidation() {
+	const themeNameInput = document.getElementById( 'theme-name' );
+	themeNameInput.addEventListener( 'input', validateThemeNameInput );
+}
+
+function slugify( text ) {
+	// Removes spaces
+	return text.toLowerCase().replace( / /g, '' );
+}
+
+function slugifyUnderscores( text ) {
+	// Replaces spaces with underscores
+	return text.toLowerCase().replace( / /g, '_' );
+}
+
+function slugifyDashes( text ) {
+	// Replaces spaces with dashes
+	return text.toLowerCase().replace( / /g, '-' );
+}
+
+function slugifyNoDashes( text ) {
+	// Removes spaces, dashes, and underscores
+	return text.toLowerCase().replace( / /g, '' ).replace( /[-_]/g, '' );
+}
+
+const ERROR_NAME_NOT_AVAILABLE = __(
+	'Theme name is not available in the WordPress.org theme directory',
+	'create-block-theme'
+);
+const ERROR_NAME_CONTAINS_THEME = __(
+	'Theme name cannot contain the word "theme"',
+	'create-block-theme'
+);
+const ERROR_NAME_CONTAINS_WORDPRESS = __(
+	'Theme name cannot contain the word "WordPress"',
+	'create-block-theme'
+);
+const ERROR_NAME_CONTAINS_MARKUP_WORDS = __(
+	'Theme name cannot contain the words as "HTML", "CSS", or "PHP"',
+	'create-block-theme'
+);
+const ERROR_NAME_CONTAINS_RELATED_WORDS = __(
+	'Theme name cannot contain the words as "Blog", "Web log", "Template", "Skin", etc.'
+);
+
+/* eslint-disable @wordpress/no-unused-vars-before-return */
+function isThemeNameValid( themeName ) {
+	// Check the validity of the theme name following the WordPress.org theme directory rules
+	// https://make.wordpress.org/themes/2013/02/26/clarifying-guidelines-for-theme-name/
+
+	const lowerCaseName = themeName.toLowerCase();
+	const slug = slugify( themeName );
+	const slugDashes = slugifyUnderscores( themeName );
+	const slugUnderscores = slugifyDashes( themeName );
+	const slugNoDashes = slugifyNoDashes( themeName );
+
+	const validityStatus = {
+		isValid: true,
+		errorMessage: '',
+	};
+
+	// Check if the theme contains the word theme
+	if ( lowerCaseName.includes( 'theme' ) ) {
+		validityStatus.isValid = false;
+		validityStatus.errorMessage = ERROR_NAME_CONTAINS_THEME;
+		return validityStatus;
+	}
+
+	// Check if the theme name contains WordPress
+	if ( slugNoDashes.includes( 'wordpress' ) ) {
+		validityStatus.isValid = false;
+		validityStatus.errorMessage = ERROR_NAME_CONTAINS_WORDPRESS;
+		return validityStatus;
+	}
+
+	// Check if the theme name contains markup words
+	const markupWords = [
+		'html',
+		'html5',
+		'css',
+		'css3',
+		'php',
+		'js',
+		'javascript',
+	];
+	if ( markupWords.some( ( w ) => lowerCaseName.includes( w ) ) ) {
+		validityStatus.isValid = false;
+		validityStatus.errorMessage = ERROR_NAME_CONTAINS_MARKUP_WORDS;
+		return validityStatus;
+	}
+
+	// Check if the theme name contains related words
+	const relatedWords = [ 'blog', 'weblog', 'template', 'skin' ];
+	if ( relatedWords.some( ( w ) => lowerCaseName.includes( w ) ) ) {
+		validityStatus.isValid = false;
+		validityStatus.errorMessage = ERROR_NAME_CONTAINS_RELATED_WORDS;
+		return validityStatus;
+	}
+
+	// Check if the theme name is available
+	const isNameAvailable = () => {
+		// default to empty array if the unavailable theme names are not loaded yet from the API
+		const notAvailableSlugs = wpOrgThemeDirectory.themeSlugs || [];
+
+		// Compare the theme name to the list of unavailable theme names using several different slug formats
+		return ! notAvailableSlugs.some(
+			( s ) =>
+				s === slug ||
+				s === slugDashes ||
+				s === slugUnderscores ||
+				slugifyNoDashes( s ) === slugNoDashes
+		);
+	};
+
+	if ( ! isNameAvailable() ) {
+		validityStatus.isValid = false;
+		validityStatus.errorMessage = ERROR_NAME_NOT_AVAILABLE;
+		return validityStatus;
+	}
+
+	return validityStatus;
+}
+
+function validateThemeNameInput() {
+	const themeName = this?.value;
+	if ( ! themeName ) return true;
+
+	// Check if theme name is available
+	const validityStatus = isThemeNameValid( themeName );
+
+	if ( ! validityStatus.isValid ) {
+		this.setCustomValidity( validityStatus.errorMessage );
+		this.reportValidity();
+	} else {
+		this.setCustomValidity( '' );
+	}
+}
 
 // Resets all theme tag states (checked, disabled) to default values
 function resetThemeTags( themeType ) {
@@ -127,4 +271,10 @@ function resetThemeTags( themeType ) {
 			checkbox.checked = true;
 		} );
 	}
+}
+
+function resetThemeName() {
+	const themeNameInput = document.getElementById( 'theme-name' );
+	themeNameInput.value = '';
+	themeNameInput.setCustomValidity( '' );
 }

--- a/admin/wp-org-theme-directory.php
+++ b/admin/wp-org-theme-directory.php
@@ -1,0 +1,72 @@
+<?php
+
+class WP_Theme_Directory {
+
+    const THEME_NAMES_ENDPOINT = 'https://themes.svn.wordpress.org/';
+
+    /**
+	 * Initialize the class and set its properties.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_theme_names_endpoint' ) );
+        add_action( 'admin_init', array( $this, 'assets_enqueue' ) );
+	}
+
+    public static function register_theme_names_endpoint () {
+        register_rest_route(
+            'create-block-theme/v1',
+            '/wp-org-theme-names',
+            array(
+                'methods' => 'GET',
+                'callback' => array( 'WP_Theme_Directory', 'get_theme_names' ),
+                'permission_callback' => function () {
+                    return current_user_can( 'edit_theme_options' );
+                },
+            )
+        );
+        
+    }
+
+    public static function get_theme_names () {
+        $html = wp_remote_get( self::THEME_NAMES_ENDPOINT );
+
+        // parse the html response extracting all the a inside li elements
+        $pattern = '/<li><a href=".*?">(.*?)<\/a><\/li>/';
+        preg_match_all($pattern, $html['body'], $matches);
+        
+        // Revemo the / from the end of the theme name
+        $cleaned_names = array_map( function ( $name ) {
+            return str_replace( '/', '', $name );
+        }, $matches[1] );
+
+        $names = array( 'names' => $cleaned_names );
+        return rest_ensure_response( $names );
+    }
+    
+    function assets_enqueue() {
+		$asset_file = include( plugin_dir_path( dirname( __FILE__ ) ) . 'build/wp-org-theme-directory.asset.php' );
+
+		wp_register_script(
+			'wp-org-theme-directory',
+			plugins_url( 'build/wp-org-theme-directory.js', dirname( __FILE__ ) ),
+			$asset_file['dependencies'],
+			$asset_file['version']
+		);
+
+		wp_enqueue_script(
+			'wp-org-theme-directory',
+		);
+
+        // Initialize and empty array of theme names to be shared between different client side scripts
+        wp_localize_script(
+			'wp-org-theme-directory',
+			'wpOrgThemeDirectory',
+			array(
+				'themeSlugs' => null,
+			)
+		);
+	}
+
+}
+
+?>

--- a/includes/class-create-block-theme.php
+++ b/includes/class-create-block-theme.php
@@ -42,6 +42,7 @@ class Create_Block_Theme {
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-create-block-theme-admin.php';
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-manage-fonts.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/wp-org-theme-directory.php';
 
 		$this->loader = new Create_Block_Theme_Loader();
 
@@ -58,6 +59,7 @@ class Create_Block_Theme {
 
 		$plugin_admin       = new Create_Block_Theme_Admin();
 		$manage_fonts_admin = new Manage_Fonts_Admin();
+		$wp_theme_directory = new WP_Theme_Directory();
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"simple-git": "^3.14.1"
 	},
 	"scripts": {
-		"build": "wp-scripts build src/index.js src/plugin-sidebar.js",
+		"build": "wp-scripts build src/index.js src/plugin-sidebar.js src/wp-org-theme-directory.js",
 		"format": "wp-scripts format",
 		"lint:css": "wp-scripts lint-style",
 		"lint:css:fix": "npm run lint:css -- --fix",
@@ -47,7 +47,7 @@
 		"lint:php": "composer run-script lint",
 		"lint:php:fix": "composer run-script format",
 		"packages-update": "wp-scripts packages-update",
-		"start": "wp-scripts start src/index.js src/plugin-sidebar.js",
+		"start": "wp-scripts start src/index.js src/plugin-sidebar.js src/wp-org-theme-directory.js",
 		"update-version": "node update-version-and-changelog.js",
 		"prepare": "husky install"
 	},

--- a/src/wp-org-theme-directory.js
+++ b/src/wp-org-theme-directory.js
@@ -1,0 +1,11 @@
+import apiFetch from '@wordpress/api-fetch';
+
+async function loadUnavailableThemeNames() {
+	const requestOptions = {
+		path: '/create-block-theme/v1/wp-org-theme-names',
+	};
+	const request = await apiFetch( requestOptions );
+	wpOrgThemeDirectory.themeSlugs = request.names;
+}
+
+window.addEventListener( 'load', loadUnavailableThemeNames );


### PR DESCRIPTION
## What?
Add theme name validation.
The user won't be able to create a theme using a name if it:
- Already exists in the WordPress.org theme directory (#299)
- Doesn't follow the naming guidelines: https://meta.svn.wordpress.org/sites/trunk/wordpress.org/public_html/wp-content/plugins/theme-directory/class-wporg-themes-upload.php

##  Why?
To early warning theme creators about not valid theme names


## Screencast

https://user-images.githubusercontent.com/1310626/230172711-a1e8a747-3b3d-4e98-b08b-8e7ed945d45e.mp4





Fixes https://github.com/WordPress/create-block-theme/issues/299
