### PR TITLE
Updating "Requires at least" field of generated themes

### DIFF
--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -24,7 +24,7 @@ class Theme_Readme {
 
 		return "=== {$name} ===
 Contributors: {$author}
-Requires at least: 5.8
+Requires at least: 6.0
 Tested up to: {$wp_version}
 Requires PHP: 5.7
 License: GPLv2 or later

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -24,7 +24,7 @@ Theme URI: {$uri}
 Author: {$author}
 Author URI: {$author_uri}
 Description: {$description}
-Requires at least: 5.8
+Requires at least: 6.0
 Tested up to: {$wp_version}
 Requires PHP: 5.7
 Version: 0.0.1


### PR DESCRIPTION
Fixes: https://github.com/WordPress/create-block-theme/issues/355