### PR TITLE
Google fonts: Change onClick handlers to onChange

### DIFF
--- a/src/google-fonts/font-variant.js
+++ b/src/google-fonts/font-variant.js
@@ -44,7 +44,7 @@ function FontVariant( { font, variant, isSelected, handleToggle } ) {
 					id={ fontId }
 					value={ variant }
 					checked={ isSelected }
-					onClick={ handleToggle }
+					onChange={ handleToggle }
 				/>
 			</td>
 			<td className="">

--- a/src/google-fonts/index.js
+++ b/src/google-fonts/index.js
@@ -283,7 +283,7 @@ function GoogleFonts() {
 											<input
 												type="checkbox"
 												id={ `select-all-${ selectedFontFamilyId }` }
-												onClick={ () =>
+												onChange={ () =>
 													handleToggleAllVariants(
 														selectedFont.family
 													)


### PR DESCRIPTION
This small PR changes the `onClick` handler to `onChange` for both of the checkbox inputs used for managing Google fonts.

This should fix the related React warning and close https://github.com/WordPress/create-block-theme/issues/362.