### PR TITLE
Update "Tested up to" version to 6.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg, mikachan, onemaggie, pbking, scruffian, mmaattiiaass, jffng, madhudollu, egregor
 Tags: themes, theme, block-theme
 Requires at least: 6.0
-Tested up to: 6.2
+Tested up to: 6.3
 Stable tag: 1.13.2
 Requires PHP: 7.0
 License: GPLv2 or later


### PR DESCRIPTION
This small PR updates the "Tested up to" WordPress version from 6.2 to 6.3, in preparation for the release of WordPress 6.3.