### PR TITLE
Fix console error in `prepareThemeNameValidation` function

### DIFF
--- a/admin/js/form-script.js
+++ b/admin/js/form-script.js
@@ -108,7 +108,9 @@ window.addEventListener( 'load', prepareThemeNameValidation );
 
 function prepareThemeNameValidation() {
 	const themeNameInput = document.getElementById( 'theme-name' );
-	themeNameInput.addEventListener( 'input', validateThemeNameInput );
+	if ( themeNameInput ) {
+		themeNameInput.addEventListener( 'input', validateThemeNameInput );
+	}
 }
 
 function slugify( text ) {


### PR DESCRIPTION
This fixes a small console error triggered from the `prepareThemeNameValidation` function, by checking for the `themeNameInput` element before adding the event listener.

Here's an example of the error, which is currently showing on WP admin pages:

<img width="578" alt="image" src="https://user-images.githubusercontent.com/1645628/235686050-3b8f4b27-544a-4422-96d1-04a3df0fe910.png">

To test, check that the above error is no longer shown and that the `prepareThemeNameValidation` function still runs correctly when the `themeNameInput` element exists (i.e. where you can edit the theme name for a generated theme at `/wp-admin/themes.php?page=create-block-theme`).
