### PR TITLE
Avoid white spaces or other weird characters on font asset paths.

### DIFF
--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -160,7 +160,7 @@ class Manage_Fonts_Admin {
 			) {
 				$font_slug      = sanitize_title( $_POST['font-name'] );
 				$file_extension = pathinfo( $_FILES['font-file']['name'], PATHINFO_EXTENSION );
-				$file_name      = $font_slug . '_' . $_POST['font-style'] . '_' . $_POST['font-weight'] . '.' . $file_extension;
+				$file_name      = sanitize_title( $font_slug . '_' . $_POST['font-style'] . '_' . $_POST['font-weight'] . '.' . $file_extension );
 
 				move_uploaded_file( $_FILES['font-file']['tmp_name'], get_stylesheet_directory() . '/assets/fonts/' . $file_name );
 
@@ -216,7 +216,7 @@ class Manage_Fonts_Admin {
 				foreach ( $variants as $variant ) {
 					// variant name is $variant_and_url[0] and font asset url is $variant_and_url[1]
 					$file_extension = pathinfo( $variant['src'], PATHINFO_EXTENSION );
-					$file_name      = $font_slug . '_' . $variant['style'] . '_' . $variant['weight'] . '.' . $file_extension;
+					$file_name      = sanitize_title( $font_slug . '_' . $variant['style'] . '_' . $variant['weight'] . '.' . $file_extension );
 
 					// Download font asset in temp folder
 					$temp_file = download_url( $variant['src'] );

--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -160,7 +160,7 @@ class Manage_Fonts_Admin {
 			) {
 				$font_slug      = sanitize_title( $_POST['font-name'] );
 				$file_extension = pathinfo( $_FILES['font-file']['name'], PATHINFO_EXTENSION );
-				$file_name      = sanitize_title( $font_slug . '_' . $_POST['font-style'] . '_' . $_POST['font-weight'] . '.' . $file_extension );
+				$file_name      = sanitize_title( $font_slug . '_' . $_POST['font-style'] . '_' . $_POST['font-weight'] ) . '.' . $file_extension;
 
 				move_uploaded_file( $_FILES['font-file']['tmp_name'], get_stylesheet_directory() . '/assets/fonts/' . $file_name );
 
@@ -216,7 +216,7 @@ class Manage_Fonts_Admin {
 				foreach ( $variants as $variant ) {
 					// variant name is $variant_and_url[0] and font asset url is $variant_and_url[1]
 					$file_extension = pathinfo( $variant['src'], PATHINFO_EXTENSION );
-					$file_name      = sanitize_title( $font_slug . '_' . $variant['style'] . '_' . $variant['weight'] . '.' . $file_extension );
+					$file_name      = sanitize_title( $font_slug . '_' . $variant['style'] . '_' . $variant['weight'] ) . '.' . $file_extension;
 
 					// Download font asset in temp folder
 					$temp_file = download_url( $variant['src'] );


### PR DESCRIPTION
## What ?
If you upload a font with spaces in any of the components that end up in the file name of the font asset the resulting font URL has a space and that causes problems.

**For example:** if you upload a variable font with a font weight of "100 900", the resulting font path in theme.json would be `font-name_normal_100 900.ttf` and that can be problematic.

With this change, we would have `font-name_normal_100-900.ttf`.


## How to test:
1. Upload a font with variable width. Example: [Literata variable](https://drive.google.com/file/d/1kPE9nLUOsaQlOrB_ueqOhgAUQkiRnQx8/view?usp=drive_link) (external link because GitHub doesn't allow ttf files).
2. Test that the font asset filename and font path in theme.json don't have white spaces.