### PR TITLE
Fix error when switching to template edit mode in the post editor

### DIFF
--- a/admin/class-create-theme.php
+++ b/admin/class-create-theme.php
@@ -34,6 +34,12 @@ class Create_Block_Theme_Admin {
 	}
 
 	function create_block_theme_enqueue() {
+		global $pagenow;
+
+		if ( 'site-editor.php' !== $pagenow ) {
+			return;
+		}
+
 		$asset_file = include( plugin_dir_path( dirname( __FILE__ ) ) . 'build/plugin-sidebar.asset.php' );
 
 		wp_register_script(


### PR DESCRIPTION
Fixes: #308

This PR fixes error when switching to template edit mode in the post editor. As noted in the issue, this error is caused by loading a script with `create-block-theme-slot-fill` handle in the post editor.

The approach of controlling the scripts to be loaded by the editor instance is based on this section of the Gutenberg project:
https://github.com/WordPress/gutenberg/blob/f82dcc198d52d9aaf0d150f30bcecaf052f64204/lib/compat/wordpress-6.2/script-loader.php#L73-L90

Confirm the following:

### Post Editor

- "Create Block Theme" should not appear in the options menu.
- Blocks should not be broken when template edit mode is opened

### Site Editor

- "Create Block Theme" should appear in the options menu.
