### PR TITLE
Fix export theme from Site Editor

### DIFF
--- a/admin/create-theme/theme-zip.php
+++ b/admin/create-theme/theme-zip.php
@@ -162,6 +162,10 @@ class Theme_Zip {
 	}
 
 	static function add_media_to_zip( $zip, $media ) {
+		if ( ! is_admin() ) {
+			include( ABSPATH . 'wp-admin/includes/admin.php' );
+		}
+
 		$media = array_unique( $media );
 		foreach ( $media as $url ) {
 			$folder_path   = Theme_Media::get_media_folder_path_from_url( $url );

--- a/admin/create-theme/theme-zip.php
+++ b/admin/create-theme/theme-zip.php
@@ -162,8 +162,8 @@ class Theme_Zip {
 	}
 
 	static function add_media_to_zip( $zip, $media ) {
-		if ( ! is_admin() ) {
-			include( ABSPATH . 'wp-admin/includes/admin.php' );
+		if ( ! function_exists( 'download_url' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
 		}
 
 		$media = array_unique( $media );

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -30,6 +30,7 @@ const ExportTheme = () => {
 		uri: '',
 		author: '',
 		author_uri: '',
+		tags_custom: '',
 	} );
 
 	useSelect( ( select ) => {


### PR DESCRIPTION
Related. https://github.com/WordPress/create-block-theme/pull/294#issuecomment-1515416458
I've been looking into why the Export function is broken on the site editor, and the problem is two-fold.
First, this error was thrown:
```sh
[26-Apr-2023 20:52:44 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function download_url() in /var/www/html/wp-content/plugins/create-block-theme/admin/create-theme/theme-zip.php:114
```
This happens because when hitting the endpoint, theme-zip.php is not within the admin context, so wp-admin/includes.php is never included, and `download_url` never defined.

It can be solved by modifying `add_media_to_zip` to import wp-admin/includes/admin.php when needed, although we might want to add that somewhere up the chain in case other admin functions are made available through the REST API.

Second, `uri` has a different name in the frontend app — `theme_uri` — and `tags_custom`  is absent.
```sh
[26-Apr-2023 20:52:44 UTC] PHP Warning:  Undefined array key "uri" in /var/www/html/wp-content/plugins/create-block-theme/admin/class-create-theme.php on line 312
[26-Apr-2023 20:52:44 UTC] PHP Warning:  Undefined array key "tags_custom" in /var/www/html/wp-content/plugins/create-block-theme/admin/class-create-theme.php on line 315

```