### PR TITLE
Replace theme slug in templates after getting media urls from them

### DIFF
--- a/admin/create-theme/theme-media.php
+++ b/admin/create-theme/theme-media.php
@@ -138,11 +138,14 @@ class Theme_Media {
 	public static function add_media_to_local( $media ) {
 		foreach ( $media as $url ) {
 			$download_file = download_url( $url );
-			$media_path    = get_stylesheet_directory() . DIRECTORY_SEPARATOR . self::get_media_folder_path_from_url( $url );
-			if ( ! is_dir( $media_path ) ) {
-				wp_mkdir_p( $media_path );
+			// TODO: implement a warning if the file is missing
+			if ( is_wp_error( $download_file ) ) {
+				$media_path = get_stylesheet_directory() . DIRECTORY_SEPARATOR . self::get_media_folder_path_from_url( $url );
+				if ( ! is_dir( $media_path ) ) {
+					wp_mkdir_p( $media_path );
+				}
+				rename( $download_file, $media_path . basename( $url ) );
 			}
-			rename( $download_file, $media_path . basename( $url ) );
 		}
 	}
 }

--- a/admin/create-theme/theme-templates.php
+++ b/admin/create-theme/theme-templates.php
@@ -8,9 +8,7 @@ class Theme_Templates {
 	/*
 	 * Build a collection of templates and template-parts that should be exported (and modified) based on the given export_type and new slug
 	 */
-	public static function get_theme_templates( $export_type, $new_slug ) {
-
-		$old_slug           = wp_get_theme()->get( 'TextDomain' );
+	public static function get_theme_templates( $export_type ) {
 		$templates          = get_block_templates();
 		$template_parts     = get_block_templates( array(), 'wp_template_part' );
 		$exported_templates = array();
@@ -25,9 +23,7 @@ class Theme_Templates {
 			$template = self::filter_theme_template(
 				$template,
 				$export_type,
-				$templates_path,
-				$old_slug,
-				$new_slug
+				$templates_path
 			);
 			if ( $template ) {
 				$exported_templates[] = $template;
@@ -38,9 +34,7 @@ class Theme_Templates {
 			$template = self::filter_theme_template(
 				$template,
 				$export_type,
-				$parts_path,
-				$old_slug,
-				$new_slug
+				$parts_path
 			);
 			if ( $template ) {
 				$exported_parts[] = $template;
@@ -59,7 +53,7 @@ class Theme_Templates {
 	 * Templates not filtered out are modified based on the slug information provided and cleaned up
 	 * to have the expected exported value.
 	 */
-	static function filter_theme_template( $template, $export_type, $path, $old_slug, $new_slug ) {
+	static function filter_theme_template( $template, $export_type, $path ) {
 		if ( 'theme' === $template->source && 'user' === $export_type ) {
 			return false;
 		}
@@ -107,7 +101,7 @@ class Theme_Templates {
 
 	public static function add_templates_to_local( $export_type ) {
 
-		$theme_templates  = self::get_theme_templates( $export_type, null );
+		$theme_templates  = self::get_theme_templates( $export_type );
 		$template_folders = get_block_theme_folders();
 
 		// If there is no templates folder, create it.

--- a/admin/create-theme/theme-templates.php
+++ b/admin/create-theme/theme-templates.php
@@ -75,10 +75,6 @@ class Theme_Templates {
 		// This replaces that with dashes again. We should consider decoding the entire string but that is proving difficult.
 		$template->content = str_replace( '\u002d', '-', $template->content );
 
-		// if ( $new_slug ) {
-		// 	$template->content = str_replace( $old_slug, $new_slug, $template->content );
-		// }
-
 		return $template;
 	}
 

--- a/admin/create-theme/theme-templates.php
+++ b/admin/create-theme/theme-templates.php
@@ -75,10 +75,18 @@ class Theme_Templates {
 		// This replaces that with dashes again. We should consider decoding the entire string but that is proving difficult.
 		$template->content = str_replace( '\u002d', '-', $template->content );
 
+		// if ( $new_slug ) {
+		// 	$template->content = str_replace( $old_slug, $new_slug, $template->content );
+		// }
+
+		return $template;
+	}
+
+	public static function replace_template_namespace( $template, $new_slug ) {
+		$old_slug = wp_get_theme()->get( 'TextDomain' );
 		if ( $new_slug ) {
 			$template->content = str_replace( $old_slug, $new_slug, $template->content );
 		}
-
 		return $template;
 	}
 
@@ -113,6 +121,7 @@ class Theme_Templates {
 
 		foreach ( $theme_templates->templates as $template ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template );
+			$template_data = Theme_Templates::replace_template_namespace( $template_data, $new_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( ! empty( $template_data->media ) ) {
@@ -153,6 +162,7 @@ class Theme_Templates {
 
 		foreach ( $theme_templates->parts as $template_part ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template_part );
+			$template_data = Theme_Templates::replace_template_namespace( $template_data, $new_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( ! empty( $template_data->media ) ) {

--- a/admin/create-theme/theme-zip.php
+++ b/admin/create-theme/theme-zip.php
@@ -89,7 +89,7 @@ class Theme_Zip {
 	 *                      all = all templates no matter what
 	 */
 	public static function add_templates_to_zip( $zip, $export_type, $new_slug ) {
-		$theme_templates = Theme_Templates::get_theme_templates( $export_type, $new_slug );
+		$theme_templates = Theme_Templates::get_theme_templates( $export_type );
 
 		if ( $theme_templates->templates ) {
 			$zip->addEmptyDir( 'templates' );

--- a/admin/create-theme/theme-zip.php
+++ b/admin/create-theme/theme-zip.php
@@ -101,6 +101,7 @@ class Theme_Zip {
 
 		foreach ( $theme_templates->templates as $template ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template );
+			$template_data = Theme_Templates::replace_template_namespace( $template_data, $new_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( count( $template_data->media ) > 0 ) {
@@ -130,6 +131,7 @@ class Theme_Zip {
 
 		foreach ( $theme_templates->parts as $template_part ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template_part );
+			$template_data = Theme_Templates::replace_template_namespace( $template_data, $new_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( count( $template_data->media ) > 0 ) {
@@ -162,12 +164,15 @@ class Theme_Zip {
 	static function add_media_to_zip( $zip, $media ) {
 		$media = array_unique( $media );
 		foreach ( $media as $url ) {
-			$folder_path    = Theme_Media::get_media_folder_path_from_url( $url );
-			$download_file  = download_url( $url );
-			$content_array  = file( $download_file );
-			$file_as_string = implode( '', $content_array );
-
-			$zip->addFromString( $folder_path . basename( $url ), $file_as_string );
+			$folder_path   = Theme_Media::get_media_folder_path_from_url( $url );
+			$download_file = download_url( $url );
+			// If there was an error downloading the file, skip it.
+			// TODO: Implement a warning if the file is missing
+			if ( ! is_wp_error( $download_file ) ) {
+				$content_array  = file( $download_file );
+				$file_as_string = implode( '', $content_array );
+				$zip->addFromString( $folder_path . basename( $url ), $file_as_string );
+			}
 		}
 	}
 


### PR DESCRIPTION
## What?

Replace theme slug in templates after getting media urls from them to avoid non-existing urls.

## Why?
If we replace the slug before getting the media URLs and those urls contain the old slug name, we get non-existing URLs.


## Thanks!

Thanks, @henriqueiamarino for reporting this issue.
Thanks, @vcanales for pairing on this!
