### PR TITLE
Strip escaping characters before printing stylesheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ vendor/
 
 # ignore system files
 .DS_Store
+.vscode
 
 # plugin build folder
 build/

--- a/admin/create-theme/form-messages.php
+++ b/admin/create-theme/form-messages.php
@@ -41,7 +41,7 @@ class Form_Messages {
 				printf(
 					// translators: %1$s: Theme name
 					esc_html__( 'Blank theme created, head over to Appearance > Themes to activate %1$s', 'create-block-theme' ),
-					esc_html( $theme_name )
+					esc_html( stripslashes( $theme_name ) )
 				);
 				?>
 					</p>

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -8,10 +8,10 @@ class Theme_Styles {
 	 */
 	public static function build_child_style_css( $theme ) {
 		$slug        = $theme['slug'];
-		$name        = $theme['name'];
-		$description = $theme['description'];
+		$name        = stripslashes( $theme['name'] );
+		$description = stripslashes( $theme['description'] );
 		$uri         = $theme['uri'];
-		$author      = $theme['author'];
+		$author      = stripslashes( $theme['author'] );
 		$author_uri  = $theme['author_uri'];
 		$wp_version  = get_bloginfo( 'version' );
 		$template    = $theme['template'];


### PR DESCRIPTION
Removes backslashes before printing the stylesheet file on fields that are **not _special_** (Slug, URIs, template).

Fixes https://github.com/WordPress/create-block-theme/issues/222