### PR TITLE
[I18n] Fix plugin internationalization

### DIFF
--- a/admin/class-create-theme.php
+++ b/admin/class-create-theme.php
@@ -50,6 +50,9 @@ class Create_Block_Theme_Admin {
 		wp_enqueue_script(
 			'create-block-theme-slot-fill',
 		);
+
+		// Enable localization in the plugin sidebar.
+		wp_set_script_translations( 'create-block-theme-slot-fill', 'create-block-theme' );
 	}
 
 	function create_admin_menu() {

--- a/admin/class-react-app.php
+++ b/admin/class-react-app.php
@@ -18,6 +18,9 @@ class React_App {
 		array_push( $asset_file['dependencies'], 'wp-i18n' );
 		wp_enqueue_script( 'create-block-theme-app', plugins_url( 'build/index.js', __DIR__ ), $asset_file['dependencies'], $asset_file['version'] );
 
+		// Sets translated strings for the script.
+		wp_set_script_translations( 'create-block-theme-app', 'create-block-theme' );
+
 		// Set google fonts json file url.
 		wp_localize_script(
 			'create-block-theme-app',

--- a/admin/class-react-app.php
+++ b/admin/class-react-app.php
@@ -18,7 +18,7 @@ class React_App {
 		array_push( $asset_file['dependencies'], 'wp-i18n' );
 		wp_enqueue_script( 'create-block-theme-app', plugins_url( 'build/index.js', __DIR__ ), $asset_file['dependencies'], $asset_file['version'] );
 
-		// Sets translated strings for the script.
+		// Enable localization in the app.
 		wp_set_script_translations( 'create-block-theme-app', 'create-block-theme' );
 
 		// Set google fonts json file url.

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -223,7 +223,7 @@ Plugin Description',
 	}
 
 	public static function form_script() {
-		wp_enqueue_script( 'form-script', plugin_dir_url( dirname( __FILE__ ) ) . '/js/form-script.js' );
-		wp_enqueue_style( 'form-style', plugin_dir_url( dirname( __FILE__ ) ) . '/css/form.css' );
+		wp_enqueue_script( 'form-script', plugin_dir_url( dirname( __FILE__ ) ) . 'js/form-script.js' );
+		wp_enqueue_style( 'form-style', plugin_dir_url( dirname( __FILE__ ) ) . 'css/form.css' );
 	}
 }

--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -225,5 +225,8 @@ Plugin Description',
 	public static function form_script() {
 		wp_enqueue_script( 'form-script', plugin_dir_url( dirname( __FILE__ ) ) . 'js/form-script.js' );
 		wp_enqueue_style( 'form-style', plugin_dir_url( dirname( __FILE__ ) ) . 'css/form.css' );
+
+		// Enable localization in the form.
+		wp_set_script_translations( 'form-script', 'create-block-theme' );
 	}
 }

--- a/src/demo-text-input/index.js
+++ b/src/demo-text-input/index.js
@@ -45,7 +45,7 @@ function DemoTextInput( { axes, setAxes, resetAxes } ) {
 						</SelectControl>
 
 						<InputControl
-							label="Demo text"
+							label={ __( 'Demo text', 'create-block-theme' ) }
 							value={ demoText }
 							onChange={ handleDemoTextChange }
 						/>

--- a/src/editor-sidebar/update-panel.js
+++ b/src/editor-sidebar/update-panel.js
@@ -204,7 +204,7 @@ export const UpdateThemePanel = () => {
 							) }
 							<br />
 							<ExternalLink href="https://make.wordpress.org/themes/handbook/review/required/#6-plugins">
-								{ __( 'Read more.' ) }
+								{ __( 'Read more.', 'create-block-theme' ) }
 							</ExternalLink>
 						</>
 					}

--- a/src/fonts-sidebar/index.js
+++ b/src/fonts-sidebar/index.js
@@ -88,23 +88,31 @@ function FontsSidebar( {
 																key
 															].faces.length && (
 																<>
-																	({ ' ' }
-																	{
-																		fontsOutline[
-																			key
-																		].faces
-																			.length
-																	}{ ' ' }
-																	{ _n(
-																		'Variant',
-																		'Variants',
-																		fontsOutline[
-																			key
-																		].faces
-																			.length,
-																		'create-block-theme'
-																	) }{ ' ' }
-																	)
+																	{ sprintf(
+																		// translators: %s: Variants information.
+																		__(
+																			'( %s )',
+																			'create-block-theme'
+																		),
+																		sprintf(
+																			// translators: %d: Number of variants.
+																			_n(
+																				'%d Variant',
+																				'%d Variants',
+																				fontsOutline[
+																					key
+																				]
+																					.faces
+																					.length,
+																				'create-block-theme'
+																			),
+																			fontsOutline[
+																				key
+																			]
+																				.faces
+																				.length
+																		)
+																	) }
 																</>
 															) }
 														</span>
@@ -171,12 +179,15 @@ function FontsSidebar( {
 
 					<div className="variants-total">
 						<div className="variant">
-							{ variantsCount }{ ' ' }
-							{ _n(
-								'Variant',
-								'Variants',
-								variantsCount,
-								'create-block-theme'
+							{ sprintf(
+								// translators: %d: Number of variants.
+								_n(
+									'%d Variant',
+									'%d Variants',
+									variantsCount,
+									'create-block-theme'
+								),
+								variantsCount
 							) }
 						</div>
 						<div className="size">{ totalSize }</div>

--- a/src/fonts-sidebar/index.js
+++ b/src/fonts-sidebar/index.js
@@ -1,10 +1,9 @@
 import { _n } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
-import { bytesToSize } from '../utils';
+import { bytesToSize, getFontStyleLocalized } from '../utils';
 import './fonts-sidebar.css';
 import { Button } from '@wordpress/components';
 import { trash } from '@wordpress/icons';
-import { getFontStyleLocalized } from '../utils';
 
 function FontsSidebar( {
 	title,

--- a/src/fonts-sidebar/index.js
+++ b/src/fonts-sidebar/index.js
@@ -1,6 +1,6 @@
 import { _n } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
-import { bytesToSize, getFontStyleLocalized } from '../utils';
+import { bytesToSize, locallizeFontStyles } from '../utils';
 import './fonts-sidebar.css';
 import { Button } from '@wordpress/components';
 import { trash } from '@wordpress/icons';
@@ -138,7 +138,7 @@ function FontsSidebar( {
 														>
 															<div className="variant">
 																{ face.weight }{ ' ' }
-																{ getFontStyleLocalized(
+																{ locallizeFontStyles(
 																	face.style
 																) }
 															</div>

--- a/src/fonts-sidebar/index.js
+++ b/src/fonts-sidebar/index.js
@@ -1,6 +1,6 @@
 import { _n } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
-import { bytesToSize, locallizeFontStyles } from '../utils';
+import { bytesToSize, localizeFontStyle } from '../utils';
 import './fonts-sidebar.css';
 import { Button } from '@wordpress/components';
 import { trash } from '@wordpress/icons';
@@ -138,7 +138,7 @@ function FontsSidebar( {
 														>
 															<div className="variant">
 																{ face.weight }{ ' ' }
-																{ locallizeFontStyles(
+																{ localizeFontStyle(
 																	face.style
 																) }
 															</div>

--- a/src/fonts-sidebar/index.js
+++ b/src/fonts-sidebar/index.js
@@ -4,6 +4,7 @@ import { bytesToSize } from '../utils';
 import './fonts-sidebar.css';
 import { Button } from '@wordpress/components';
 import { trash } from '@wordpress/icons';
+import { getFontStyleLocalized } from '../utils';
 
 function FontsSidebar( {
 	title,
@@ -138,7 +139,9 @@ function FontsSidebar( {
 														>
 															<div className="variant">
 																{ face.weight }{ ' ' }
-																{ face.style }
+																{ getFontStyleLocalized(
+																	face.style
+																) }
 															</div>
 															<div className="size">
 																{ getFileSize(

--- a/src/google-fonts/font-variant.js
+++ b/src/google-fonts/font-variant.js
@@ -1,5 +1,6 @@
 import { useEffect } from '@wordpress/element';
 import Demo from '../demo-text-input/demo';
+import { getFontStyleLocalized } from '../utils';
 
 function FontVariant( { font, variant, isSelected, handleToggle } ) {
 	const style = variant.includes( 'italic' ) ? 'italic' : 'normal';
@@ -51,7 +52,9 @@ function FontVariant( { font, variant, isSelected, handleToggle } ) {
 				<label htmlFor={ fontId }>{ weight }</label>
 			</td>
 			<td className="">
-				<label htmlFor={ fontId }>{ style }</label>
+				<label htmlFor={ fontId }>
+					{ getFontStyleLocalized( style ) }
+				</label>
 			</td>
 			<td className="demo-cell">
 				<label htmlFor={ fontId }>

--- a/src/google-fonts/font-variant.js
+++ b/src/google-fonts/font-variant.js
@@ -1,6 +1,6 @@
 import { useEffect } from '@wordpress/element';
 import Demo from '../demo-text-input/demo';
-import { getFontStyleLocalized } from '../utils';
+import { locallizeFontStyles } from '../utils';
 
 function FontVariant( { font, variant, isSelected, handleToggle } ) {
 	const style = variant.includes( 'italic' ) ? 'italic' : 'normal';
@@ -53,7 +53,7 @@ function FontVariant( { font, variant, isSelected, handleToggle } ) {
 			</td>
 			<td className="">
 				<label htmlFor={ fontId }>
-					{ getFontStyleLocalized( style ) }
+					{ locallizeFontStyles( style ) }
 				</label>
 			</td>
 			<td className="demo-cell">

--- a/src/google-fonts/font-variant.js
+++ b/src/google-fonts/font-variant.js
@@ -1,6 +1,6 @@
 import { useEffect } from '@wordpress/element';
 import Demo from '../demo-text-input/demo';
-import { locallizeFontStyles } from '../utils';
+import { localizeFontStyle } from '../utils';
 
 function FontVariant( { font, variant, isSelected, handleToggle } ) {
 	const style = variant.includes( 'italic' ) ? 'italic' : 'normal';
@@ -52,9 +52,7 @@ function FontVariant( { font, variant, isSelected, handleToggle } ) {
 				<label htmlFor={ fontId }>{ weight }</label>
 			</td>
 			<td className="">
-				<label htmlFor={ fontId }>
-					{ locallizeFontStyles( style ) }
-				</label>
+				<label htmlFor={ fontId }>{ localizeFontStyle( style ) }</label>
 			</td>
 			<td className="demo-cell">
 				<label htmlFor={ fontId }>

--- a/src/local-fonts/upload-font-form.js
+++ b/src/local-fonts/upload-font-form.js
@@ -7,6 +7,7 @@ import {
 import { Font } from 'lib-font';
 import { __ } from '@wordpress/i18n';
 import { variableAxesToCss } from '../demo-text-input/utils';
+import { getFontStyleLocalized } from '../utils';
 
 function UploadFontForm( {
 	formData,
@@ -168,8 +169,12 @@ function UploadFontForm( {
 							setFormData( { ...formData, style: val } )
 						}
 					>
-						<option value="normal">Normal</option>
-						<option value="italic">Italic</option>
+						<option value="normal">
+							{ getFontStyleLocalized( 'normal' ) }
+						</option>
+						<option value="italic">
+							{ getFontStyleLocalized( 'italic' ) }
+						</option>
 					</SelectControl>
 				</div>
 

--- a/src/local-fonts/upload-font-form.js
+++ b/src/local-fonts/upload-font-form.js
@@ -7,7 +7,7 @@ import {
 import { Font } from 'lib-font';
 import { __ } from '@wordpress/i18n';
 import { variableAxesToCss } from '../demo-text-input/utils';
-import { locallizeFontStyles } from '../utils';
+import { localizeFontStyle } from '../utils';
 
 function UploadFontForm( {
 	formData,
@@ -170,10 +170,10 @@ function UploadFontForm( {
 						}
 					>
 						<option value="normal">
-							{ locallizeFontStyles( 'normal' ) }
+							{ localizeFontStyle( 'normal' ) }
 						</option>
 						<option value="italic">
-							{ locallizeFontStyles( 'italic' ) }
+							{ localizeFontStyle( 'italic' ) }
 						</option>
 					</SelectControl>
 				</div>

--- a/src/local-fonts/upload-font-form.js
+++ b/src/local-fonts/upload-font-form.js
@@ -7,7 +7,7 @@ import {
 import { Font } from 'lib-font';
 import { __ } from '@wordpress/i18n';
 import { variableAxesToCss } from '../demo-text-input/utils';
-import { getFontStyleLocalized } from '../utils';
+import { locallizeFontStyles } from '../utils';
 
 function UploadFontForm( {
 	formData,
@@ -170,10 +170,10 @@ function UploadFontForm( {
 						}
 					>
 						<option value="normal">
-							{ getFontStyleLocalized( 'normal' ) }
+							{ locallizeFontStyles( 'normal' ) }
 						</option>
 						<option value="italic">
-							{ getFontStyleLocalized( 'italic' ) }
+							{ locallizeFontStyles( 'italic' ) }
 						</option>
 					</SelectControl>
 				</div>

--- a/src/local-fonts/upload-font-form.js
+++ b/src/local-fonts/upload-font-form.js
@@ -180,7 +180,7 @@ function UploadFontForm( {
 						name="font-weight"
 						id="font-weight"
 						placeholder={ __(
-							'Font weight:',
+							'Font weight',
 							'create-block-theme'
 						) }
 						value={ formData.weight || '' }

--- a/src/manage-fonts/confirm-delete-modal.js
+++ b/src/manage-fonts/confirm-delete-modal.js
@@ -3,7 +3,7 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { locallizeFontStyles } from '../utils';
+import { localizeFontStyle } from '../utils';
 
 function ConfirmDeleteModal( { isOpen, onConfirm, onCancel, fontToDelete } ) {
 	const deleteFontFaceMessage = sprintf(
@@ -13,7 +13,7 @@ function ConfirmDeleteModal( { isOpen, onConfirm, onCancel, fontToDelete } ) {
 			'create-block-theme'
 		),
 		fontToDelete?.weight,
-		locallizeFontStyles( fontToDelete?.style ),
+		localizeFontStyle( fontToDelete?.style ),
 		fontToDelete?.fontFamily
 	);
 

--- a/src/manage-fonts/confirm-delete-modal.js
+++ b/src/manage-fonts/confirm-delete-modal.js
@@ -3,6 +3,7 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { getFontStyleLocalized } from '../utils';
 
 function ConfirmDeleteModal( { isOpen, onConfirm, onCancel, fontToDelete } ) {
 	const deleteFontFaceMessage = sprintf(
@@ -12,7 +13,7 @@ function ConfirmDeleteModal( { isOpen, onConfirm, onCancel, fontToDelete } ) {
 			'create-block-theme'
 		),
 		fontToDelete?.weight,
-		fontToDelete?.style,
+		getFontStyleLocalized( fontToDelete?.style ),
 		fontToDelete?.fontFamily
 	);
 

--- a/src/manage-fonts/confirm-delete-modal.js
+++ b/src/manage-fonts/confirm-delete-modal.js
@@ -3,7 +3,7 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { getFontStyleLocalized } from '../utils';
+import { locallizeFontStyles } from '../utils';
 
 function ConfirmDeleteModal( { isOpen, onConfirm, onCancel, fontToDelete } ) {
 	const deleteFontFaceMessage = sprintf(
@@ -13,7 +13,7 @@ function ConfirmDeleteModal( { isOpen, onConfirm, onCancel, fontToDelete } ) {
 			'create-block-theme'
 		),
 		fontToDelete?.weight,
-		getFontStyleLocalized( fontToDelete?.style ),
+		locallizeFontStyles( fontToDelete?.style ),
 		fontToDelete?.fontFamily
 	);
 

--- a/src/manage-fonts/font-face.js
+++ b/src/manage-fonts/font-face.js
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import Demo from '../demo-text-input/demo';
 import { __ } from '@wordpress/i18n';
+import { getFontStyleLocalized } from '../utils';
 
 function FontFace( { face, deleteFont, shouldBeRemoved, isFamilyOpen } ) {
 	const demoStyles = {
@@ -21,7 +22,7 @@ function FontFace( { face, deleteFont, shouldBeRemoved, isFamilyOpen } ) {
 
 	return (
 		<tr className="font-face">
-			<td>{ face.fontStyle }</td>
+			<td>{ getFontStyleLocalized( face.fontStyle ) }</td>
 			<td>{ face.fontWeight }</td>
 			<td className="demo-cell">
 				<Demo style={ demoStyles } />

--- a/src/manage-fonts/font-face.js
+++ b/src/manage-fonts/font-face.js
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import Demo from '../demo-text-input/demo';
-const { __ } = wp.i18n;
+import { __ } from '@wordpress/i18n';
 
 function FontFace( { face, deleteFont, shouldBeRemoved, isFamilyOpen } ) {
 	const demoStyles = {

--- a/src/manage-fonts/font-face.js
+++ b/src/manage-fonts/font-face.js
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import Demo from '../demo-text-input/demo';
 import { __ } from '@wordpress/i18n';
-import { locallizeFontStyles } from '../utils';
+import { localizeFontStyle } from '../utils';
 
 function FontFace( { face, deleteFont, shouldBeRemoved, isFamilyOpen } ) {
 	const demoStyles = {
@@ -22,7 +22,7 @@ function FontFace( { face, deleteFont, shouldBeRemoved, isFamilyOpen } ) {
 
 	return (
 		<tr className="font-face">
-			<td>{ locallizeFontStyles( face.fontStyle ) }</td>
+			<td>{ localizeFontStyle( face.fontStyle ) }</td>
 			<td>{ face.fontWeight }</td>
 			<td className="demo-cell">
 				<Demo style={ demoStyles } />

--- a/src/manage-fonts/font-face.js
+++ b/src/manage-fonts/font-face.js
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import Demo from '../demo-text-input/demo';
 import { __ } from '@wordpress/i18n';
-import { getFontStyleLocalized } from '../utils';
+import { locallizeFontStyles } from '../utils';
 
 function FontFace( { face, deleteFont, shouldBeRemoved, isFamilyOpen } ) {
 	const demoStyles = {
@@ -22,7 +22,7 @@ function FontFace( { face, deleteFont, shouldBeRemoved, isFamilyOpen } ) {
 
 	return (
 		<tr className="font-face">
-			<td>{ getFontStyleLocalized( face.fontStyle ) }</td>
+			<td>{ locallizeFontStyles( face.fontStyle ) }</td>
 			<td>{ face.fontWeight }</td>
 			<td className="demo-cell">
 				<Demo style={ demoStyles } />

--- a/src/manage-fonts/font-family.js
+++ b/src/manage-fonts/font-family.js
@@ -36,14 +36,20 @@ function FontFamily( { fontFamily, deleteFont } ) {
 							{ hasFontFaces && (
 								<span className="variants-count">
 									{ ' ' }
-									( { fontFamily.fontFace.length }{ ' ' }
-									{ _n(
-										'Variant',
-										'Variants',
-										fontFamily.fontFace.length,
-										'create-block-theme'
-									) }{ ' ' }
-									)
+									{ sprintf(
+										// translators: %s: Variants information.
+										__( '( %s )', 'create-block-theme' ),
+										sprintf(
+											// translators: %d: Number of variants.
+											_n(
+												'%d Variant',
+												'%d Variants',
+												fontFamily.fontFace.length,
+												'create-block-theme'
+											),
+											fontFamily.fontFace.length
+										)
+									) }
 								</span>
 							) }
 						</div>

--- a/src/manage-fonts/font-family.js
+++ b/src/manage-fonts/font-family.js
@@ -2,8 +2,8 @@ import { useContext } from '@wordpress/element';
 import { Button, Icon } from '@wordpress/components';
 import FontFace from './font-face';
 import { ManageFontsContext } from '../fonts-context';
+import { __, _n } from '@wordpress/i18n';
 
-const { __, _n } = wp.i18n;
 function FontFamily( { fontFamily, deleteFont } ) {
 	const { familiesOpen, handleToggleFamily } =
 		useContext( ManageFontsContext );

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -1,6 +1,6 @@
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-site';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { downloadFile } from './utils';
 import { useDispatch } from '@wordpress/data';
@@ -88,7 +88,8 @@ const CreateBlockThemePlugin = () => {
 					error.message && error.code !== 'unknown_error'
 						? error.message
 						: __(
-								'An error occurred while attempting to export the theme.'
+								'An error occurred while attempting to export the theme.',
+								'create-block-theme'
 						  );
 				createErrorNotice( errorMessage, { type: 'snackbar' } );
 			}
@@ -102,12 +103,20 @@ const CreateBlockThemePlugin = () => {
 				target="create-block-theme-sidebar"
 				icon={ tool }
 			>
-				{ __( 'Create Block Theme' ) }
+				{ _x(
+					'Create Block Theme',
+					'UI String',
+					'create-block-theme'
+				) }
 			</PluginSidebarMoreMenuItem>
 			<PluginSidebar
 				name="create-block-theme-sidebar"
 				icon={ tool }
-				title={ __( 'Create Block Theme' ) }
+				title={ _x(
+					'Create Block Theme',
+					'UI String',
+					'create-block-theme'
+				) }
 			>
 				<NavigatorProvider initialPath="/">
 					<NavigatorScreen path="/">
@@ -117,7 +126,10 @@ const CreateBlockThemePlugin = () => {
 									icon={ archive }
 									onClick={ handleSaveClick }
 								>
-									{ __( 'Save Changes' ) }
+									{ __(
+										'Save Changes',
+										'create-block-theme'
+									) }
 								</Button>
 								<Text variant="muted">
 									{ __(
@@ -130,7 +142,7 @@ const CreateBlockThemePlugin = () => {
 									icon={ download }
 									onClick={ handleExportClick }
 								>
-									{ __( 'Export Zip' ) }
+									{ __( 'Export Zip', 'create-block-theme' ) }
 								</Button>
 								<Text variant="muted">
 									{ __(
@@ -143,7 +155,10 @@ const CreateBlockThemePlugin = () => {
 									<Spacer />
 									<HStack justify="space-between">
 										<FlexItem>
-											{ __( 'Theme Info' ) }
+											{ __(
+												'Theme Info',
+												'create-block-theme'
+											) }
 										</FlexItem>
 										<Icon icon={ chevronRight } />
 									</HStack>
@@ -159,7 +174,10 @@ const CreateBlockThemePlugin = () => {
 									<Spacer />
 									<HStack>
 										<FlexItem>
-											{ __( 'Create Theme' ) }
+											{ __(
+												'Create Theme',
+												'create-block-theme'
+											) }
 										</FlexItem>
 										<Icon icon={ chevronRight } />
 									</HStack>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import { __, _x } from '@wordpress/i18n';
+
 export function getStyleFromGoogleVariant( variant ) {
 	return variant.includes( 'italic' ) ? 'italic' : 'normal';
 }
@@ -19,6 +21,14 @@ export function getGoogleVariantFromStyleAndWeight( style, weight ) {
 		return weight;
 	}
 	return weight + style;
+}
+
+export function getFontStyleLocalized( style ) {
+	const styles = {
+		normal: _x( 'Normal', 'Font style', 'create-block-theme' ),
+		italic: _x( 'Italic', 'Font style', 'create-block-theme' ),
+	};
+	return styles[ style ] !== undefined ? styles[ style ] : style;
 }
 
 export function forceHttps( url ) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,7 @@ export function getGoogleVariantFromStyleAndWeight( style, weight ) {
 	return weight + style;
 }
 
-export function locallizeFontStyles( style ) {
+export function localizeFontStyle( style ) {
 	const styles = {
 		normal: _x( 'Normal', 'Font style', 'create-block-theme' ),
 		italic: _x( 'Italic', 'Font style', 'create-block-theme' ),

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,7 +37,7 @@ export function forceHttps( url ) {
 
 export function bytesToSize( bytes ) {
 	const sizes = [ 'Bytes', 'KB', 'MB', 'GB', 'TB' ];
-	if ( bytes === 0 ) return 'n/a';
+	if ( bytes === 0 ) return __( 'n/a', 'create-block-theme' );
 	const i = parseInt( Math.floor( Math.log( bytes ) / Math.log( 1024 ) ) );
 	if ( i === 0 ) return bytes + ' ' + sizes[ i ];
 	return ( bytes / Math.pow( 1024, i ) ).toFixed( 1 ) + ' ' + sizes[ i ];

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,7 @@ export function getGoogleVariantFromStyleAndWeight( style, weight ) {
 	return weight + style;
 }
 
-export function getFontStyleLocalized( style ) {
+export function locallizeFontStyles( style ) {
 	const styles = {
 		normal: _x( 'Normal', 'Font style', 'create-block-theme' ),
 		italic: _x( 'Italic', 'Font style', 'create-block-theme' ),


### PR DESCRIPTION
This PR addresses many i18n issues:

- [x] Fix missing `wp_set_script_translations()` to translate JavaScript scripts
- [x] Fix missing gettext wrappers
- [x] Fix missing text domains
- [x] Fix extra leading slash on form assets path
- [x] Add i18n to Font Styles (Normal/Italic)
- [x] Use correct i18n for strings with plurals - include variable on string ( %d Variant / %d Variants )

Solves issue reported on https://wordpress.org/support/topic/the-screen-manage-theme-fonts-is-not-translated/