### PR TITLE
Try: Apply theme color schema to Manage Theme Fonts page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 			"devDependencies": {
 				"@actions/core": "^1.10.0",
 				"@emotion/babel-plugin": "^11.11.0",
+				"@wordpress/base-styles": "^4.28.0",
 				"@wordpress/browserslist-config": "^5.16.0",
 				"@wordpress/element": "^5.10.0",
 				"@wordpress/env": "^8.3.0",
@@ -4111,9 +4112,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.24.0.tgz",
-			"integrity": "sha512-rvsyihxkJSWKzPLPZ//oBV994TZY7X0mHwuqFvS4S5j2F57JTAM5PbJs2M1B47A7hQ75E2x2NOMizYtjhtYK7g==",
+			"version": "4.28.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.28.0.tgz",
+			"integrity": "sha512-ibg63Pc0oS2WGoW72bdRDSrbbJZ4i2OcOPXb135gdvT1P89sGQK/hGFHqPyaRzi4yI+sUuyFDEwlsvOIBfh12w==",
 			"dev": true
 		},
 		"node_modules/@wordpress/browserslist-config": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	"devDependencies": {
 		"@actions/core": "^1.10.0",
 		"@emotion/babel-plugin": "^11.11.0",
+		"@wordpress/base-styles": "^4.28.0",
 		"@wordpress/browserslist-config": "^5.16.0",
 		"@wordpress/element": "^5.10.0",
 		"@wordpress/env": "^8.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ManageFonts from './manage-fonts';
 import GoogleFonts from './google-fonts';
 import LocalFonts from './local-fonts';
 import { ManageFontsProvider } from './fonts-context';
+import './index.scss';
 
 function App() {
 	const params = new URLSearchParams( document.location.search );

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,0 +1,2 @@
+@import "../node_modules/@wordpress/base-styles/mixins";
+@include wordpress-admin-schemes();


### PR DESCRIPTION
This PR attempts to apply the user's theme color scheme to a Manage Theme Fonts page rendered as a React app.

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/create-block-theme/assets/54422211/0c5c4740-4fbb-4d3b-be16-9c3b11eea606) | ![after](https://github.com/WordPress/create-block-theme/assets/54422211/53f88385-0fce-4121-995c-7e9819dc47b9) |

---

The WordPress admin page loads the CSS file according to the color schema selected by the user and applies the colors. 

![admin-css](https://github.com/WordPress/create-block-theme/assets/54422211/4a5aa522-0960-4015-a3f1-375406debea9)

Therefore, the "Create Block Theme" page will correctly reflect that color.

![create-block-theme](https://github.com/WordPress/create-block-theme/assets/54422211/09538cac-db6e-4aef-8dad-7735dd6a5db7)

However, components of the Gutenberg package, such as `Button`, do not apply this CSS because their colors are controlled by their own CSS variables.

React-based canvases, such as the Post Editor and Site Editor, use [the `base-styles` package](https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/README.md) and use CSS variables generated from its [mixins](https://github.com/WordPress/gutenberg/blob/9879bdb7abebf9f45299f38c4a05682b7dc5d730/packages/base-styles/_mixins.scss#L439).

Therefore, on a React page that is built independently, we need to explicitly call this mixin in order to apply the user's color schema to the components.

I have first added `@wordpress/base-styles` to the npm package to achieve this. Then I defined `index.scss` in the `src` directory to import the styles according to [the documentation](https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/README.md#scss-utilities-and-variables).

