### PR TITLE
Move check for `download_url` higher up

### DIFF
--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -169,10 +169,6 @@ class Theme_Utils {
 	}
 
 	public static function add_media_to_folder( $location, $media ) {
-		if ( ! function_exists( 'download_url' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-
 		$media = array_unique( $media );
 		foreach ( $media as $url ) {
 			$folder_path   = Theme_Media::get_media_folder_path_from_url( $url );

--- a/admin/create-theme/theme-zip.php
+++ b/admin/create-theme/theme-zip.php
@@ -164,10 +164,6 @@ class Theme_Zip {
 	}
 
 	static function add_media_to_zip( $zip, $media ) {
-		if ( ! function_exists( 'download_url' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-
 		$media = array_unique( $media );
 		foreach ( $media as $url ) {
 			$folder_path   = Theme_Media::get_media_folder_path_from_url( $url );

--- a/create-block-theme.php
+++ b/create-block-theme.php
@@ -18,6 +18,11 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+// Include download_url() if it doesn't exist.
+if ( ! function_exists( 'download_url' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/file.php';
+}
+
 /**
  * The core plugin class.
  */

--- a/create-block-theme.php
+++ b/create-block-theme.php
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-// Include download_url() if it doesn't exist.
+// Include file with download_url() if function doesn't exist.
 if ( ! function_exists( 'download_url' ) ) {
 	require_once ABSPATH . 'wp-admin/includes/file.php';
 }


### PR DESCRIPTION
This moves the check for `download_url` into the main plugin file, `create-block-theme.php`. This means we shouldn't need to repeat this check whenever the `download_url()` function is called.

Partly addresses a comment from another issue: https://github.com/WordPress/create-block-theme/issues/395#issuecomment-1590535195