### PR TITLE
Add default value for recommended plugins section

### DIFF
--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -24,9 +24,7 @@ class Theme_Readme {
 		$copyright_section      = self::copyright_section( $new_copyright_section, $original_theme_credits, $name, $copy_year, $author, $image_credits );
 
 		// Handle recommended plugins section.
-		if ( $recommended_plugins ) {
-			$recommended_plugins_section = self::recommended_plugins_section( $recommended_plugins );
-		}
+		$recommended_plugins_section = self::recommended_plugins_section( $recommended_plugins ) ?? '';
 
 		return "=== {$name} ===
 Contributors: {$author}


### PR DESCRIPTION
Add a default value to `$recommended_plugins_section` to avoid errors when providing no recommended plugins.

Error:
```
Warning: Undefined variable $recommended_plugins_section in wp-content/plugins/create-block-theme/admin/create-theme/theme-readme.php on line 47
```