### PR TITLE
Try: Only run google font update on WordPress repo

### DIFF
--- a/.github/workflows/update-google-fonts-data.yml
+++ b/.github/workflows/update-google-fonts-data.yml
@@ -13,6 +13,7 @@ on:
 jobs:
     # This workflow contains a single job called "update-google-fonts-json"
     update-google-fonts-json:
+        if: github.repository_owner == 'WordPress'
         # The type of runner that the job will run on
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
Checks if the repo triggering the workflow is owned by WordPress; otherwise, skip running it.

Fixes: https://github.com/WordPress/create-block-theme/issues/386

