### PR TITLE
Set the initial version to 1.0.0 insted of 0.0.1

### DIFF
--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -40,7 +40,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Changelog ==
 
-= 0.0.1 =
+= 1.0.0 =
 * Initial release
 {$recommended_plugins_section}
 {$copyright_section}

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -64,7 +64,7 @@ Tags: {$tags}
 		$wp_version  = get_bloginfo( 'version' );
 		$template    = $theme['template'];
 		$text_domain = $theme['text_domain'];
-		$version     = '0.0.1';
+		$version     = '1.0.0';
 		$tags        = Theme_Tags::theme_tags_list( $theme );
 
 		if ( isset( $theme['version'] ) ) {


### PR DESCRIPTION
## What ?
Set the initial version of the exported themes to 1.0.0 instead of 0.0.1


## Why?
Versions below 1.0.0 imply that the product is not production ready. Block themes are production ready.