### PR TITLE
Add image credits input

### DIFF
--- a/admin/class-create-theme.php
+++ b/admin/class-create-theme.php
@@ -104,15 +104,16 @@ class Create_Block_Theme_Admin {
 		$theme_slug = Theme_Utils::get_theme_slug( $theme['name'] );
 
 		// Sanitize inputs.
-		$theme['name']        = sanitize_text_field( $theme['name'] );
-		$theme['description'] = sanitize_text_field( $theme['description'] );
-		$theme['uri']         = sanitize_text_field( $theme['uri'] );
-		$theme['author']      = sanitize_text_field( $theme['author'] );
-		$theme['author_uri']  = sanitize_text_field( $theme['author_uri'] );
-		$theme['tags_custom'] = sanitize_text_field( $theme['tags_custom'] );
-		$theme['slug']        = $theme_slug;
-		$theme['template']    = wp_get_theme()->get( 'Template' );
-		$theme['text_domain'] = $theme_slug;
+		$theme['name']          = sanitize_text_field( $theme['name'] );
+		$theme['description']   = sanitize_text_field( $theme['description'] );
+		$theme['uri']           = sanitize_text_field( $theme['uri'] );
+		$theme['author']        = sanitize_text_field( $theme['author'] );
+		$theme['author_uri']    = sanitize_text_field( $theme['author_uri'] );
+		$theme['tags_custom']   = sanitize_text_field( $theme['tags_custom'] );
+		$theme['image_credits'] = sanitize_textarea_field( $theme['image_credits'] );
+		$theme['slug']          = $theme_slug;
+		$theme['template']      = wp_get_theme()->get( 'Template' );
+		$theme['text_domain']   = $theme_slug;
 
 		// Create ZIP file in the temporary directory.
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
@@ -170,6 +171,7 @@ class Create_Block_Theme_Admin {
 		$theme['author']         = sanitize_text_field( $theme['author'] );
 		$theme['author_uri']     = sanitize_text_field( $theme['author_uri'] );
 		$theme['tags_custom']    = sanitize_text_field( $theme['tags_custom'] );
+		$theme['image_credits']  = sanitize_textarea_field( $theme['image_credits'] );
 		$theme['slug']           = $theme_slug;
 		$theme['template']       = '';
 		$theme['original_theme'] = wp_get_theme()->get( 'Name' );
@@ -253,12 +255,13 @@ class Create_Block_Theme_Admin {
 		$child_theme_slug  = Theme_Utils::get_theme_slug( $theme['name'] );
 
 		// Sanitize inputs.
-		$theme['name']        = sanitize_text_field( $theme['name'] );
-		$theme['description'] = sanitize_text_field( $theme['description'] );
-		$theme['uri']         = sanitize_text_field( $theme['uri'] );
-		$theme['author']      = sanitize_text_field( $theme['author'] );
-		$theme['author_uri']  = sanitize_text_field( $theme['author_uri'] );
-		$theme['tags_custom'] = sanitize_text_field( $theme['tags_custom'] );
+		$theme['name']          = sanitize_text_field( $theme['name'] );
+		$theme['description']   = sanitize_text_field( $theme['description'] );
+		$theme['uri']           = sanitize_text_field( $theme['uri'] );
+		$theme['author']        = sanitize_text_field( $theme['author'] );
+		$theme['author_uri']    = sanitize_text_field( $theme['author_uri'] );
+		$theme['tags_custom']   = sanitize_text_field( $theme['tags_custom'] );
+		$theme['image_credits'] = sanitize_textarea_field( $theme['image_credits'] );
 
 		$theme['text_domain'] = $child_theme_slug;
 		$theme['template']    = $parent_theme_slug;
@@ -329,15 +332,16 @@ class Create_Block_Theme_Admin {
 		$theme_slug = Theme_Utils::get_theme_slug( $theme['name'] );
 
 		// Sanitize inputs.
-		$theme['name']        = sanitize_text_field( $theme['name'] );
-		$theme['description'] = sanitize_text_field( $theme['description'] );
-		$theme['uri']         = sanitize_text_field( $theme['uri'] );
-		$theme['author']      = sanitize_text_field( $theme['author'] );
-		$theme['author_uri']  = sanitize_text_field( $theme['author_uri'] );
-		$theme['tags_custom'] = sanitize_text_field( $theme['tags_custom'] );
-		$theme['template']    = '';
-		$theme['slug']        = $theme_slug;
-		$theme['text_domain'] = $theme_slug;
+		$theme['name']          = sanitize_text_field( $theme['name'] );
+		$theme['description']   = sanitize_text_field( $theme['description'] );
+		$theme['uri']           = sanitize_text_field( $theme['uri'] );
+		$theme['author']        = sanitize_text_field( $theme['author'] );
+		$theme['author_uri']    = sanitize_text_field( $theme['author_uri'] );
+		$theme['tags_custom']   = sanitize_text_field( $theme['tags_custom'] );
+		$theme['image_credits'] = sanitize_textarea_field( $theme['image_credits'] );
+		$theme['template']      = '';
+		$theme['slug']          = $theme_slug;
+		$theme['text_domain']   = $theme_slug;
 
 		// Create theme directory.
 		$source           = plugin_dir_path( __DIR__ ) . 'assets/boilerplate';

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -166,6 +166,21 @@ class Theme_Form {
 								<div>
 									<?php Theme_Tags::theme_tags_section(); ?>
 								</div>
+								<br /><br />
+								<label>
+								<?php _e( 'Image Credits:', 'create-block-theme' ); ?><br />
+									<small><?php _e( 'List the credits for each image you have included in the theme. Include the image name, license type, and source URL.', 'create-block-theme' ); ?></small><br />
+									<textarea placeholder="
+									<?php
+									_e(
+										'Image Title
+License Type
+Source: https://source-url.com',
+										'create-block-theme'
+									);
+									?>
+															" rows="4" cols="50" name="theme[image_credits]" class="large-text"></textarea>
+								</label>
 							</div>
 							<input type="hidden" name="page" value="create-block-theme" />
 							<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_block_theme' ); ?>" />

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -164,8 +164,17 @@ class Theme_Form {
 								</label>
 								<br /><br />
 								<label>
-								<?php _e( 'Image Credits:', 'create-block-theme' ); ?><br />
+									<?php _e( 'Image Credits:', 'create-block-theme' ); ?><br />
 									<small><?php _e( 'List the credits for each image you have included in the theme. Include the image name, license type, and source URL.', 'create-block-theme' ); ?></small><br />
+									<small>
+										<?php
+										printf(
+											/* Translators: Bundled resources licenses link. */
+											esc_html__( 'All bundled resources must have GPL-compatible licenses (%s).', 'create-block-theme' ),
+											'<a href="' . esc_url( __( 'https://make.wordpress.org/themes/handbook/review/resources/#licenses-bundled-resources', 'create-block-theme' ) ) . '">read more</a>'
+										);
+										?>
+									</small><br />
 									<?php
 									$image_credits_placeholder = __(
 										'Image Title

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -163,10 +163,6 @@ class Theme_Form {
 									<input type="file" accept=".png"  name="screenshot" id="screenshot" class="upload"/>
 								</label>
 								<br /><br />
-								<div>
-									<?php Theme_Tags::theme_tags_section(); ?>
-								</div>
-								<br /><br />
 								<label>
 								<?php _e( 'Image Credits:', 'create-block-theme' ); ?><br />
 									<small><?php _e( 'List the credits for each image you have included in the theme. Include the image name, license type, and source URL.', 'create-block-theme' ); ?></small><br />
@@ -174,12 +170,16 @@ class Theme_Form {
 									$image_credits_placeholder = __(
 										'Image Title
 License Type
-Source: https://source-url.com',
+Source: https://example.com/source-url',
 										'create-block-theme'
 									);
 									?>
 									<textarea placeholder="<?php echo $image_credits_placeholder; ?>" rows="4" cols="50" name="theme[image_credits]" class="large-text"></textarea>
 								</label>
+								<br /><br />
+								<div>
+									<?php Theme_Tags::theme_tags_section(); ?>
+								</div>
 							</div>
 							<input type="hidden" name="page" value="create-block-theme" />
 							<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'create_block_theme' ); ?>" />

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -170,16 +170,15 @@ class Theme_Form {
 								<label>
 								<?php _e( 'Image Credits:', 'create-block-theme' ); ?><br />
 									<small><?php _e( 'List the credits for each image you have included in the theme. Include the image name, license type, and source URL.', 'create-block-theme' ); ?></small><br />
-									<textarea placeholder="
 									<?php
-									_e(
+									$image_credits_placeholder = __(
 										'Image Title
 License Type
 Source: https://source-url.com',
 										'create-block-theme'
 									);
 									?>
-															" rows="4" cols="50" name="theme[image_credits]" class="large-text"></textarea>
+									<textarea placeholder="<?php echo $image_credits_placeholder; ?>" rows="4" cols="50" name="theme[image_credits]" class="large-text"></textarea>
 								</label>
 							</div>
 							<input type="hidden" name="page" value="create-block-theme" />

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -171,7 +171,7 @@ class Theme_Form {
 										printf(
 											/* Translators: Bundled resources licenses link. */
 											esc_html__( 'All bundled resources must have GPL-compatible licenses (%s).', 'create-block-theme' ),
-											'<a href="' . esc_url( __( 'https://make.wordpress.org/themes/handbook/review/resources/#licenses-bundled-resources', 'create-block-theme' ) ) . '">read more</a>'
+											'<a href="' . esc_url( __( 'https://make.wordpress.org/themes/handbook/review/resources/#licenses-bundled-resources', 'create-block-theme' ) ) . '" target="_blank">read more</a>'
 										);
 										?>
 									</small><br />

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -13,13 +13,18 @@ class Theme_Readme {
 		$author_uri             = $theme['author_uri'];
 		$copy_year              = gmdate( 'Y' );
 		$wp_version             = get_bloginfo( 'version' );
+		$image_credits          = $theme['image_credits'] ?? '';
 		$original_theme         = $theme['original_theme'] ?? '';
 		$original_theme_credits = $original_theme ? self::original_theme_credits( $name ) : '';
 
 		if ( $original_theme_credits ) {
 			// Add a new line to the original theme credits
-			$original_theme_credits = "{$original_theme_credits}
-";
+			$original_theme_credits = $original_theme_credits . "\n";
+		}
+
+		if ( $image_credits ) {
+			// Add new lines around the image credits
+			$image_credits = "\n" . $image_credits . "\n";
 		}
 
 		return "=== {$name} ===
@@ -53,6 +58,7 @@ This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+{$image_credits}
 ";
 	}
 

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -24,7 +24,7 @@ class Theme_Readme {
 
 		if ( $image_credits ) {
 			// Add new lines around the image credits
-			$image_credits = "\n" . $image_credits . "\n";
+			$image_credits = "\n" . 'This theme bundles the following third-party images:' . "\n\n" . $image_credits;
 		}
 
 		return "=== {$name} ===

--- a/admin/create-theme/theme-tags.php
+++ b/admin/create-theme/theme-tags.php
@@ -38,7 +38,7 @@ class Theme_Tags {
 		printf(
 			/* Translators: Theme Tags link. */
 			esc_html__( 'Add theme tags to help categorize the theme (%s).', 'create-block-theme' ),
-			'<a href="' . esc_url( __( 'https://make.wordpress.org/themes/handbook/review/required/theme-tags/', 'create-block-theme' ) ) . '">read more</a>'
+			'<a href="' . esc_url( __( 'https://make.wordpress.org/themes/handbook/review/required/theme-tags/', 'create-block-theme' ) ) . '" target="_blank">read more</a>'
 		);
 		echo '</small><br />';
 		echo '</div>';

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -31,6 +31,7 @@ const ExportTheme = () => {
 		author: '',
 		author_uri: '',
 		tags_custom: '',
+		image_credits: '',
 	} );
 
 	useSelect( ( select ) => {


### PR DESCRIPTION
This PR adds a textarea input for adding image credits to a theme's readme.txt file.

Textarea:
![image](https://github.com/WordPress/create-block-theme/assets/1645628/e409d794-859c-4d24-8ac6-883491f76506)

Readme.txt output:
![image](https://github.com/WordPress/create-block-theme/assets/1645628/486a2f98-6b0b-4ce9-add9-26b78b5ea0e8)

### Testing Instructions
1. Go to the Create Block Theme admin page
2. Create a child theme, clone a theme, or create a blank theme
3. There should be a new textarea near the bottom of the theme metadata form for image credits
4. Try adding some image credits to this textarea
5. When you generate the theme, the image credits content should be added to the end of the readme.txt file