### PR TITLE
Do not call replace_template_namespace when overwrting theme

### DIFF
--- a/admin/create-theme/theme-templates.php
+++ b/admin/create-theme/theme-templates.php
@@ -111,7 +111,6 @@ class Theme_Templates {
 
 		foreach ( $theme_templates->templates as $template ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template );
-			$template_data = Theme_Templates::replace_template_namespace( $template_data, $new_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( ! empty( $template_data->media ) ) {
@@ -152,7 +151,6 @@ class Theme_Templates {
 
 		foreach ( $theme_templates->parts as $template_part ) {
 			$template_data = Theme_Blocks::make_template_images_local( $template_part );
-			$template_data = Theme_Templates::replace_template_namespace( $template_data, $new_slug );
 
 			// If there are images in the template, add it as a pattern
 			if ( ! empty( $template_data->media ) ) {


### PR DESCRIPTION
Do not call replace_template_namespace when overwrting theme because it is not necesary.

