### PR TITLE
Fix double replacement in replace_namespace

### DIFF
--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -30,15 +30,25 @@ class Theme_Utils {
 	}
 
 	public static function replace_namespace( $content, $new_slug, $new_name ) {
-
 		$old_slug            = wp_get_theme()->get( 'TextDomain' );
 		$new_slug_underscore = str_replace( '-', '_', $new_slug );
 		$old_slug_underscore = str_replace( '-', '_', $old_slug );
 		$old_name            = wp_get_theme()->get( 'Name' );
 
-		$content = str_replace( $old_slug, $new_slug, $content );
-		$content = str_replace( $old_slug_underscore, $new_slug_underscore, $content );
-		$content = str_replace( $old_name, $new_name, $content );
+		// Generate placeholders
+		$placeholder_slug            = md5( $old_slug );
+		$placeholder_slug_underscore = md5( $old_slug_underscore );
+		$placeholder_name            = md5( $old_name );
+
+		// Replace old values with placeholders
+		$content = str_replace( $old_slug, $placeholder_slug, $content );
+		$content = str_replace( $old_slug_underscore, $placeholder_slug_underscore, $content );
+		$content = str_replace( $old_name, $placeholder_name, $content );
+
+		// Replace placeholders with new values
+		$content = str_replace( $placeholder_slug, $new_slug, $content );
+		$content = str_replace( $placeholder_slug_underscore, $new_slug_underscore, $content );
+		$content = str_replace( $placeholder_name, $new_name, $content );
 
 		return $content;
 	}


### PR DESCRIPTION
Fixes #387. This PR alters the `replace_namespace` function to use placeholders before performing the actual string replacement. 

When performing multiple replacements in the same string, some of the replacements can result in a string that matches an earlier search pattern. I think this is what's happening in #387.

**To test**
Follow the instructions in 387 on trunk and this PR, verify you don't get duplicated aspects of the old theme slug in the new theme slug.