### PR TITLE
Update theme `version` logic to use isset()

### DIFF
--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -67,7 +67,7 @@ Tags: {$tags}
 		$version     = '0.0.1';
 		$tags        = Theme_Tags::theme_tags_list( $theme );
 
-		if ( $theme['version'] ) {
+		if ( isset( $theme['version'] ) ) {
 			$version = $theme['version'];
 		}
 


### PR DESCRIPTION
I was seeing the error, `Undefined index: version`, when creating a zip from the wp-admin pages of the plugin. This PR should fix this error by checking if `version` exists before using the value.