### PR TITLE
Fix delete font family/face when name is different from family

### DIFF
--- a/src/manage-fonts/index.js
+++ b/src/manage-fonts/index.js
@@ -84,7 +84,10 @@ function ManageFonts() {
 
 	function deleteFontFamily( fontFamily ) {
 		const updatedFonts = newThemeFonts.map( ( family ) => {
-			if ( fontFamily === family.fontFamily ) {
+			if (
+				fontFamily === family.fontFamily ||
+				fontFamily === family.name
+			) {
 				return {
 					...family,
 					shouldBeRemoved: true,
@@ -110,7 +113,8 @@ function ManageFonts() {
 				if (
 					weight === face.fontWeight &&
 					style === face.fontStyle &&
-					fontFamily === family.fontFamily
+					( fontFamily === family.fontFamily ||
+						fontFamily === family.name )
 				) {
 					return {
 						...face,


### PR DESCRIPTION
## What?
A fix for deleting font family and font faces.

## Why?
When the font name is different from the font family the delete function is not working.
With this change, we look for both name and family.

## How to test:
1. Activate a theme including fonts with different name that fontFamily as `Disco` theme.
2. Try to remove the font using the font manager screen and see that it is failing silently.

Example from disco:
```
 "fontFamilies": [
				{
					"fontFamily": "SpaceMono, serif",   <--------------------
					"name": "SpaceMono", <-----------------------------------
					"slug": "spacemono",
					"fontFace": [
						{
							"fontDisplay": "block",
							"fontFamily": "SpaceMono",
							"fontWeight": "400",
							"fontStyle": "normal",
							"fontStretch": "normal",
							"src": [
								"file:./assets/fonts/SpaceMono-Regular.ttf"
							]
						},
...
```


