### PR TITLE
Automatically add font license info for local fonts

### DIFF
--- a/src/google-fonts/index.js
+++ b/src/google-fonts/index.js
@@ -177,13 +177,13 @@ function GoogleFonts() {
 
 			function getFontData( event ) {
 				const font = event.detail.font;
-				const nameTable = font.opentype.tables.name;
+				const { name } = font.opentype.tables;
 
 				const fontCredits = {
-					copyright: nameTable.get( 0 ),
-					source: nameTable.get( 11 ),
-					license: nameTable.get( 13 ),
-					licenseURL: nameTable.get( 14 ),
+					copyright: name.get( 0 ),
+					source: name.get( 11 ),
+					license: name.get( 13 ),
+					licenseURL: name.get( 14 ),
 				};
 
 				setSelectedFontCredits( fontCredits );

--- a/src/local-fonts/upload-font-form.js
+++ b/src/local-fonts/upload-font-form.js
@@ -86,6 +86,12 @@ function UploadFontForm( {
 							{}
 					  )
 					: {};
+				const fontCredits = {
+					copyright: name.get( 0 ),
+					source: name.get( 11 ),
+					license: name.get( 13 ),
+					licenseURL: name.get( 14 ),
+				};
 
 				setFormData( {
 					file,
@@ -93,6 +99,7 @@ function UploadFontForm( {
 					style: isItalic ? 'italic' : 'normal',
 					weight: !! weightAxis ? weightRange : fontWeight,
 					variable: isVariable,
+					fontCredits,
 				} );
 				setAxes( axes );
 			};
@@ -191,6 +198,12 @@ function UploadFontForm( {
 						value={ fontVariationSettings }
 					/>
 				) }
+
+				<input
+					type="hidden"
+					name="font-credits"
+					value={ JSON.stringify( formData.fontCredits ) }
+				/>
 			</form>
 
 			<Button


### PR DESCRIPTION
This automatically grabs the font license info from a local font file and adds it to the theme's readme.txt. Based on the work done in https://github.com/WordPress/create-block-theme/pull/298.

Closes https://github.com/WordPress/create-block-theme/issues/348.