### PR TITLE
Improve handling of font license errors

### DIFF
--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -332,6 +332,10 @@ class Manage_Fonts_Admin {
 				// Get font credits from font file metadata
 				$font_credits = json_decode( stripslashes( $_POST['font-credits'] ), true );
 
+				if ( ! $font_credits ) {
+					return;
+				}
+
 				// Assign font credits to variables
 				$copyright    = array_key_exists( 'copyright', $font_credits ) ? trim( $font_credits['copyright'] ) : '';
 				$license_info = array_key_exists( 'license', $font_credits ) ? "\n" . trim( $font_credits['license'] ) : '';

--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -325,14 +325,14 @@ class Manage_Fonts_Admin {
 			return;
 		}
 
-		// If file_name exists, then add font license to readme.txt
-		if ( 'remove' !== $file_name && is_string( $file_name ) && ! empty( $_POST['font-credits'] ) ) {
+		// If file_name and font-credits exist, then add font license to readme.txt
+		if ( 'remove' !== $file_name && is_string( $file_name ) && ! empty( $_POST['font-credits'] ) && isset( $_POST['font-credits'] ) ) {
 			// Check that the font is not already credited in readme.txt
 			if ( false === stripos( $readme_file_contents, $font_name ) ) {
 				// Get font credits from font file metadata
 				$font_credits = json_decode( stripslashes( $_POST['font-credits'] ), true );
 
-				if ( ! $font_credits ) {
+				if ( ! is_array( $font_credits ) ) {
 					return;
 				}
 

--- a/src/google-fonts/index.js
+++ b/src/google-fonts/index.js
@@ -158,8 +158,14 @@ function GoogleFonts() {
 		const fontObj = new Font( selectedFontObj.family );
 		let fontError = false;
 
+		// Force font file to be https
+		let fontFile = Object.values( selectedFontObj.files )[ 0 ];
+		if ( fontFile.includes( 'http://' ) ) {
+			fontFile = fontFile.replace( 'http://', 'https://' );
+		}
+
 		// Load font file
-		fontObj.src = Object.values( selectedFontObj.files )[ 0 ];
+		fontObj.src = fontFile;
 		fontObj.onerror = ( event ) => {
 			// eslint-disable-next-line no-console
 			console.error( event );

--- a/src/google-fonts/index.js
+++ b/src/google-fonts/index.js
@@ -156,25 +156,32 @@ function GoogleFonts() {
 
 	const getFontCredits = ( selectedFontObj ) => {
 		const fontObj = new Font( selectedFontObj.family );
+		let fontError = false;
 
 		// Load font file
 		fontObj.src = Object.values( selectedFontObj.files )[ 0 ];
-		// eslint-disable-next-line no-console
-		fontObj.onerror = ( event ) => console.error( event );
-		fontObj.onload = ( event ) => getFontData( event );
+		fontObj.onerror = ( event ) => {
+			// eslint-disable-next-line no-console
+			console.error( event );
+			fontError = true;
+		};
 
-		function getFontData( event ) {
-			const font = event.detail.font;
-			const nameTable = font.opentype.tables.name;
+		if ( ! fontError ) {
+			fontObj.onload = ( event ) => getFontData( event );
 
-			const fontCredits = {
-				copyright: nameTable.get( 0 ),
-				source: nameTable.get( 11 ),
-				license: nameTable.get( 13 ),
-				licenseURL: nameTable.get( 14 ),
-			};
+			function getFontData( event ) {
+				const font = event.detail.font;
+				const nameTable = font.opentype.tables.name;
 
-			setSelectedFontCredits( fontCredits );
+				const fontCredits = {
+					copyright: nameTable.get( 0 ),
+					source: nameTable.get( 11 ),
+					license: nameTable.get( 13 ),
+					licenseURL: nameTable.get( 14 ),
+				};
+
+				setSelectedFontCredits( fontCredits );
+			}
 		}
 	};
 

--- a/src/google-fonts/index.js
+++ b/src/google-fonts/index.js
@@ -36,7 +36,7 @@ const EMPTY_SELECTION_DATA = {};
 function GoogleFonts() {
 	const [ googleFontsData, setGoogleFontsData ] = useState( {} );
 	const [ selectedFont, setSelectedFont ] = useState( null );
-	const [ selectedFontCredits, setSelectedFontCredits ] = useState( null );
+	const [ selectedFontCredits, setSelectedFontCredits ] = useState( {} );
 	const [ selectionData, setSelectionData ] =
 		useState( EMPTY_SELECTION_DATA );
 


### PR DESCRIPTION
This PR improves the handling of errors caused by the font license functionality.

- Checks if the `font-credits` form data is set and is an array before running any further code
- Sets an empty object `{}` as the default state for the `font-credits` data
- Checks that the font file has loaded successfully before setting the `font-credits` data
- Ensures all Google fonts are served over https, to prevent mixed content errors

To test:

1. Add a Google font to your theme (e.g. IBM Plex Mono)
2. Add multiple font variants (e.g. 2 different font weights)
3. The plugin should not crash or error
4. Check that the font license has been added to the theme readme.txt correctly