### PR TITLE
Escape special characters to avoid syntax errors

### DIFF
--- a/admin/create-theme/theme-patterns.php
+++ b/admin/create-theme/theme-patterns.php
@@ -58,7 +58,8 @@ class Theme_Patterns {
 
 	static function escape_text_for_pattern( $text ) {
 		if ( $text && trim( $text ) !== '' ) {
-			return "<?php echo esc_attr_e( '" . $text . "', '" . wp_get_theme()->get( 'Name' ) . "' ); ?>";
+			$escaped_text = addslashes( $text );
+			return "<?php echo esc_attr_e( '" . $escaped_text . "', '" . wp_get_theme()->get( 'Name' ) . "' ); ?>";
 		}
 	}
 


### PR DESCRIPTION
Special characters were causing patterns to crash the site due to syntax errors. In this change, we make sure that these characters are escaped before being printed to the pattern.

Tested using the string "ABC/'"-.`\';//\\''``" as alt text for a template image.

Fixes: https://github.com/WordPress/create-block-theme/issues/349