### PR TITLE
Fix: react render warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { render } from '@wordpress/element';
+import { render, createRoot } from '@wordpress/element';
 import ManageFonts from './manage-fonts';
 import GoogleFonts from './google-fonts';
 import LocalFonts from './local-fonts';
@@ -34,7 +34,16 @@ function App() {
 window.addEventListener(
 	'load',
 	function () {
-		render( <App />, document.querySelector( '#create-block-theme-app' ) );
+		const domNode = document.getElementById( 'create-block-theme-app' );
+
+		// If version is less than 18 use `render` to render the app
+		// otherwise use `createRoot` to render the app
+		if ( createRoot === undefined ) {
+			render( <App />, domNode );
+		} else {
+			const root = createRoot( domNode );
+			root.render( <App /> );
+		}
 	},
 	false
 );


### PR DESCRIPTION
For more information, see the following issue in the Gutenberg project:
https://github.com/WordPress/gutenberg/issues/49308

In WordPress 6.2, React version has been updated from 17 to 18. This causes a warning error to appear in the browser console when using the `render` function.

In order to get rid of this warning error, we need to do compatible processing regardless of whether you are using React version 17 or 18.

The PR check for the presence of `createRoot`, which is recommended from React 18, as suggested in [this comment](https://github.com/WordPress/gutenberg/issues/49308#issuecomment-1481251249), and if it is present, use `createRoot` instead of `render`.