### PR TITLE
Add FAQ section to readme.txt

### DIFF
--- a/admin/js/form-script.js
+++ b/admin/js/form-script.js
@@ -108,7 +108,9 @@ window.addEventListener( 'load', prepareThemeNameValidation );
 
 function prepareThemeNameValidation() {
 	const themeNameInput = document.getElementById( 'theme-name' );
-	themeNameInput.addEventListener( 'input', validateThemeNameInput );
+	if ( themeNameInput ) {
+		themeNameInput.addEventListener( 'input', validateThemeNameInput );
+	}
 }
 
 function slugify( text ) {

--- a/readme.txt
+++ b/readme.txt
@@ -34,6 +34,10 @@ Make changes to your site styles and templates using the Site Editor. You can al
 = Step 3 – Export =
 Still in the WordPress dashboard, navigate to "Appearance" -> "Create Block Theme" section. Select one of the available options and then, if necessary, add the details for the theme here. These details will be used in the style.css file. Click "Generate” button, to save the theme.
 
+== Frequently Asked Questions ==
+
+If you run into an issue, you should check the [Support forum](https://wordpress.org/support/plugin/create-block-theme/) first. The forum is a great place to get help. If you have a bug to report, please submit it to the [GitHub repository](https://github.com/WordPress/create-block-theme/issues) as an issue. Please search prior to creating a new bug to confirm its not a duplicate.
+
 == Changelog ==
 
 = 1.8.2 =

--- a/readme.txt
+++ b/readme.txt
@@ -36,7 +36,13 @@ Still in the WordPress dashboard, navigate to "Appearance" -> "Create Block Them
 
 == Frequently Asked Questions ==
 
-If you run into an issue, you should check the [Support forum](https://wordpress.org/support/plugin/create-block-theme/) first. The forum is a great place to get help. If you have a bug to report, please submit it to the [GitHub repository](https://github.com/WordPress/create-block-theme/issues) as an issue. Please search prior to creating a new bug to confirm its not a duplicate.
+= How do I get support? =
+
+If you run into an issue, you should check the [Support forum](https://wordpress.org/support/plugin/create-block-theme/) first. The forum is a great place to get help.
+
+= How do I report an issue? =
+
+If you have a bug to report, please submit it to the [GitHub repository](https://github.com/WordPress/create-block-theme/issues) as an issue. Please search prior to creating a new bug to confirm its not a duplicate.
 
 == Changelog ==
 


### PR DESCRIPTION
This adds an FAQ section to the readme.txt file including links to the support forum and this GitHub repo. This should appear on the WordPress.org plugin page.

Closes https://github.com/WordPress/create-block-theme/issues/350.