### PR TITLE
Enhance create block theme UI [experimental]

### DIFF
--- a/admin/class-create-theme.php
+++ b/admin/class-create-theme.php
@@ -53,7 +53,7 @@ class Create_Block_Theme_Admin {
 		}
 		$page_title = _x( 'Create Block Theme', 'UI String', 'create-block-theme' );
 		$menu_title = _x( 'Create Block Theme', 'UI String', 'create-block-theme' );
-		add_theme_page( $page_title, $menu_title, 'edit_theme_options', 'create-block-theme', array( 'Theme_Form', 'create_admin_form_page' ) );
+		add_theme_page( $page_title, $menu_title, 'edit_theme_options', 'create-block-theme', array( 'Theme_Form', 'create_theme_form_page' ) );
 
 		add_action( 'admin_enqueue_scripts', array( 'Theme_Form', 'form_script' ) );
 	}

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -1,8 +1,38 @@
 <?php
 
+require_once( dirname(__DIR__) . '/class-react-app.php' );
 require_once( __DIR__ . '/theme-tags.php' );
 
 class Theme_Form {
+	public static function create_theme_form_page() {
+		if ( ! wp_is_block_theme() ) {
+			?>
+			<div class="wrap">
+				<h2><?php _ex( 'Create Block Theme', 'UI String', 'create-block-theme' ); ?></h2>
+				<p><?php _e( 'Activate a block theme to use this tool.', 'create-block-theme' ); ?></p>
+			</div>
+			<?php
+			return;
+		}
+
+		React_App::bootstrap();
+		
+		$nounce = wp_create_nonce( 'create_block_theme' );
+		$themeName = wp_get_theme()->get( 'Name' );
+		$isChildTheme = is_child_theme();
+		$tags = get_theme_feature_list();
+		if ( ! is_array( $tags ) ) {
+			$tags = array();
+		}
+
+		$metadata = json_encode(array( 'themeName' => $themeName, 'isChildTheme' => $isChildTheme, 'tags' => $tags));
+		?>
+		<input id="nonce" type="hidden" value="<?php echo $nounce; ?>" />
+		<div id="create-block-theme-app" data-metadata='<?php echo $metadata; ?>'></div>
+
+		<?php
+	}
+
 	public static function create_admin_form_page() {
 		if ( ! wp_is_block_theme() ) {
 			?>

--- a/src/create-theme/create-theme-form.js
+++ b/src/create-theme/create-theme-form.js
@@ -1,0 +1,229 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { getThemeExportOptions } from './create-theme-options';
+import styles from './styles.module.css';
+
+export function CreateThemeForm( { themeName, tags, selectedOption } ) {
+	const themeOptions = getThemeExportOptions( themeName );
+	const optionDesc = ( themeOptions[ selectedOption ] || {} ).description;
+	const showThemeForm = [ 'export', 'blank', 'child', 'sibling' ].includes(
+		selectedOption
+	);
+	const showVariationForm = selectedOption === 'variation';
+
+	return (
+		<div>
+			<div className={ styles.optionDesc }>{ optionDesc }</div>
+			<div className={ styles.themeFormContainer }>
+				<div className={ styles.themeForm }>
+					{ showVariationForm && <VariationForm /> }
+					{ showThemeForm && <ThemeForm /> }
+
+					<input
+						type="hidden"
+						name="page"
+						value="create-block-theme"
+					/>
+					<input type="hidden" name="nonce" value={ nonce } />
+				</div>
+				<div>{ showThemeForm && <ThemeTags tags={ tags } /> }</div>
+			</div>
+		</div>
+	);
+}
+
+function ThemeForm() {
+	return (
+		<div id="new_theme_metadata_form" className="theme-form">
+			<p>
+				<em>
+					{ __(
+						'Items indicated with (*) are required.',
+						'create-block-theme'
+					) }
+				</em>
+			</p>
+			<label>
+				{ __( 'Theme Name (*):', 'create-block-theme' ) }
+				<br />
+				<input
+					placeholder={ __( 'Theme Name', 'create-block-theme' ) }
+					type="text"
+					name="theme[name]"
+					className="large-text"
+				/>
+			</label>
+			<br />
+			<br />
+			<label>
+				{ __( 'Theme Description:', 'create-block-theme' ) }
+				<br />
+				<textarea
+					placeholder={ __(
+						'A short description of the theme.',
+						'create-block-theme'
+					) }
+					rows="4"
+					cols="50"
+					name="theme[description]"
+					className="large-text"
+				></textarea>
+			</label>
+			<br />
+			<br />
+			<label>
+				{ __( 'Theme URI:', 'create-block-theme' ) }
+				<br />
+				<small>
+					{ __(
+						'The URL of a public web page where users can find more information about the theme.',
+						'create-block-theme'
+					) }
+				</small>
+				<br />
+				<input
+					placeholder={ __(
+						'https://github.com/wordpress/twentytwentythree/',
+						'create-block-theme'
+					) }
+					type="text"
+					name="theme[uri]"
+					className="large-text code"
+				/>
+			</label>
+			<br />
+			<br />
+			<label>
+				{ __( 'Author:', 'create-block-theme' ) }
+				<br />
+				<small>
+					{ __(
+						'The name of the individual or organization who developed the theme.',
+						'create-block-theme'
+					) }
+				</small>
+				<br />
+				<input
+					placeholder={ __(
+						'the WordPress team',
+						'create-block-theme'
+					) }
+					type="text"
+					name="theme[author]"
+					className="large-text"
+				/>
+			</label>
+			<br />
+			<br />
+			<label>
+				{ __( 'Author URI:', 'create-block-theme' ) }
+				<br />
+				<small>
+					{ __(
+						'The URL of the authoring individual or organization.',
+						'create-block-theme'
+					) }
+				</small>
+				<br />
+				<input
+					placeholder={ __(
+						'https://wordpress.org/',
+						'create-block-theme'
+					) }
+					type="text"
+					name="theme[author_uri]"
+					className="large-text code"
+				/>
+			</label>
+			<br />
+			<br />
+			<label htmlFor="screenshot">
+				{ __( 'Screenshot:', 'create-block-theme' ) }
+				<br />
+				<small>
+					{ __(
+						'Upload a new theme screenshot (2mb max | .png only | 1200x900 recommended)',
+						'create-block-theme'
+					) }
+				</small>
+				<br />
+				<input
+					type="file"
+					accept=".png"
+					name="screenshot"
+					id="screenshot"
+					className="upload"
+				/>
+			</label>
+			<br />
+			<br />
+		</div>
+	);
+}
+
+function VariationForm() {
+	return (
+		<div id="new_variation_metadata_form" className="theme-form">
+			<p>
+				<em>
+					{ __(
+						'Items indicated with (*) are required.',
+						'create-block-theme'
+					) }
+				</em>
+			</p>
+			<label>
+				{ __( 'Variation Name (*):', 'create-block-theme' ) }
+				<br />
+				<input
+					placeholder={ __( 'Variation Name', 'create-block-theme' ) }
+					type="text"
+					name="theme[variation]"
+					className="large-text"
+				/>
+			</label>
+		</div>
+	);
+}
+
+function ThemeTags( { tags } ) {
+    const subjectTags = Object.entries(tags['Subject'] || {}).map(([key,value]) => ({value: key, label: value}))
+    const layoutTags = Object.entries(tags['Layout'] || {}).map(([key,value]) => ({value: key, label: value}))
+    const featureTags = Object.entries(tags['Features'] || {}).map(([key,value]) => ({value: key, label: value}))
+    
+	return (
+		<div>
+			<div>
+				<span>Theme Tags:</span>
+				<br />
+				<span>Add theme tags to help categorize the theme </span>
+				<a href="https://make.wordpress.org/themes/handbook/review/required/theme-tags/">
+					read more
+				</a>
+			</div>
+
+            <div style={{marginTop: '1rem', marginBottom: '0.5rem'}}>Subject (max 3):</div>
+			<div style={{display: 'grid', gridTemplateColumns: '1fr 1fr'}}>{ subjectTags.map(tag => {
+                return <div>
+                    <input type="checkbox" name={tag.value} value={tag.value} />
+			        <label>{tag.label}</label>
+                </div>
+            }) }</div>
+
+            <div style={{marginTop: '1rem', marginBottom: '0.5rem'}}>Layout:</div>
+			<div style={{display: 'grid', gridTemplateColumns: '1fr 1fr'}}>{ layoutTags.map(tag => {
+                return <div>
+                    <input type="checkbox" name={tag.value} value={tag.value} />
+			        <label>{tag.label}</label>
+                </div>
+            }) }</div>
+
+            <div style={{marginTop: '1rem', marginBottom: '0.5rem'}}>Features:</div>
+			<div style={{display: 'grid', gridTemplateColumns: '1fr 1fr'}}>{ featureTags.map(tag => {
+                return <div>
+                    <input type="checkbox" name={tag.value} value={tag.value} />
+			        <label>{tag.label}</label>
+                </div>
+            }) }</div>
+		</div>
+	);
+}

--- a/src/create-theme/create-theme-form.js
+++ b/src/create-theme/create-theme-form.js
@@ -1,6 +1,15 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { getThemeExportOptions } from './create-theme-options';
 import styles from './styles.module.css';
+import {
+	Button,
+	RangeControl,
+	SelectControl,
+	// eslint-disable-next-line
+	__experimentalInputControl as InputControl,
+    TextareaControl,
+    CheckboxControl
+} from '@wordpress/components';
 
 export function CreateThemeForm( { themeName, tags, selectedOption } ) {
 	const themeOptions = getThemeExportOptions( themeName );
@@ -34,107 +43,67 @@ export function CreateThemeForm( { themeName, tags, selectedOption } ) {
 function ThemeForm() {
 	return (
 		<div id="new_theme_metadata_form" className="theme-form">
-			<p>
+			{/* <p>
 				<em>
 					{ __(
 						'Items indicated with (*) are required.',
 						'create-block-theme'
 					) }
 				</em>
-			</p>
-			<label>
-				{ __( 'Theme Name (*):', 'create-block-theme' ) }
-				<br />
-				<input
-					placeholder={ __( 'Theme Name', 'create-block-theme' ) }
-					type="text"
-					name="theme[name]"
-					className="large-text"
-				/>
-			</label>
+			</p> */}
+
+            <InputControl
+                label="Theme Name"
+                required
+                value={ '' }
+                onChange={ () => {} }
+            />
+
+            <br />
+            <TextareaControl
+                __nextHasNoMarginBottom
+                label={ __( 'Theme Description' ) }
+                value={ '' }
+                onChange={ ( ) => {} }
+                placeholder='A short description of the theme.'
+            />
+			
+            <br />
+            <InputControl
+                label="Theme URI"
+                placeholder={ __(
+                    'https://github.com/wordpress/twentytwentythree/',
+                    'create-block-theme'
+                ) }
+                help="The URL of a public web page where users can find more information about the theme."
+                value={ '' }
+                onChange={ () => {} }
+            />
+
 			<br />
+            <InputControl
+                label="Author"
+                placeholder={ __(
+                    'WordPress Team',
+                    'create-block-theme'
+                ) }
+                help="The name of the individual or organization who developed the theme."
+                value={ '' }
+                onChange={ () => {} }
+            />
+
 			<br />
-			<label>
-				{ __( 'Theme Description:', 'create-block-theme' ) }
-				<br />
-				<textarea
-					placeholder={ __(
-						'A short description of the theme.',
-						'create-block-theme'
-					) }
-					rows="4"
-					cols="50"
-					name="theme[description]"
-					className="large-text"
-				></textarea>
-			</label>
-			<br />
-			<br />
-			<label>
-				{ __( 'Theme URI:', 'create-block-theme' ) }
-				<br />
-				<small>
-					{ __(
-						'The URL of a public web page where users can find more information about the theme.',
-						'create-block-theme'
-					) }
-				</small>
-				<br />
-				<input
-					placeholder={ __(
-						'https://github.com/wordpress/twentytwentythree/',
-						'create-block-theme'
-					) }
-					type="text"
-					name="theme[uri]"
-					className="large-text code"
-				/>
-			</label>
-			<br />
-			<br />
-			<label>
-				{ __( 'Author:', 'create-block-theme' ) }
-				<br />
-				<small>
-					{ __(
-						'The name of the individual or organization who developed the theme.',
-						'create-block-theme'
-					) }
-				</small>
-				<br />
-				<input
-					placeholder={ __(
-						'the WordPress team',
-						'create-block-theme'
-					) }
-					type="text"
-					name="theme[author]"
-					className="large-text"
-				/>
-			</label>
-			<br />
-			<br />
-			<label>
-				{ __( 'Author URI:', 'create-block-theme' ) }
-				<br />
-				<small>
-					{ __(
-						'The URL of the authoring individual or organization.',
-						'create-block-theme'
-					) }
-				</small>
-				<br />
-				<input
-					placeholder={ __(
-						'https://wordpress.org/',
-						'create-block-theme'
-					) }
-					type="text"
-					name="theme[author_uri]"
-					className="large-text code"
-				/>
-			</label>
-			<br />
+			<InputControl
+                label="Author URI"
+                placeholder={ __(
+                    'https://wordpress.org/',
+                    'create-block-theme'
+                ) }
+                help="The URL of the authoring individual or organization."
+                value={ '' }
+                onChange={ () => {} }
+            />
+
 			<br />
 			<label htmlFor="screenshot">
 				{ __( 'Screenshot:', 'create-block-theme' ) }
@@ -163,24 +132,12 @@ function ThemeForm() {
 function VariationForm() {
 	return (
 		<div id="new_variation_metadata_form" className="theme-form">
-			<p>
-				<em>
-					{ __(
-						'Items indicated with (*) are required.',
-						'create-block-theme'
-					) }
-				</em>
-			</p>
-			<label>
-				{ __( 'Variation Name (*):', 'create-block-theme' ) }
-				<br />
-				<input
-					placeholder={ __( 'Variation Name', 'create-block-theme' ) }
-					type="text"
-					name="theme[variation]"
-					className="large-text"
-				/>
-			</label>
+			<InputControl
+                label="Variation Name"
+                required
+                value={ '' }
+                onChange={ () => {} }
+            />
 		</div>
 	);
 }
@@ -204,24 +161,39 @@ function ThemeTags( { tags } ) {
             <div style={{marginTop: '1rem', marginBottom: '0.5rem'}}>Subject (max 3):</div>
 			<div style={{display: 'grid', gridTemplateColumns: '1fr 1fr'}}>{ subjectTags.map(tag => {
                 return <div>
-                    <input type="checkbox" name={tag.value} value={tag.value} />
-			        <label>{tag.label}</label>
+                    <CheckboxControl
+						// __nextHasNoMarginBottom
+						label={ tag.label }
+						checked={ false }
+						// indeterminate={ isMixed }
+						onChange={ ( newValue ) => {}}
+					/>
                 </div>
             }) }</div>
 
             <div style={{marginTop: '1rem', marginBottom: '0.5rem'}}>Layout:</div>
 			<div style={{display: 'grid', gridTemplateColumns: '1fr 1fr'}}>{ layoutTags.map(tag => {
                 return <div>
-                    <input type="checkbox" name={tag.value} value={tag.value} />
-			        <label>{tag.label}</label>
+                    <CheckboxControl
+						// __nextHasNoMarginBottom
+						label={ tag.label }
+						checked={ false }
+						// indeterminate={ isMixed }
+						onChange={ ( newValue ) => {}}
+					/>
                 </div>
             }) }</div>
 
             <div style={{marginTop: '1rem', marginBottom: '0.5rem'}}>Features:</div>
 			<div style={{display: 'grid', gridTemplateColumns: '1fr 1fr'}}>{ featureTags.map(tag => {
                 return <div>
-                    <input type="checkbox" name={tag.value} value={tag.value} />
-			        <label>{tag.label}</label>
+                    <CheckboxControl
+						// __nextHasNoMarginBottom
+						label={ tag.label }
+						checked={ false }
+						// indeterminate={ isMixed }
+						onChange={ ( newValue ) => {}}
+					/>
                 </div>
             }) }</div>
 		</div>

--- a/src/create-theme/create-theme-header.js
+++ b/src/create-theme/create-theme-header.js
@@ -1,0 +1,17 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+export function PageHeader( { themeName } ) {
+	return (
+		<>
+			<h1 className="wp-heading-inline">
+				{ __( 'Create Block Theme', 'create-block-theme' ) }
+			</h1>
+			<p>
+				{ __(
+					'Create or export a block theme with changes made to Templates, Template Parts and Global Styles.',
+					'create-block-theme'
+				) }
+			</p>
+		</>
+	);
+}

--- a/src/create-theme/create-theme-options.js
+++ b/src/create-theme/create-theme-options.js
@@ -1,0 +1,150 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { Dashicon } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import styles from './styles.module.css';
+
+export function getThemeExportOptions( themeName ) {
+	return {
+		export: {
+			label: sprintf(
+				/* translators: %s: Theme Name. */
+				__( 'Export %s', 'create-block-theme' ),
+				themeName
+			),
+			description: __(
+				'Export the activated theme with user changes.',
+				'create-block-theme'
+			),
+		},
+		clone: {
+			label: sprintf(
+				/* translators: %s: Theme Name. */
+				__( 'Clone %s', 'create-block-theme' ),
+				themeName
+			),
+			description: __(
+				'Create a new theme cloning the activated theme. The resulting theme will have all of the assets of the activated theme as well as user changes.',
+				'create-block-theme'
+			),
+		},
+		child: {
+			label: sprintf(
+				/* translators: %s: Theme Name. */
+				__( `Create child of %s`, 'create-block-theme' ),
+				themeName
+			),
+			description: __(
+				'Create a new child theme. The currently activated theme will be the parent theme.',
+				'create-block-theme'
+			),
+		},
+		sibling: {
+			label: sprintf(
+				/* translators: %s: Theme Name. */
+				__( `Create sibling of %s`, 'create-block-theme' ),
+				themeName
+			),
+			description: __(
+				'Create a new theme cloning the activated child theme.  The parent theme will be the same as the parent of the currently activated theme. The resulting theme will have all of the assets of the activated theme, none of the assets provided by the parent theme, as well as user changes.',
+				'create-block-theme'
+			),
+		},
+		override: {
+			label: sprintf(
+				/* translators: %s: Theme Name. */
+				__( 'Overwrite %s', 'create-block-theme' ),
+				themeName
+			),
+			description: __(
+				'Save USER changes as THEME changes and delete the USER changes.  Your changes will be saved in the theme on the folder.',
+				'create-block-theme'
+			),
+		},
+		blank: {
+			label: __( 'Create blank theme', 'create-block-theme' ),
+			description: __(
+				`Generate a boilerplate "empty" theme inside of this site's themes directory.`,
+				'create-block-theme'
+			),
+		},
+		variation: {
+			label: __( 'Create a style variation', 'create-block-theme' ),
+			description: sprintf(
+				// translators: %1$s: Theme name
+				__(
+					'Save user changes as a style variation of %1$s.',
+					'create-block-theme'
+				),
+				themeName
+			),
+		},
+	};
+}
+
+export function CreateThemeOptions( { themeName, isChildTheme, onChange } ) {
+	const [ selected, setSelected ] = useState();
+	const op = getThemeExportOptions( themeName );
+
+	const exportCategories = [
+		{
+			label: 'Start fresh',
+			options: [ 'export', 'blank' ].map( ( o ) => ( {
+				value: o,
+				...op[ o ],
+			} ) ),
+		},
+		{
+			label: 'Start from an existing theme',
+			options: [
+				isChildTheme ? 'sibling' : 'child',
+				'override',
+				'variation',
+			].map( ( o ) => ( { value: o, ...op[ o ] } ) ),
+		},
+	];
+
+	function handleOptionClick( option ) {
+		setSelected( option );
+		onChange && onChange( option );
+	}
+
+	return (
+		<div className={ styles.optionsContainer }>
+			<h2>Active theme: { themeName }</h2>
+
+			{ exportCategories.map( ( category, index ) => {
+				return (
+					<div key={ index }>
+						<h3>{ category.label }</h3>
+						{ category.options.map( ( option ) => (
+							<Option
+								key={ option.value }
+								{ ...option }
+								isSelected={ option.value === selected }
+								onClick={ handleOptionClick }
+							/>
+						) ) }
+					</div>
+				);
+			} ) }
+		</div>
+	);
+}
+
+function Option( { label, value, isSelected, onClick } ) {
+	return (
+		<div
+			className={
+				styles.themeOption +
+				' ' +
+				( isSelected ? styles.selectedOption : '' )
+			}
+			onClick={ () => onClick && onClick( value ) }
+		>
+			<span>{ label }</span>
+			<span className={ styles.selectedIcon }>
+				{ isSelected && <Dashicon icon="yes-alt" /> }
+			</span>
+		</div>
+	);
+}

--- a/src/create-theme/index.js
+++ b/src/create-theme/index.js
@@ -1,0 +1,39 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { CreateThemePageLayout } from './page-layout';
+import { PageHeader } from './create-theme-header';
+import {
+	CreateThemeOptions,
+	getThemeExportOptions,
+} from './create-theme-options';
+import { CreateThemeForm } from './create-theme-form';
+
+export default function CreateBlockTheme( { metadata } ) {
+	const [ selected, setSelected ] = useState();
+
+	const nonce = document.querySelector( '#nonce' ).value;
+
+	const themeName = metadata.themeName;
+	const isChildTheme = metadata.isChildTheme;
+	const tags = metadata.tags;
+
+	return (
+		<CreateThemePageLayout
+			header={ <PageHeader themeName={ themeName } /> }
+			sidebar={
+				<CreateThemeOptions
+					themeName={ themeName }
+					isChildTheme={ isChildTheme }
+					onChange={ setSelected }
+				/>
+			}
+			main={
+				<CreateThemeForm
+					themeName={ themeName }
+					tags={ tags }
+					selectedOption={ selected }
+				/>
+			}
+		/>
+	);
+}

--- a/src/create-theme/page-layout.js
+++ b/src/create-theme/page-layout.js
@@ -1,0 +1,13 @@
+import styles from './styles.module.css';
+
+export function CreateThemePageLayout( { header, sidebar, main } ) {
+	return (
+		<div className={ styles.pageLayout }>
+			<div className={ styles.pageHeader }>{ header }</div>
+			<div className={ styles.pageContainer }>
+				{ sidebar }
+				{ main }
+			</div>
+		</div>
+	);
+}

--- a/src/create-theme/styles.module.css
+++ b/src/create-theme/styles.module.css
@@ -1,0 +1,61 @@
+/* layout */
+.pageLayout {
+    padding: 2rem;
+    padding-bottom: 0;
+    height: calc(100% - 2rem);
+    display: flex;
+    flex-direction: column;
+}
+.pageHeader {
+    border-bottom: 1px solid #e2e2e2;
+}
+.pageContainer {
+    display: grid;
+    grid-template-columns: minmax(250px, 1fr) 3fr;
+    flex-grow: 1;
+}
+
+/* sidebar */
+.optionsContainer {
+    border-right: 1px solid #e2e2e2;
+    padding-right: 2rem;
+    overflow: auto;
+}
+.optionsContainer h2 {
+    margin-bottom: 1.5rem;
+}
+.optionsContainer h3 {
+    font-size: 0.75rem;
+    margin-top: 1.5rem;
+}
+.themeOption {
+    box-sizing: border-box;
+    padding: 1rem 1rem;
+    margin-bottom: 0.5rem;
+    border: 1px solid #e2e2e2;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    position: relative;
+    display: flex;
+    justify-content: space-between;
+    line-height: 20px;
+}
+.selectedIcon {
+    color: blue;
+}
+.themeOption:hover, .selectedOption {
+    border-color: blue;
+}
+
+/* main container */
+.themeFormContainer {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+}
+.optionDesc {
+    font-weight: 700;
+    margin: 1rem 2rem;
+}
+.themeForm {
+    padding: 0 2rem;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,19 @@
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 import ManageFonts from './manage-fonts';
 import GoogleFonts from './google-fonts';
 import LocalFonts from './local-fonts';
 import { ManageFontsProvider } from './fonts-context';
+import CreateBlockTheme from './create-theme';
 
-function App() {
+function App( { metadata } ) {
 	const params = new URLSearchParams( document.location.search );
 	const page = params.get( 'page' );
 
 	let PageComponent = null;
 	switch ( page ) {
+		case 'create-block-theme':
+			PageComponent = CreateBlockTheme;
+			break;
 		case 'manage-fonts':
 			PageComponent = ManageFonts;
 			break;
@@ -26,7 +30,7 @@ function App() {
 
 	return (
 		<ManageFontsProvider>
-			<PageComponent />
+			<PageComponent metadata={ metadata } />
 		</ManageFontsProvider>
 	);
 }
@@ -34,7 +38,19 @@ function App() {
 window.addEventListener(
 	'load',
 	function () {
-		render( <App />, document.querySelector( '#create-block-theme-app' ) );
+		const rootElement = document.getElementById( 'create-block-theme-app' );
+		rootElement.style = 'height: calc(100vh - 32px)';
+		const metadata = getAppMetadata( rootElement );
+		const root = createRoot( rootElement );
+		root.render( <App metadata={ metadata } /> );
 	},
 	false
 );
+
+function getAppMetadata( rootElement ) {
+	try {
+		return JSON.parse( rootElement.getAttribute( 'data-metadata' ) );
+	} catch ( error ) {
+		return {};
+	}
+}


### PR DESCRIPTION
This change aims at improving UI of the create block theme by moving to react components.
Also keeps the UI consistent with font management.

Old:

<img width="1510" alt="image" src="https://user-images.githubusercontent.com/1935113/232015363-e597d534-24d6-4ebe-92d2-c09835955a1c.png">


Following is the new work in progress UI.

![cbt-new-ui](https://user-images.githubusercontent.com/1935113/232015880-4a1fdf83-4645-4a89-918e-7a74ec9c89b5.gif)

@beafialho @henriqueiamarino could you please share your thoughts and feedback on this.
I am not sure if it is still right to keep the generate button on the left.

**Note:** This is UI only change for now to gain early feedback, and complete functionality is not ported yet.

### Related WIP issues:
https://github.com/WordPress/create-block-theme/issues/322
https://github.com/WordPress/create-block-theme/pull/294
