### PR TITLE
Fix `tabIndex` prop

### DIFF
--- a/src/manage-fonts/font-face.js
+++ b/src/manage-fonts/font-face.js
@@ -31,7 +31,7 @@ function FontFace( { face, deleteFont, shouldBeRemoved, isFamilyOpen } ) {
 					<Button
 						variant="tertiary"
 						onClick={ deleteFont }
-						tabindex={ isFamilyOpen ? 0 : -1 }
+						tabIndex={ isFamilyOpen ? 0 : -1 }
 					>
 						{ __( 'Remove', 'create-block-theme' ) }
 					</Button>


### PR DESCRIPTION
Replaces a reference to `tabindex` with `tabIndex`.

Fixes https://github.com/WordPress/create-block-theme/issues/363.