### PR TITLE
Prevent additional white space in font credits in readme.txt

### DIFF
--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -355,11 +355,15 @@ class Manage_Fonts_Admin {
 
 				// Build the font credits string
 				$font_credits = "
-
 {$font_name} Font
 {$copyright} {$license_info} {$license_url} {$font_source}
 {$end_credits_note}
 ";
+
+				// Check if readme.txt ends with a new line
+				if ( "\n" !== $readme_file_contents[ strlen( $readme_file_contents ) - 1 ] ) {
+					$font_credits = "\n" . $font_credits;
+				}
 
 				// Add font credits to the end of readme.txt
 				file_put_contents(


### PR DESCRIPTION
When the font credits are added to the readme.txt file, they add an unnecessary line break above the font license info. This PR should fix this so that a new line break is only added when the readme.txt does not already have a line break at the end of the file. This line break above the font credits block should also be removed from the readme.txt when a font family is removed from the theme.

Testing instructions:

1. Go to the Manage Theme Fonts page
2. Add a new font
3. Check that the font license info has been added to the theme readme.txt and that there is a line break between the previous end of the readme contents and the new font credits
4. Go back to the Manage Themes Fonts page
5. Remove a font family
6. Check that the font license info has been removed from the readme.txt and there are no unnecessary line breaks left behind

Closes https://github.com/WordPress/create-block-theme/issues/361.