### PR TITLE
Add "Recommended Plugins" input box

### DIFF
--- a/admin/class-create-theme.php
+++ b/admin/class-create-theme.php
@@ -103,16 +103,17 @@ class Create_Block_Theme_Admin {
 		$theme_slug = Theme_Utils::get_theme_slug( $theme['name'] );
 
 		// Sanitize inputs.
-		$theme['name']          = sanitize_text_field( $theme['name'] );
-		$theme['description']   = sanitize_text_field( $theme['description'] );
-		$theme['uri']           = sanitize_text_field( $theme['uri'] );
-		$theme['author']        = sanitize_text_field( $theme['author'] );
-		$theme['author_uri']    = sanitize_text_field( $theme['author_uri'] );
-		$theme['tags_custom']   = sanitize_text_field( $theme['tags_custom'] );
-		$theme['image_credits'] = sanitize_textarea_field( $theme['image_credits'] );
-		$theme['slug']          = $theme_slug;
-		$theme['template']      = wp_get_theme()->get( 'Template' );
-		$theme['text_domain']   = $theme_slug;
+		$theme['name']                = sanitize_text_field( $theme['name'] );
+		$theme['description']         = sanitize_text_field( $theme['description'] );
+		$theme['uri']                 = sanitize_text_field( $theme['uri'] );
+		$theme['author']              = sanitize_text_field( $theme['author'] );
+		$theme['author_uri']          = sanitize_text_field( $theme['author_uri'] );
+		$theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
+		$theme['image_credits']       = sanitize_textarea_field( $theme['image_credits'] );
+		$theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
+		$theme['slug']                = $theme_slug;
+		$theme['template']            = wp_get_theme()->get( 'Template' );
+		$theme['text_domain']         = $theme_slug;
 
 		// Create ZIP file in the temporary directory.
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
@@ -164,17 +165,18 @@ class Create_Block_Theme_Admin {
 		$theme_slug = Theme_Utils::get_theme_slug( $theme['name'] );
 
 		// Sanitize inputs.
-		$theme['name']           = sanitize_text_field( $theme['name'] );
-		$theme['description']    = sanitize_text_field( $theme['description'] );
-		$theme['uri']            = sanitize_text_field( $theme['uri'] );
-		$theme['author']         = sanitize_text_field( $theme['author'] );
-		$theme['author_uri']     = sanitize_text_field( $theme['author_uri'] );
-		$theme['tags_custom']    = sanitize_text_field( $theme['tags_custom'] );
-		$theme['image_credits']  = sanitize_textarea_field( $theme['image_credits'] );
-		$theme['slug']           = $theme_slug;
-		$theme['template']       = '';
-		$theme['original_theme'] = wp_get_theme()->get( 'Name' );
-		$theme['text_domain']    = $theme_slug;
+		$theme['name']                = sanitize_text_field( $theme['name'] );
+		$theme['description']         = sanitize_text_field( $theme['description'] );
+		$theme['uri']                 = sanitize_text_field( $theme['uri'] );
+		$theme['author']              = sanitize_text_field( $theme['author'] );
+		$theme['author_uri']          = sanitize_text_field( $theme['author_uri'] );
+		$theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
+		$theme['image_credits']       = sanitize_textarea_field( $theme['image_credits'] );
+		$theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
+		$theme['slug']                = $theme_slug;
+		$theme['template']            = '';
+		$theme['original_theme']      = wp_get_theme()->get( 'Name' );
+		$theme['text_domain']         = $theme_slug;
 
 		// Use previous theme's tags if custom tags are empty.
 		if ( empty( $theme['tags_custom'] ) ) {
@@ -235,17 +237,18 @@ class Create_Block_Theme_Admin {
 		$child_theme_slug  = Theme_Utils::get_theme_slug( $theme['name'] );
 
 		// Sanitize inputs.
-		$theme['name']            = sanitize_text_field( $theme['name'] );
-		$theme['description']     = sanitize_text_field( $theme['description'] );
-		$theme['uri']             = sanitize_text_field( $theme['uri'] );
-		$theme['author']          = sanitize_text_field( $theme['author'] );
-		$theme['author_uri']      = sanitize_text_field( $theme['author_uri'] );
-		$theme['tags_custom']     = sanitize_text_field( $theme['tags_custom'] );
-		$theme['image_credits']   = sanitize_textarea_field( $theme['image_credits'] );
-		$theme['is_parent_theme'] = true;
-		$theme['text_domain']     = $child_theme_slug;
-		$theme['template']        = $parent_theme_slug;
-		$theme['slug']            = $child_theme_slug;
+		$theme['name']                = sanitize_text_field( $theme['name'] );
+		$theme['description']         = sanitize_text_field( $theme['description'] );
+		$theme['uri']                 = sanitize_text_field( $theme['uri'] );
+		$theme['author']              = sanitize_text_field( $theme['author'] );
+		$theme['author_uri']          = sanitize_text_field( $theme['author_uri'] );
+		$theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
+		$theme['image_credits']       = sanitize_textarea_field( $theme['image_credits'] );
+		$theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
+		$theme['is_parent_theme']     = true;
+		$theme['text_domain']         = $child_theme_slug;
+		$theme['template']            = $parent_theme_slug;
+		$theme['slug']                = $child_theme_slug;
 
 		// Create ZIP file in the temporary directory.
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
@@ -312,16 +315,17 @@ class Create_Block_Theme_Admin {
 		$theme_slug = Theme_Utils::get_theme_slug( $theme['name'] );
 
 		// Sanitize inputs.
-		$theme['name']          = sanitize_text_field( $theme['name'] );
-		$theme['description']   = sanitize_text_field( $theme['description'] );
-		$theme['uri']           = sanitize_text_field( $theme['uri'] );
-		$theme['author']        = sanitize_text_field( $theme['author'] );
-		$theme['author_uri']    = sanitize_text_field( $theme['author_uri'] );
-		$theme['tags_custom']   = sanitize_text_field( $theme['tags_custom'] );
-		$theme['image_credits'] = sanitize_textarea_field( $theme['image_credits'] );
-		$theme['template']      = '';
-		$theme['slug']          = $theme_slug;
-		$theme['text_domain']   = $theme_slug;
+		$theme['name']                = sanitize_text_field( $theme['name'] );
+		$theme['description']         = sanitize_text_field( $theme['description'] );
+		$theme['uri']                 = sanitize_text_field( $theme['uri'] );
+		$theme['author']              = sanitize_text_field( $theme['author'] );
+		$theme['author_uri']          = sanitize_text_field( $theme['author_uri'] );
+		$theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
+		$theme['image_credits']       = sanitize_textarea_field( $theme['image_credits'] );
+		$theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
+		$theme['template']            = '';
+		$theme['slug']                = $theme_slug;
+		$theme['text_domain']         = $theme_slug;
 
 		// Create theme directory.
 		$source           = plugin_dir_path( __DIR__ ) . 'assets/boilerplate';

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -163,7 +163,7 @@ class Theme_Form {
 									<input type="file" accept=".png"  name="screenshot" id="screenshot" class="upload"/>
 								</label>
 								<br /><br />
-								<label id="image_credits_input">
+								<label class="hide-on-blank-theme">
 									<?php _e( 'Image Credits:', 'create-block-theme' ); ?><br />
 									<small><?php _e( 'List the credits for each image you have included in the theme. Include the image name, license type, and source URL.', 'create-block-theme' ); ?></small><br />
 									<small>
@@ -186,8 +186,7 @@ Source: https://example.com/source-url',
 									<textarea placeholder="<?php echo $image_credits_placeholder; ?>" rows="4" cols="50" name="theme[image_credits]" class="large-text"></textarea>
 									<br /><br />
 								</label>
-								<br /><br />
-								<label id="recommended_plugins_input">
+								<label class="hide-on-blank-theme">
 									<?php _e( 'Recommended Plugins:', 'create-block-theme' ); ?><br />
 									<small>
 										<?php

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -186,6 +186,21 @@ Source: https://example.com/source-url',
 									<textarea placeholder="<?php echo $image_credits_placeholder; ?>" rows="4" cols="50" name="theme[image_credits]" class="large-text"></textarea>
 									<br /><br />
 								</label>
+								<br /><br />
+								<label id="recommended_plugins_input">
+									<?php _e( 'Recommended Plugins:', 'create-block-theme' ); ?><br />
+									<small>
+										<?php
+										printf(
+											/* Translators: Recommended plugins link. */
+											esc_html__( 'List the recommended plugins for this theme. e.g. contact forms, social media. Plugins must be from the WordPress.org plugin repository (%s).', 'create-block-theme' ),
+											'<a href="' . esc_url( __( 'https://make.wordpress.org/themes/handbook/review/resources/#licenses-bundled-resources', 'create-block-theme' ) ) . '" target="_blank">read more</a>'
+										);
+										?>
+									</small><br />
+									<textarea rows="4" cols="50" name="theme[recommended_plugins]" class="large-text"></textarea>
+									<br /><br />
+								</label>
 								<div>
 									<?php Theme_Tags::theme_tags_section(); ?>
 								</div>

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -197,7 +197,15 @@ Source: https://example.com/source-url',
 										);
 										?>
 									</small><br />
-									<textarea rows="4" cols="50" name="theme[recommended_plugins]" class="large-text"></textarea>
+									<?php
+									$recommended_plugins_placeholder = __(
+										'Plugin Name
+https://wordpress.org/plugins/plugin-name/
+Plugin Description',
+										'create-block-theme'
+									);
+									?>
+									<textarea placeholder="<?php echo $recommended_plugins_placeholder; ?>" rows="4" cols="50" name="theme[recommended_plugins]" class="large-text"></textarea>
 									<br /><br />
 								</label>
 								<div>

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -193,7 +193,7 @@ Source: https://example.com/source-url',
 										printf(
 											/* Translators: Recommended plugins link. */
 											esc_html__( 'List the recommended plugins for this theme. e.g. contact forms, social media. Plugins must be from the WordPress.org plugin repository (%s).', 'create-block-theme' ),
-											'<a href="' . esc_url( __( 'https://make.wordpress.org/themes/handbook/review/resources/#licenses-bundled-resources', 'create-block-theme' ) ) . '" target="_blank">read more</a>'
+											'<a href="' . esc_url( __( 'https://make.wordpress.org/themes/handbook/review/required/#6-plugins', 'create-block-theme' ) ) . '" target="_blank">read more</a>'
 										);
 										?>
 									</small><br />

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -188,7 +188,7 @@ GNU General Public License for more details.";
 
 		// Remove existing Recommended Plugins section.
 		if ( $updated_readme && str_contains( $updated_readme, $section_start ) ) {
-			$pattern = '/\s+== Recommended Plugins ==\s+(.*?)(\s+==|$)/s';
+			$pattern = '/\s+== Recommended Plugins ==\s+(.*?)(?=(\n\=\=)|$)/s';
 			preg_match_all( $pattern, $updated_readme, $matches );
 			$current_section = $matches[0][0];
 			$updated_readme  = str_replace( $current_section, '', $updated_readme );

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -184,12 +184,11 @@ GNU General Public License for more details.";
 			return '';
 		}
 
-		$section_start = '
-== Recommended Plugins ==
-';
+		$section_start = "\n== Recommended Plugins ==\n";
+
 		// Remove existing Recommended Plugins section.
 		if ( $updated_readme && str_contains( $updated_readme, $section_start ) ) {
-			$pattern = '/== Recommended Plugins ==\s+(.*?)(\s+==|$)/s';
+			$pattern = '/\s+== Recommended Plugins ==\s+(.*?)(\s+==|$)/s';
 			preg_match_all( $pattern, $updated_readme, $matches );
 			$current_section = $matches[0][0];
 			$updated_readme  = str_replace( $current_section, '', $updated_readme );

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -186,19 +186,16 @@ GNU General Public License for more details.";
 
 		$section_start = '
 == Recommended Plugins ==
-
-The following plugins are recommended for use with this theme:';
-		$section_end   = "(End of Recommended Plugins)\n";
-
+';
 		// Remove existing Recommended Plugins section.
 		if ( $updated_readme && str_contains( $updated_readme, $section_start ) ) {
-			$pattern = '/(' . preg_quote( $section_start, '/' ) . ')(.*?)((' . preg_quote( $section_end, '/' ) . ')|$)/s';
+			$pattern = '/== Recommended Plugins ==\s+(.*?)(\s+==|$)/s';
 			preg_match_all( $pattern, $updated_readme, $matches );
 			$current_section = $matches[0][0];
 			$updated_readme  = str_replace( $current_section, '', $updated_readme );
 		}
 
-		$recommended_plugins_section = $section_start . "\n\n" . $recommended_plugins . "\n\n" . $section_end;
+		$recommended_plugins_section = $section_start . "\n\n" . $recommended_plugins . "\n\n";
 
 		if ( $updated_readme ) {
 			return $updated_readme . $recommended_plugins_section;

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -195,7 +195,7 @@ GNU General Public License for more details.";
 			$updated_readme  = str_replace( $current_section, '', $updated_readme );
 		}
 
-		$recommended_plugins_section = $section_start . "\n\n" . $recommended_plugins . "\n\n";
+		$recommended_plugins_section = $section_start . "\n" . $recommended_plugins . "\n";
 
 		if ( $updated_readme ) {
 			return $updated_readme . $recommended_plugins_section;

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -24,7 +24,9 @@ class Theme_Readme {
 		$copyright_section      = self::copyright_section( $new_copyright_section, $original_theme_credits, $name, $copy_year, $author, $image_credits );
 
 		// Handle recommended plugins section.
-		$recommended_plugins_section = self::recommended_plugins_section( $recommended_plugins );
+		if ( $recommended_plugins ) {
+			$recommended_plugins_section = self::recommended_plugins_section( $recommended_plugins );
+		}
 
 		// Handle updating current theme.
 		if ( $update_current_theme ) {

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -4,7 +4,7 @@ class Theme_Readme {
 	/**
 	* Build a readme.txt file for CHILD/GRANDCHILD themes.
 	*/
-	public static function build_readme_txt( $theme, $update_current_theme = false ) {
+	public static function build_readme_txt( $theme ) {
 		$slug                = $theme['slug'];
 		$name                = $theme['name'];
 		$description         = $theme['description'];
@@ -26,12 +26,6 @@ class Theme_Readme {
 		// Handle recommended plugins section.
 		if ( $recommended_plugins ) {
 			$recommended_plugins_section = self::recommended_plugins_section( $recommended_plugins );
-		}
-
-		// Handle updating current theme.
-		if ( $update_current_theme ) {
-			$updated_readme = self::update_readme( $image_credits, $recommended_plugins );
-			return $updated_readme;
 		}
 
 		return "=== {$name} ===
@@ -218,11 +212,12 @@ The following plugins are recommended for use with this theme:';
 	 *
 	 * @return string
 	 */
-	static function update_readme( $image_credits, $recommended_plugins ) {
-		$updated_readme = '';
-
-		$current_readme = get_stylesheet_directory() . '/readme.txt' ?? '';
-		$readme_content = file_exists( $current_readme ) ? file_get_contents( $current_readme ) : '';
+	public static function update_readme_txt( $theme ) {
+		$image_credits       = $theme['image_credits'] ?? '';
+		$recommended_plugins = $theme['recommended_plugins'] ?? '';
+		$updated_readme      = '';
+		$current_readme      = get_stylesheet_directory() . '/readme.txt' ?? '';
+		$readme_content      = file_exists( $current_readme ) ? file_get_contents( $current_readme ) : '';
 
 		if ( ! $readme_content ) {
 			return;

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -14,10 +14,19 @@ class Theme_Readme {
 		$copy_year              = gmdate( 'Y' );
 		$wp_version             = get_bloginfo( 'version' );
 		$image_credits          = $theme['image_credits'] ?? '';
+		$recommended_plugins    = $theme['recommended_plugins'] ?? '';
 		$is_parent_theme        = $theme['is_parent_theme'] ?? false;
 		$original_theme         = $theme['original_theme'] ?? '';
 		$new_copyright_section  = $is_parent_theme || $original_theme ? true : false;
 		$original_theme_credits = $new_copyright_section ? self::original_theme_credits( $name, $is_parent_theme ) : '';
+
+		$recommended_plugins_section = $recommended_plugins ? "
+== Recommended Plugins ==
+
+The following plugins are recommended for use with this theme:
+
+{$recommended_plugins}
+" : '';
 
 		$default_copyright_section = "== Copyright ==
 
@@ -52,7 +61,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 = 0.0.1 =
 * Initial release
-
+{$recommended_plugins_section}
 {$copyright_section}
 ";
 	}

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -213,6 +213,9 @@ The following plugins are recommended for use with this theme:';
 	 * @return string
 	 */
 	public static function update_readme_txt( $theme ) {
+		$description         = $theme['description'];
+		$author              = $theme['author'];
+		$wp_version          = get_bloginfo( 'version' );
 		$image_credits       = $theme['image_credits'] ?? '';
 		$recommended_plugins = $theme['recommended_plugins'] ?? '';
 		$updated_readme      = '';
@@ -224,6 +227,30 @@ The following plugins are recommended for use with this theme:';
 		}
 
 		$updated_readme = $readme_content;
+
+		// Update description.
+		if ( $description ) {
+			$pattern = '/(== Description ==)(.*?)(\n\n=|$)/s';
+			preg_match_all( $pattern, $updated_readme, $matches );
+			$current_description = $matches[0][0];
+			$updated_readme      = str_replace( $current_description, "== Description ==\n\n{$description}\n\n=", $updated_readme );
+		}
+
+		// Update Author/Contributors.
+		if ( $author ) {
+			$pattern = '/(Contributors:)(.*?)(\n|$)/s';
+			preg_match_all( $pattern, $updated_readme, $matches );
+			$current_uri    = $matches[0][0];
+			$updated_readme = str_replace( $current_uri, "Contributors: {$author}\n", $updated_readme );
+		}
+
+		// Update "Tested up to" version.
+		if ( $wp_version ) {
+			$pattern = '/(Tested up to:)(.*?)(\n|$)/s';
+			preg_match_all( $pattern, $updated_readme, $matches );
+			$current_uri    = $matches[0][0];
+			$updated_readme = str_replace( $current_uri, "Tested up to: {$wp_version}\n", $updated_readme );
+		}
 
 		if ( $recommended_plugins ) {
 			$updated_readme = self::recommended_plugins_section( $recommended_plugins, $updated_readme );

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -170,7 +170,7 @@ GNU General Public License for more details.";
 		}
 
 		if ( $image_credits ) {
-			$copyright_section = $copyright_section . "\n\n" . $image_credits;
+			$copyright_section = $copyright_section . "\n" . $image_credits;
 		}
 
 		return $copyright_section;
@@ -192,7 +192,7 @@ GNU General Public License for more details.";
 == Recommended Plugins ==
 
 The following plugins are recommended for use with this theme:';
-		$section_end   = '(End of Recommended Plugins)';
+		$section_end   = "(End of Recommended Plugins)\n";
 
 		// Remove existing Recommended Plugins section.
 		if ( $updated_readme && str_contains( $updated_readme, $section_start ) ) {
@@ -228,12 +228,12 @@ The following plugins are recommended for use with this theme:';
 
 		$updated_readme = $readme_content;
 
-		if ( $image_credits ) {
-			$updated_readme = $updated_readme . "\n\n" . $image_credits;
-		}
-
 		if ( $recommended_plugins ) {
 			$updated_readme = self::recommended_plugins_section( $recommended_plugins, $updated_readme );
+		}
+
+		if ( $image_credits ) {
+			$updated_readme = $updated_readme . "\n\n" . $image_credits;
 		}
 
 		return $updated_readme;

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -170,7 +170,7 @@ GNU General Public License for more details.";
 		}
 
 		if ( $image_credits ) {
-			$copyright_section = $copyright_section . "\n" . $image_credits;
+			$copyright_section = $copyright_section . "\n\n" . $image_credits;
 		}
 
 		return $copyright_section;
@@ -229,7 +229,7 @@ The following plugins are recommended for use with this theme:';
 		$updated_readme = $readme_content;
 
 		if ( $image_credits ) {
-			$updated_readme = $updated_readme . "\n" . $image_credits;
+			$updated_readme = $updated_readme . "\n\n" . $image_credits;
 		}
 
 		if ( $recommended_plugins ) {

--- a/admin/create-theme/theme-tags.php
+++ b/admin/create-theme/theme-tags.php
@@ -7,7 +7,7 @@
 
 class Theme_Tags {
 	/**
-	 * Build theme tags list for readme.txt.
+	 * Build theme tags list for style.css.
 	 *
 	 * @param array $theme Theme data.
 	 * @return string

--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -183,5 +183,23 @@ class Theme_Utils {
 		}
 	}
 
+	public static function get_readme_data() {
+		$readme_location = get_template_directory() . '/readme.txt';
+
+		if ( ! file_exists( $readme_location ) ) {
+			throw new Exception( 'No readme file found' );
+		}
+
+		$readme_file_contents = file_get_contents( $readme_location );
+
+		$readme_file_details = array();
+
+		$pattern = '/== Recommended Plugins ==\s+(.*?)(\s+==|$)/s';
+		preg_match_all( $pattern, $readme_file_contents, $matches );
+		$readme_file_details['recommendedPlugins'] = $matches[1][0];
+
+		return $readme_file_details;
+
+	}
 
 }

--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -194,6 +194,7 @@ class Theme_Utils {
 
 		$readme_file_details = array();
 
+		// Handle Recommended Plugins.
 		$pattern = '/== Recommended Plugins ==\s+(.*?)(\s+==|$)/s';
 		preg_match_all( $pattern, $readme_file_contents, $matches );
 		$readme_file_details['recommendedPlugins'] = $matches[1][0] ?? '';

--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -196,7 +196,7 @@ class Theme_Utils {
 
 		$pattern = '/== Recommended Plugins ==\s+(.*?)(\s+==|$)/s';
 		preg_match_all( $pattern, $readme_file_contents, $matches );
-		$readme_file_details['recommendedPlugins'] = $matches[1][0];
+		$readme_file_details['recommendedPlugins'] = $matches[1][0] ?? '';
 
 		return $readme_file_details;
 

--- a/admin/js/form-script.js
+++ b/admin/js/form-script.js
@@ -6,11 +6,7 @@ function toggleForm( element ) {
 	if ( ! element?.value ) return;
 	const themeType = element.value;
 
-	const imageCreditsInput = document.getElementById( 'image_credits_input' );
-	if ( imageCreditsInput ) {
-		imageCreditsInput.toggleAttribute( 'hidden', false );
-	}
-
+	toggleInputsOnBlankTheme();
 	hideAllForms();
 
 	switch ( themeType ) {
@@ -39,10 +35,7 @@ function toggleForm( element ) {
 				.getElementById( 'new_theme_metadata_form' )
 				.toggleAttribute( 'hidden', false );
 
-			if ( imageCreditsInput ) {
-				imageCreditsInput.toggleAttribute( 'hidden', true );
-			}
-
+			toggleInputsOnBlankTheme( true );
 			resetThemeTags( element.value );
 			validateThemeTags( 'subject' );
 			break;
@@ -56,6 +49,16 @@ function toggleForm( element ) {
 
 		default:
 			break;
+	}
+}
+
+function toggleInputsOnBlankTheme( isHidden = false ) {
+	const inputsHiddenOnBlankTheme = document.getElementsByClassName(
+		'hide-on-blank-theme'
+	);
+
+	for ( let i = 0; i < inputsHiddenOnBlankTheme.length; i++ ) {
+		inputsHiddenOnBlankTheme[ i ].toggleAttribute( 'hidden', isHidden );
 	}
 }
 

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -97,15 +97,16 @@ class Create_Block_Theme_API {
 		$theme_slug = Theme_Utils::get_theme_slug( $theme['name'] );
 
 		// Sanitize inputs.
-		$theme['name']        = sanitize_text_field( $theme['name'] );
-		$theme['description'] = sanitize_text_field( $theme['description'] );
-		$theme['uri']         = sanitize_text_field( $theme['uri'] );
-		$theme['author']      = sanitize_text_field( $theme['author'] );
-		$theme['author_uri']  = sanitize_text_field( $theme['author_uri'] );
-		$theme['tags_custom'] = sanitize_text_field( $theme['tags_custom'] );
-		$theme['template']    = '';
-		$theme['slug']        = $theme_slug;
-		$theme['text_domain'] = $theme_slug;
+		$theme['name']                = sanitize_text_field( $theme['name'] );
+		$theme['description']         = sanitize_text_field( $theme['description'] );
+		$theme['uri']                 = sanitize_text_field( $theme['uri'] );
+		$theme['author']              = sanitize_text_field( $theme['author'] );
+		$theme['author_uri']          = sanitize_text_field( $theme['author_uri'] );
+		$theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
+		$theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
+		$theme['template']            = '';
+		$theme['slug']                = $theme_slug;
+		$theme['text_domain']         = $theme_slug;
 
 		// Create theme directory.
 		$source         = get_stylesheet_directory();
@@ -239,16 +240,17 @@ class Create_Block_Theme_API {
 		$theme_slug = Theme_Utils::get_theme_slug( $theme['name'] );
 
 		// Sanitize inputs.
-		$theme['name']           = sanitize_text_field( $theme['name'] );
-		$theme['description']    = sanitize_text_field( $theme['description'] );
-		$theme['uri']            = sanitize_text_field( $theme['uri'] );
-		$theme['author']         = sanitize_text_field( $theme['author'] );
-		$theme['author_uri']     = sanitize_text_field( $theme['author_uri'] );
-		$theme['tags_custom']    = sanitize_text_field( $theme['tags_custom'] );
-		$theme['slug']           = $theme_slug;
-		$theme['template']       = '';
-		$theme['original_theme'] = wp_get_theme()->get( 'Name' );
-		$theme['text_domain']    = $theme_slug;
+		$theme['name']                = sanitize_text_field( $theme['name'] );
+		$theme['description']         = sanitize_text_field( $theme['description'] );
+		$theme['uri']                 = sanitize_text_field( $theme['uri'] );
+		$theme['author']              = sanitize_text_field( $theme['author'] );
+		$theme['author_uri']          = sanitize_text_field( $theme['author_uri'] );
+		$theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
+		$theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
+		$theme['slug']                = $theme_slug;
+		$theme['template']            = '';
+		$theme['original_theme']      = wp_get_theme()->get( 'Name' );
+		$theme['text_domain']         = $theme_slug;
 
 		// Use previous theme's tags if custom tags are empty.
 		if ( empty( $theme['tags_custom'] ) ) {

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -86,6 +86,37 @@ class Create_Block_Theme_API {
 				},
 			)
 		);
+		register_rest_route(
+			'create-block-theme/v1',
+			'/get-readme-data',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'rest_get_readme_data' ),
+				'permission_callback' => function () {
+					return current_user_can( 'edit_theme_options' );
+				},
+			)
+		);
+	}
+
+	function rest_get_readme_data( $request ) {
+		try {
+			$readme_data = Theme_Utils::get_readme_data();
+			return new WP_REST_Response(
+				array(
+					'status'  => 'SUCCESS',
+					'message' => __( 'Cloned Theme Created.', 'create-block-theme' ),
+					'data'    => $readme_data,
+				)
+			);
+		} catch ( Exception $error ) {
+			return new WP_REST_Response(
+				array(
+					'status'  => 'FAILURE',
+					'message' => __( 'No Readme File', 'create-block-theme' ),
+				)
+			);
+		}
 	}
 
 	function rest_clone_theme( $request ) {

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -379,7 +379,7 @@ class Create_Block_Theme_API {
 		file_put_contents( get_stylesheet_directory() . '/style.css', $style_css );
 		file_put_contents(
 			get_stylesheet_directory() . '/readme.txt',
-			Theme_Readme::build_readme_txt( $theme, true )
+			Theme_Readme::update_readme_txt( $theme )
 		);
 	}
 

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -113,7 +113,7 @@ class Create_Block_Theme_API {
 			return new WP_REST_Response(
 				array(
 					'status'  => 'FAILURE',
-					'message' => __( 'No Readme File', 'create-block-theme' ),
+					'message' => $error->getMessage(),
 				)
 			);
 		}

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -371,12 +371,16 @@ class Create_Block_Theme_API {
 	}
 
 	/**
-	 * Update the theme metadata in the style.css file.
+	 * Update the theme metadata in the style.css and readme.txt files.
 	 */
 	function update_theme_metadata( $theme ) {
 		$style_css = file_get_contents( get_stylesheet_directory() . '/style.css' );
 		$style_css = Theme_Styles::update_style_css( $style_css, $theme );
 		file_put_contents( get_stylesheet_directory() . '/style.css', $style_css );
+		file_put_contents(
+			get_stylesheet_directory() . '/readme.txt',
+			Theme_Readme::build_readme_txt( $theme, true )
+		);
 	}
 
 	/**

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -105,7 +105,7 @@ class Create_Block_Theme_API {
 			return new WP_REST_Response(
 				array(
 					'status'  => 'SUCCESS',
-					'message' => __( 'Cloned Theme Created.', 'create-block-theme' ),
+					'message' => __( 'Readme file data retrieved.', 'create-block-theme' ),
 					'data'    => $readme_data,
 				)
 			);

--- a/src/editor-sidebar/create-panel.js
+++ b/src/editor-sidebar/create-panel.js
@@ -19,7 +19,6 @@ import {
 	Button,
 	TextControl,
 	TextareaControl,
-	ExternalLink,
 } from '@wordpress/components';
 import { chevronLeft, addCard, download, copy } from '@wordpress/icons';
 
@@ -33,7 +32,6 @@ export const CreateThemePanel = () => {
 		author: '',
 		author_uri: '',
 		tags_custom: '',
-		recommended_plugins: '',
 	} );
 
 	useSelect( ( select ) => {
@@ -209,24 +207,6 @@ export const CreateThemePanel = () => {
 						'https://wordpress.org/',
 						'create-block-theme'
 					) }
-				/>
-				<TextareaControl
-					label={ __( 'Recommended Plugins', 'create-block-theme' ) }
-					help={
-						<>
-							{ __(
-								'List the recommended plugins for this theme. e.g. contact forms, social media. Plugins must be from the WordPress.org plugin repository.'
-							) }
-							<br />
-							<ExternalLink href="https://make.wordpress.org/themes/handbook/review/required/#6-plugins">
-								{ __( 'Read more.' ) }
-							</ExternalLink>
-						</>
-					}
-					value={ theme.recommended_plugins }
-					onChange={ ( value ) =>
-						setTheme( { ...theme, recommended_plugins: value } )
-					}
 				/>
 				<TextControl
 					label={ __( 'Theme Subfolder', 'create-block-theme' ) }

--- a/src/editor-sidebar/create-panel.js
+++ b/src/editor-sidebar/create-panel.js
@@ -218,7 +218,7 @@ export const CreateThemePanel = () => {
 								'List the recommended plugins for this theme. e.g. contact forms, social media. Plugins must be from the WordPress.org plugin repository.'
 							) }
 							<br />
-							<ExternalLink href="https://make.wordpress.org/themes/handbook/review/resources/#licenses-bundled-resources">
+							<ExternalLink href="https://make.wordpress.org/themes/handbook/review/required/#6-plugins">
 								{ __( 'Read more.' ) }
 							</ExternalLink>
 						</>

--- a/src/editor-sidebar/create-panel.js
+++ b/src/editor-sidebar/create-panel.js
@@ -19,6 +19,7 @@ import {
 	Button,
 	TextControl,
 	TextareaControl,
+	ExternalLink,
 } from '@wordpress/components';
 import { chevronLeft, addCard, download, copy } from '@wordpress/icons';
 
@@ -32,6 +33,7 @@ export const CreateThemePanel = () => {
 		author: '',
 		author_uri: '',
 		tags_custom: '',
+		recommended_plugins: '',
 	} );
 
 	useSelect( ( select ) => {
@@ -207,6 +209,24 @@ export const CreateThemePanel = () => {
 						'https://wordpress.org/',
 						'create-block-theme'
 					) }
+				/>
+				<TextareaControl
+					label={ __( 'Recommended Plugins', 'create-block-theme' ) }
+					help={
+						<>
+							{ __(
+								'List the recommended plugins for this theme. e.g. contact forms, social media. Plugins must be from the WordPress.org plugin repository.'
+							) }
+							<br />
+							<ExternalLink href="https://make.wordpress.org/themes/handbook/review/resources/#licenses-bundled-resources">
+								{ __( 'Read more.' ) }
+							</ExternalLink>
+						</>
+					}
+					value={ theme.recommended_plugins }
+					onChange={ ( value ) =>
+						setTheme( { ...theme, recommended_plugins: value } )
+					}
 				/>
 				<TextControl
 					label={ __( 'Theme Subfolder', 'create-block-theme' ) }

--- a/src/editor-sidebar/update-panel.js
+++ b/src/editor-sidebar/update-panel.js
@@ -181,7 +181,7 @@ export const UpdateThemePanel = () => {
 								'List the recommended plugins for this theme. e.g. contact forms, social media. Plugins must be from the WordPress.org plugin repository.'
 							) }
 							<br />
-							<ExternalLink href="https://make.wordpress.org/themes/handbook/review/resources/#licenses-bundled-resources">
+							<ExternalLink href="https://make.wordpress.org/themes/handbook/review/required/#6-plugins">
 								{ __( 'Read more.' ) }
 							</ExternalLink>
 						</>

--- a/src/editor-sidebar/update-panel.js
+++ b/src/editor-sidebar/update-panel.js
@@ -18,6 +18,7 @@ import {
 	Button,
 	TextControl,
 	TextareaControl,
+	ExternalLink,
 } from '@wordpress/components';
 import { chevronLeft } from '@wordpress/icons';
 
@@ -32,6 +33,7 @@ export const UpdateThemePanel = () => {
 		author: '',
 		author_uri: '',
 		tags_custom: '',
+		recommended_plugins: '',
 	} );
 
 	useSelect( ( select ) => {
@@ -170,6 +172,24 @@ export const UpdateThemePanel = () => {
 						'A comma-separated collection of tags',
 						'create-block-theme'
 					) }
+				/>
+				<TextareaControl
+					label={ __( 'Recommended Plugins', 'create-block-theme' ) }
+					help={
+						<>
+							{ __(
+								'List the recommended plugins for this theme. e.g. contact forms, social media. Plugins must be from the WordPress.org plugin repository.'
+							) }
+							<br />
+							<ExternalLink href="https://make.wordpress.org/themes/handbook/review/resources/#licenses-bundled-resources">
+								{ __( 'Read more.' ) }
+							</ExternalLink>
+						</>
+					}
+					value={ theme.recommended_plugins }
+					onChange={ ( value ) =>
+						setTheme( { ...theme, recommended_plugins: value } )
+					}
 				/>
 				<TextControl
 					label={ __( 'Theme Subfolder', 'create-block-theme' ) }

--- a/src/editor-sidebar/update-panel.js
+++ b/src/editor-sidebar/update-panel.js
@@ -36,8 +36,23 @@ export const UpdateThemePanel = () => {
 		recommended_plugins: '',
 	} );
 
-	useSelect( ( select ) => {
+	async function getThemeReadmeData() {
+		return apiFetch( {
+			path: '/create-block-theme/v1/get-readme-data',
+			method: 'GET',
+		} ).then( ( response ) => {
+			if ( response.status === 'SUCCESS' ) {
+				return response.data;
+			}
+			return {
+				recommendedPlugins: '',
+			};
+		} );
+	}
+
+	useSelect( async ( select ) => {
 		const themeData = select( 'core' ).getCurrentTheme();
+		const themeReadmeData = await getThemeReadmeData();
 		setTheme( {
 			name: themeData.name.raw,
 			description: themeData.description.raw,
@@ -46,7 +61,7 @@ export const UpdateThemePanel = () => {
 			author: themeData.author.raw,
 			author_uri: themeData.author_uri.raw,
 			tags_custom: themeData.tags.rendered,
-			recommended_plugins: '',
+			recommended_plugins: themeReadmeData.recommendedPlugins,
 			subfolder:
 				themeData.stylesheet.lastIndexOf( '/' ) > 1
 					? themeData.stylesheet.substring(

--- a/src/editor-sidebar/update-panel.js
+++ b/src/editor-sidebar/update-panel.js
@@ -45,9 +45,7 @@ export const UpdateThemePanel = () => {
 				if ( response.status === 'SUCCESS' ) {
 					return response.data;
 				}
-				return {
-					recommendedPlugins: '',
-				};
+				return {};
 			} );
 		};
 		const setThemeReadmeData = async () => {

--- a/src/editor-sidebar/update-panel.js
+++ b/src/editor-sidebar/update-panel.js
@@ -208,6 +208,10 @@ export const UpdateThemePanel = () => {
 							</ExternalLink>
 						</>
 					}
+					// eslint-disable-next-line @wordpress/i18n-no-collapsible-whitespace
+					placeholder={ __( `Plugin Name
+https://wordpress.org/plugins/plugin-name/
+Plugin Description` ) }
 					value={ theme.recommended_plugins }
 					onChange={ ( value ) =>
 						setTheme( { ...theme, recommended_plugins: value } )

--- a/src/editor-sidebar/update-panel.js
+++ b/src/editor-sidebar/update-panel.js
@@ -46,6 +46,7 @@ export const UpdateThemePanel = () => {
 			author: themeData.author.raw,
 			author_uri: themeData.author_uri.raw,
 			tags_custom: themeData.tags.rendered,
+			recommended_plugins: '',
 			subfolder:
 				themeData.stylesheet.lastIndexOf( '/' ) > 1
 					? themeData.stylesheet.substring(


### PR DESCRIPTION
This PR adds a "Recommended Plugins" input to the wp-admin page and editor versions of the plugin.

Closes https://github.com/WordPress/create-block-theme/issues/399.

### Testing Instructions:
1. Open the wp-admin page or the editor sidebar panel
2. Add some text to the recommended plugins input box
3. Export the theme
4. The text should be added to the theme's readme, under a "Recommended Plugins" heading

### Screenshots:

wp-admin:
<img width="827" alt="image" src="https://github.com/WordPress/create-block-theme/assets/1645628/b71e520f-f39a-4249-9758-e373373a015e">

Editor sidebar panel:
<img width="280" alt="image" src="https://github.com/WordPress/create-block-theme/assets/1645628/77511a29-c25d-4daa-9112-9e497bccdbd5">
