### PR TITLE
add build directory to php exclude list

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -56,6 +56,7 @@
 	</rule>
 
 	<!-- Directories and third party library exclusions. -->
+	<exclude-pattern>/build/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 


### PR DESCRIPTION
This fixes issue where php linter checks for errors in build directory.