### PR TITLE
fix tag duplication in exported theme

### DIFF
--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -32,7 +32,9 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: {$template}
 Text Domain: {$text_domain}
 Tags: {$tags}
-*/";
+*/
+
+";
 	}
 
 	public static function clear_user_styles_customizations() {

--- a/admin/create-theme/theme-tags.php
+++ b/admin/create-theme/theme-tags.php
@@ -14,17 +14,15 @@ class Theme_Tags {
 	 * @since 1.5.2
 	 */
 	public static function theme_tags_list( $theme ) {
-		$checkbox_tags_merged = array_merge( $theme['tags-subject'] ?? array(), $theme['tags-layout'] ?? array(), $theme['tags-features'] ?? array() );
-		$checkbox_tags        = $checkbox_tags_merged ? ', ' . implode( ', ', $checkbox_tags_merged ) : '';
-		$custom_tags          = $theme['tags_custom'] ? ', ' . $theme['tags_custom'] : '';
-		$tags                 = $checkbox_tags . $custom_tags;
+		$checkbox_tags_merged = array_merge(
+			$theme['tags-subject'] ?? array(),
+			$theme['tags-layout'] ?? array(),
+			$theme['tags-features'] ?? array(),
+		);
+		$custom_tags          = array_map( 'trim', explode( ',', $theme['tags_custom'] ?? '' ) );
+		$tags                 = array_unique( array_merge( $checkbox_tags_merged, $custom_tags ) );
 
-		// Remove comma and space from start of tags list
-		if ( ', ' === substr( $tags, 0, 2 ) ) {
-			$tags = substr( $tags, 2 );
-		}
-
-		return $tags;
+		return implode( ', ', $tags );
 	}
 
 	/**


### PR DESCRIPTION
This removes the duplication of tags including custom-tags in the exported theme.
And ads extra space between header and css contents

Before:

<img width="528" alt="image" src="https://user-images.githubusercontent.com/1935113/231731740-1e52d78c-2a59-4b22-9da4-b049701f1aca.png">

After:

<img width="516" alt="image" src="https://user-images.githubusercontent.com/1935113/231731598-3fde711c-b551-4150-9b00-599d7ed9798b.png">

Fixes: #317
