### PR TITLE
Add wp-admin menu for git repository configuration

### DIFF
--- a/admin/class-git-integration.php
+++ b/admin/class-git-integration.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once( __DIR__ . '/class-react-app.php' );
 require_once( dirname( __DIR__ ) . '/includes/class-create-block-theme-settings.php' );
 
 class Git_Integration_Admin {
@@ -16,7 +17,17 @@ class Git_Integration_Admin {
 		}
 		$menu_title = _x( 'Create Block Theme: Git Utilities', 'UI String', 'create-block-theme' );
 		$page_title = $menu_title;
-		add_menu_page( $page_title, $menu_title, 'edit_theme_options', 'themes-git-integration', array( $this, 'git_settings_page' ) );
+		add_menu_page( $page_title, $menu_title, 'edit_theme_options', 'themes-git-integration', array( $this, 'git_settings_page_react' ) );
+	}
+
+	public function git_settings_page_react() {
+		React_App::bootstrap();
+
+		$nonce = wp_create_nonce( 'create_block_theme' );
+		?>
+		<input id="create-block-theme-app-nonce" type="hidden" value="<?php echo $nonce; ?>" />
+		<div id="create-block-theme-app"></div>
+		<?php
 	}
 
 	public function git_settings_page() {

--- a/admin/class-git-integration.php
+++ b/admin/class-git-integration.php
@@ -1,0 +1,142 @@
+<?php
+
+require_once( dirname( __DIR__ ) . '/includes/class-create-block-theme-settings.php' );
+
+class Git_Integration_Admin {
+	public $plugin_settings;
+
+	public function __construct() {
+		$this->plugin_settings = new Create_Block_Theme_Settings();
+		add_action( 'admin_menu', array( $this, 'create_admin_menu' ) );
+	}
+
+	public function create_admin_menu() {
+		if ( ! wp_is_block_theme() ) {
+			return;
+		}
+		$menu_title = _x( 'Create Block Theme: Git Utilities', 'UI String', 'create-block-theme' );
+		$page_title = $menu_title;
+		add_menu_page( $page_title, $menu_title, 'edit_theme_options', 'themes-git-integration', array( $this, 'git_settings_page' ) );
+	}
+
+	public function git_settings_page() {
+		// Add your settings page content here
+		$git_url_format = 'https://github.com/username/repository';
+		$page_title     = _x( 'Create Block Theme: Git Utilities', 'UI String', 'create-block-theme' );
+
+		if ( isset( $_POST['delete_git_config'] ) ) {
+			$this->delete_settings();
+		} elseif ( isset( $_POST['save_git_config'] ) ) {
+			$this->save_settings( $_POST );
+		}
+		$settings       = $this->get_settings();
+		$repository_url = $settings['repository_url'];
+		$default_branch = $settings['default_branch'];
+		$access_token   = $settings['access_token'];
+		$author_name    = $settings['author_name'];
+		$author_email   = $settings['author_email'];
+		?>
+
+		<div class="wrap">
+		<h2><?php echo __( 'Create Block Theme: Git Utilities.', 'create-block-theme' ); ?></h2>
+		<p style="max-width: 500px;">
+			<?php echo __( 'This plugin allows you to connect your WordPress themes with a Git repository, enabling you to pull and/or commit theme changes.', 'create-block-theme' ); ?>
+		</p>
+		<div class="theme-form">
+			<form action="" method="POST">
+				<input type="hidden" name="git_config_form" value="<?php echo wp_create_nonce( 'git_config_form' ); ?>" />
+
+				<?php
+				if ( ! empty( $repository_url ) ) {
+					echo '<p><h3>' . __( 'Your WordPress site is connected to the git repository.', 'create-block-theme' ) . '✅</h3></p>';
+					echo "<p style='display:grid;grid-template-columns:minmax(100px,120px) auto'>
+                        <strong>" . __( 'Repository URL', 'create-block-theme' ) . ": </strong>
+                        <span>$repository_url</span>
+                        <strong>" . __( 'Default Branch', 'create-block-theme' ) . ": </strong>
+                        <span>$default_branch</span>
+                        </p>";
+
+					echo "<input type='submit' name='delete_git_config' class='button-secondary' value='" . __( 'Disconnect Repository', 'create-block-theme' ) . "'/><br/><br/>";
+
+					if ( ! empty( $access_token ) ) {
+						echo '<p><strong>' . __( 'Access token configured', 'create-block-theme' ) . ' ✅</strong> <br/>' . __( 'You can still update with a new access token.', 'create-block-theme' ) . '</p>';
+					}
+				} else {
+					?>
+				<p><?php echo __( 'Configure the options below to get started.', 'create-block-theme' ); ?></p>
+				<div>
+					<label for="repository_url"><?php echo __( 'Repository URL', 'create-block-theme' ); ?> (*): </label><br/>
+					<input type="text" class="regular-text" name="repository_url" id="repository_url" value="<?php echo sanitize_text_field( $_POST['repository_url'] ); ?>" placeholder="<?php echo $git_url_format; ?>">
+				</div>
+
+				<div>
+					<label for="default_branch"><?php echo __( 'Default branch', 'create-block-theme' ); ?>: </label><br/>
+					<input type="text" class="regular-text" name="default_branch" id="default_branch" placeholder="master / main / trunk">
+				</div>
+					<?php
+				}
+
+				if ( empty( $repository_url ) ) {
+					?>
+				<p style="max-width: 500px;">
+					<?php echo __( 'Following options are required if the repository is private or if you want to commit the theme changes to git repository.', 'create-block-theme' ); ?>
+				<br/>
+				</p>
+				<?php } ?>
+
+				<div>
+					<label for="access_token"><?php echo __( 'Access token', 'create-block-theme' ); ?>: </label><br/>
+					<input type="text" class="regular-text" name="access_token" id="access_token" placeholder="<?php echo $access_token ? '********' : ''; ?>">
+				</div>
+
+				<div>
+					<label for="author_name"><?php echo __( 'Author name', 'create-block-theme' ); ?>: </label><br/>
+					<input type="text" class="regular-text" name="author_name" id="author_name" value="<?php echo $author_name; ?>">
+				</div>
+
+				<div>
+					<label for="author_email"><?php echo __( 'Author email', 'create-block-theme' ); ?>: </label><br/>
+					<input type="text" class="regular-text" name="author_email" id="author_email" value="<?php echo $author_email; ?>">
+				</div>
+				<br/>
+
+				<input type="submit" name="save_git_config" class="button-primary" value="<?php echo empty( $repository_url ) ? __( 'Connect Repository', 'create-block-theme' ) : __( 'Update Settings', 'create-block-theme' ); ?>" />
+			</form>
+		</div>
+		</div>
+		<?php
+	}
+
+	private function get_settings() {
+		return $this->plugin_settings->get_settings();
+	}
+
+	private function save_settings( $settings ) {
+		$repository_url = sanitize_text_field( $settings['repository_url'] );
+		$default_branch = sanitize_text_field( $settings['default_branch'] );
+		$access_token   = sanitize_text_field( $settings['access_token'] );
+		$author_name    = sanitize_text_field( $settings['author_name'] );
+		$author_email   = sanitize_text_field( $settings['author_email'] );
+
+		// TODO: try cloning the git repository here.
+		// Show error if it fails
+		// save the options only if git clone is successful.
+
+		$this->plugin_settings->update_settings(
+			array(
+				'repository_url' => $repository_url,
+				'default_branch' => $default_branch,
+				'access_token'   => $access_token,
+				'author_name'    => $author_name,
+				'author_email'   => $author_email,
+			)
+		);
+
+		echo '<div class="updated"><p>Settings saved!</p></div>';
+	}
+
+	public function delete_settings() {
+		$this->plugin_settings->delete_settings();
+		// TODO: delete the local clone of the repository
+	}
+}

--- a/admin/class-git-integration.php
+++ b/admin/class-git-integration.php
@@ -22,7 +22,6 @@ class Git_Integration_Admin {
 	public function git_settings_page() {
 		// Add your settings page content here
 		$git_url_format = 'https://github.com/username/repository';
-		$page_title     = _x( 'Create Block Theme: Git Utilities', 'UI String', 'create-block-theme' );
 
 		if ( isset( $_POST['delete_git_config'] ) ) {
 			$this->delete_settings();
@@ -38,9 +37,9 @@ class Git_Integration_Admin {
 		?>
 
 		<div class="wrap">
-		<h2><?php echo __( 'Create Block Theme: Git Utilities.', 'create-block-theme' ); ?></h2>
-		<p style="max-width: 500px;">
-			<?php echo __( 'This plugin allows you to connect your WordPress themes with a Git repository, enabling you to pull and/or commit theme changes.', 'create-block-theme' ); ?>
+		<h2><?php echo __( 'Create Block Theme: Git Utilities', 'create-block-theme' ); ?></h2>
+		<p style="max-width: 400px;">
+			<?php echo __( 'Connect your WordPress site themes with a Git repository. You can pull and commit theme changes to the repository.', 'create-block-theme' ); ?>
 		</p>
 		<div class="theme-form">
 			<form action="" method="POST">
@@ -48,7 +47,7 @@ class Git_Integration_Admin {
 
 				<?php
 				if ( ! empty( $repository_url ) ) {
-					echo '<p><h3>' . __( 'Your WordPress site is connected to the git repository.', 'create-block-theme' ) . '✅</h3></p>';
+					echo '<p><h3>' . __( 'Your WordPress site is connected to the git repository.', 'create-block-theme' ) . ' ✅</h3></p>';
 					echo "<p style='display:grid;grid-template-columns:minmax(100px,120px) auto'>
                         <strong>" . __( 'Repository URL', 'create-block-theme' ) . ": </strong>
                         <span>$repository_url</span>
@@ -78,8 +77,8 @@ class Git_Integration_Admin {
 
 				if ( empty( $repository_url ) ) {
 					?>
-				<p style="max-width: 500px;">
-					<?php echo __( 'Following options are required if the repository is private or if you want to commit the theme changes to git repository.', 'create-block-theme' ); ?>
+				<p style="max-width: 400px;">
+					<?php echo __( 'Following options are required if the repository is private or to commit the theme changes to git repository.', 'create-block-theme' ); ?>
 				<br/>
 				</p>
 				<?php } ?>

--- a/create-block-theme.php
+++ b/create-block-theme.php
@@ -26,7 +26,8 @@ if ( ! function_exists( 'download_url' ) ) {
 /**
  * The core plugin class.
  */
-require plugin_dir_path( __FILE__ ) . 'includes/class-create-block-theme.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-create-block-theme.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-create-block-theme-settings.php';
 
 /**
  * Begins execution of the plugin.
@@ -44,3 +45,21 @@ function run_create_block_theme() {
 
 }
 run_create_block_theme();
+
+function create_block_theme_activated() {
+	// none
+}
+
+function create_block_theme_deactivated() {
+	// none
+}
+
+function create_block_theme_uninstalled() {
+	$plugin_settings = new Create_Block_Theme_Settings();
+	$plugin_settings->delete_settings();
+}
+
+// may be some clean up required ???
+register_activation_hook( __FILE__, 'create_block_theme_activated' );
+register_deactivation_hook( __FILE__, 'create_block_theme_deactivated' );
+register_uninstall_hook( __FILE__, 'create_block_theme_uninstalled' );

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once( __DIR__ . '/class-themes-git-api.php' );
+
 /**
  * The api functionality of the plugin leveraged by the site editor UI.
  *
@@ -8,12 +10,14 @@
  * @author     WordPress.org
  */
 class Create_Block_Theme_API {
+	private $git_api;
 
 	/**
 	 * Initialize the class and set its properties.
 	 */
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+		$this->git_api = new Themes_Git_API();
 	}
 
 	/**
@@ -92,6 +96,31 @@ class Create_Block_Theme_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'rest_get_readme_data' ),
+				'permission_callback' => function () {
+					return current_user_can( 'edit_theme_options' );
+				},
+			)
+		);
+
+		// GIT Integration routes
+		register_rest_route(
+			'create-block-theme/v1',
+			'/settings',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this->git_api, 'get_settings' ),
+				'permission_callback' => function () {
+					return current_user_can( 'edit_theme_options' );
+				},
+			)
+		);
+
+		register_rest_route(
+			'create-block-theme/v1',
+			'/update-git-connection',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this->git_api, 'update_git_repo' ),
 				'permission_callback' => function () {
 					return current_user_can( 'edit_theme_options' );
 				},

--- a/includes/class-create-block-theme-settings.php
+++ b/includes/class-create-block-theme-settings.php
@@ -1,0 +1,57 @@
+<?php
+
+class Create_Block_Theme_Settings {
+	public function init_default_settings() {
+		if ( ! get_option( 'repository_url' ) ) {
+			update_option( 'repository_url', '' );
+		}
+		if ( ! get_option( 'default_branch' ) ) {
+			update_option( 'default_branch', '' );
+		}
+		if ( ! get_option( 'access_token' ) ) {
+			update_option( 'access_token', '' );
+		}
+		if ( ! get_option( 'author_name' ) ) {
+			update_option( 'author_name', '' );
+		}
+		if ( ! get_option( 'author_email' ) ) {
+			update_option( 'author_email', '' );
+		}
+	}
+
+	function get_settings() {
+		return array(
+			'repository_url' => get_option( 'repository_url', '' ),
+			'default_branch' => get_option( 'default_branch', '' ),
+			'access_token'   => get_option( 'access_token', '' ),
+			'author_name'    => get_option( 'author_name', '' ),
+			'author_email'   => get_option( 'author_email', '' ),
+		);
+	}
+
+	function update_settings( $settings ) {
+		if ( ! empty( $settings['repository_url'] ) ) {
+			update_option( 'repository_url', $settings['repository_url'] );
+		}
+		if ( ! empty( $settings['default_branch'] ) ) {
+			update_option( 'default_branch', $settings['default_branch'] );
+		}
+		if ( ! empty( $settings['access_token'] ) ) {
+			update_option( 'access_token', $settings['access_token'] );
+		}
+		if ( ! empty( $settings['author_name'] ) ) {
+			update_option( 'author_name', $settings['author_name'] );
+		}
+		if ( ! empty( $settings['author_email'] ) ) {
+			update_option( 'author_email', $settings['author_email'] );
+		}
+	}
+
+	function delete_settings() {
+		delete_option( 'repository_url' );
+		delete_option( 'default_branch' );
+		delete_option( 'access_token' );
+		delete_option( 'author_name' );
+		delete_option( 'author_email' );
+	}
+}

--- a/includes/class-create-block-theme-settings.php
+++ b/includes/class-create-block-theme-settings.php
@@ -1,57 +1,46 @@
 <?php
 
 class Create_Block_Theme_Settings {
-	public function init_default_settings() {
-		if ( ! get_option( 'repository_url' ) ) {
-			update_option( 'repository_url', '' );
-		}
-		if ( ! get_option( 'default_branch' ) ) {
-			update_option( 'default_branch', '' );
-		}
-		if ( ! get_option( 'access_token' ) ) {
-			update_option( 'access_token', '' );
-		}
-		if ( ! get_option( 'author_name' ) ) {
-			update_option( 'author_name', '' );
-		}
-		if ( ! get_option( 'author_email' ) ) {
-			update_option( 'author_email', '' );
-		}
-	}
-
 	function get_settings() {
+		// delete_option( 'connected_repos' );
 		return array(
-			'repository_url' => get_option( 'repository_url', '' ),
-			'default_branch' => get_option( 'default_branch', '' ),
-			'access_token'   => get_option( 'access_token', '' ),
-			'author_name'    => get_option( 'author_name', '' ),
-			'author_email'   => get_option( 'author_email', '' ),
+			'connected_repos' => get_option( 'connected_repos', array() ),
 		);
 	}
 
-	function update_settings( $settings ) {
-		if ( ! empty( $settings['repository_url'] ) ) {
-			update_option( 'repository_url', $settings['repository_url'] );
-		}
-		if ( ! empty( $settings['default_branch'] ) ) {
-			update_option( 'default_branch', $settings['default_branch'] );
-		}
-		if ( ! empty( $settings['access_token'] ) ) {
-			update_option( 'access_token', $settings['access_token'] );
-		}
-		if ( ! empty( $settings['author_name'] ) ) {
-			update_option( 'author_name', $settings['author_name'] );
-		}
-		if ( ! empty( $settings['author_email'] ) ) {
-			update_option( 'author_email', $settings['author_email'] );
-		}
+	function add_git_connection( $connection ) {
+		$repos = get_option( 'connected_repos', array() );
+		array_push( $repos, $connection );
+		update_option( 'connected_repos', $repos );
+	}
+
+	function update_git_connection( $connection, $theme_slug ) {
+		// TODO: update only fields with values. keep the old values if value is not set
+		$repos = get_option( 'connected_repos', array() );
+		$repos = array_map(
+			function( $repo ) use ( $connection, $theme_slug ) {
+				if ( $repo['themeSlug'] === $theme_slug ) {
+					return array_merge( $repo, $connection );
+				}
+				return $repo;
+			},
+			$repos
+		);
+		update_option( 'connected_repos', $repos );
+	}
+
+	function delete_git_connection( $theme_slug ) {
+		$repos = get_option( 'connected_repos', array() );
+		$repos = array_filter(
+			$repos,
+			function( $repo ) use ( $theme_slug ) {
+				return $repo['themeSlug'] !== $theme_slug;
+			}
+		);
+		update_option( 'connected_repos', $repos );
 	}
 
 	function delete_settings() {
-		delete_option( 'repository_url' );
-		delete_option( 'default_branch' );
-		delete_option( 'access_token' );
-		delete_option( 'author_name' );
-		delete_option( 'author_email' );
+		delete_option( 'connected_repos' );
 	}
 }

--- a/includes/class-create-block-theme.php
+++ b/includes/class-create-block-theme.php
@@ -42,6 +42,7 @@ class Create_Block_Theme {
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-create-theme.php';
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-manage-fonts.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-git-integration.php';
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/wp-org-theme-directory.php';
 
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-create-block-theme-api.php';
@@ -61,6 +62,7 @@ class Create_Block_Theme {
 
 		$plugin_admin       = new Create_Block_Theme_Admin();
 		$manage_fonts_admin = new Manage_Fonts_Admin();
+		$git_admin          = new Git_Integration_Admin();
 		$wp_theme_directory = new WP_Theme_Directory();
 		$plugin_api         = new Create_Block_Theme_API();
 	}

--- a/includes/class-themes-git-api.php
+++ b/includes/class-themes-git-api.php
@@ -1,0 +1,69 @@
+<?php
+
+require_once( __DIR__ . '/class-create-block-theme-settings.php' );
+
+class Themes_Git_API {
+	public $plugin_settings;
+
+	public function __construct() {
+		$this->plugin_settings = new Create_Block_Theme_Settings();
+	}
+
+	public function get_settings() {
+		try {
+			$settings = $this->plugin_settings->get_settings();
+			// TODO: mask accessToken
+
+			return array( 'settings' => $settings );
+		} catch ( \Throwable $th ) {
+			return array( 'status' => 'error' );
+		}
+	}
+
+	public function update_git_repo( $request ) {
+		$req_params = $request->get_params();
+		$action     = $req_params['action'];
+		$repository = $req_params['repository'];
+		$theme_slug = $req_params['themeSlug'];
+		$theme_name = $req_params['themeName'];
+
+		// do not save any other params
+		$repository = array(
+			'repositoryUrl' => $repository['repositoryUrl'],
+			'defaultBranch' => $repository['defaultBranch'],
+			'accessToken'   => $repository['accessToken'],
+			'authorName'    => $repository['authorName'],
+			'authorEmail'   => $repository['authorEmail'],
+		);
+
+		try {
+			if ( 'create' === $action ) {
+				$this->plugin_settings->add_git_connection(
+					array_merge(
+						$repository,
+						array(
+							'themeSlug' => $theme_slug,
+							'themeName' => $theme_name,
+						)
+					)
+				);
+			} elseif ( 'update' === $action ) {
+				$this->plugin_settings->update_git_connection( $repository, $theme_slug );
+			} elseif ( 'delete' === $action ) {
+				$this->plugin_settings->delete_git_connection( $theme_slug );
+			} else {
+				return array(
+					'status'  => 'error',
+					'message' => 'Invalid action.',
+				);
+			}
+
+			return array( 'status' => 'ok' );
+		} catch ( \Throwable $th ) {
+			return array(
+				'status'  => 'error',
+				'message' => $th . __toString(),
+			);
+		}
+	}
+}

--- a/src/git-integration/admin/index.js
+++ b/src/git-integration/admin/index.js
@@ -1,0 +1,437 @@
+import { __ } from '@wordpress/i18n';
+import styles from './styles.module.css';
+import {
+	Button,
+	// eslint-disable-next-line
+	__experimentalInputControl as InputControl,
+	// eslint-disable-next-line
+	__experimentalText as Text,
+	RadioControl,
+	Notice,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { Fragment, useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+export default function GitIntegrationAdminPage() {
+	const [ view, setView ] = useState( 'all-connections' );
+	const [ repos, setRepos ] = useState( [] );
+	const [ selectedRepo, setSelectedRepo ] = useState();
+	const [ allThemesConnected, setAllThemesConnected ] = useState( false );
+	const [ activeThemeConnected, setActiveThemeConnected ] = useState( false );
+	const [ theme, setTheme ] = useState( {
+		name: '',
+	} );
+	useSelect( ( select ) => {
+		const themeData = select( 'core' ).getCurrentTheme();
+		if ( ! themeData ) return;
+		setTheme( {
+			name: themeData.name.raw,
+			slug: themeData.textdomain,
+		} );
+	}, [] );
+
+	useEffect( () => {
+		fetchRepos();
+	}, [] );
+
+	useEffect( () => {
+		( repos || [] )
+			.filter(
+				( repo ) => ! repo.themeSlug || repo.themeSlug === theme.slug
+			)
+			.forEach( ( repo ) => {
+				if ( ! repo.themeSlug ) {
+					setAllThemesConnected( true );
+				} else if ( repo.themeSlug === theme.slug ) {
+					setActiveThemeConnected( true );
+				}
+			} );
+	}, [ repos, theme.slug ] );
+
+	const fetchRepos = () => {
+		apiFetch( {
+			path: '/create-block-theme/v1/settings',
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		} ).then( ( response ) => {
+			// TODO: sort the result
+			setRepos( response.settings.connected_repos );
+		} );
+	};
+
+	const onChange = ( action, data ) => {
+		if ( [ 'canceled', 'success' ].includes( action ) ) {
+			setView( 'connections' );
+			fetchRepos();
+		} else if ( action === 'update' ) {
+			setSelectedRepo( data );
+			setView( 'new-connection' );
+		} else {
+			setSelectedRepo();
+			setView( 'new-connection' );
+		}
+	};
+
+	return (
+		<div className={ styles.pageLayout }>
+			<div className={ styles.pageHeader }>
+				<h1 className="wp-heading-inline">
+					{ __(
+						'Create Block Theme: Git Utilities',
+						'create-block-theme'
+					) }
+				</h1>
+				<p>
+					{ __(
+						'Connect your WordPress site themes with Git repositories. Pull theme changes from the connected repository and commit theme changes to the repository.',
+						'create-block-theme'
+					) }
+				</p>
+			</div>
+			<div className={ styles.pageContainer }>
+				{ view === 'new-connection' ? (
+					<div className={ styles.repoForm }>
+						<GitConfigurationForm
+							repository={ selectedRepo }
+							theme={ theme }
+							nonce={ '' }
+							allThemesConnected={ allThemesConnected }
+							activeThemeConnected={ activeThemeConnected }
+							onChange={ onChange }
+						/>
+					</div>
+				) : (
+					<div className={ styles.connectedRepos }>
+						<ConnectedRepositories
+							repos={ repos }
+							onChange={ onChange }
+						/>
+					</div>
+				) }
+			</div>
+		</div>
+	);
+}
+
+function GitConfigurationForm( {
+	repository,
+	theme,
+	nonce,
+	allThemesConnected,
+	activeThemeConnected,
+	onChange,
+} ) {
+	repository = repository || {};
+	const editMode = repository.repositoryUrl;
+	const [ error, setError ] = useState( '' );
+	const [ config, setConfig ] = useState( {
+		connectionType: ! allThemesConnected ? 'all-themes' : 'active-theme',
+		repositoryUrl: repository.repositoryUrl || '',
+		defaultBranch: repository.defaultBranch || '',
+		accessToken: '',
+		authorName: repository.authorName || '',
+		authorEmail: repository.authorEmail || '',
+	} );
+
+	const validateForm = () => {
+		// TODO: add validations
+		if ( ! config.repositoryUrl ) {
+			return 'Repository Url is required.';
+		}
+
+		if ( allThemesConnected && config.connectionType === 'all-themes' ) {
+			return 'A repository is already connected with all themes.';
+		} else if (
+			activeThemeConnected &&
+			config.connectionType === 'active-theme'
+		) {
+			return `A repository is already connected with the active theme ${ theme.name }`;
+		}
+	};
+
+	const onSubmit = ( action ) => {
+		let postData = {};
+		if ( action === 'create' ) {
+			const formError = validateForm();
+			setError( formError );
+			if ( formError ) {
+				return;
+			}
+			postData = {
+				action,
+				repository: config,
+				themeSlug:
+					config.connectionType === 'all-themes' ? '' : theme.slug,
+				themeName:
+					config.connectionType === 'all-themes' ? '' : theme.name,
+			};
+		} else if ( action === 'update' || action === 'delete' ) {
+			postData = {
+				action,
+				repository: config,
+				themeSlug: repository.themeSlug,
+			};
+		}
+
+		apiFetch( {
+			path: '/create-block-theme/v1/update-git-connection',
+			method: 'POST',
+			data: postData,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		} )
+			.then( ( response ) => {
+				if ( response.status === 'error' ) {
+					setError( 'Failed to connect repository.' );
+					return;
+				}
+				onChange( 'success' );
+			} )
+			.catch( () => {
+				setError( 'Failed to connect repository.' );
+			} );
+	};
+
+	return (
+		<div id="git-integration-form" className="theme-form">
+			<h3>
+				{ editMode
+					? __( 'Edit repository connection', 'create-block-theme' )
+					: __( 'Connect a repository', 'create-block-theme' ) }
+			</h3>
+			<input type="hidden" name="nonce" value={ nonce } />
+			{ editMode ? (
+				<>
+					<div className={ styles.connectionDetails }>
+						<strong>Repository Url</strong>
+						<span>: { repository.repositoryUrl }</span>
+						<strong>Default Branch</strong>
+						<span>: { repository.defaultBranch }</span>
+						<strong>Connected Theme</strong>
+						<span>
+							{ ': ' +
+								( config.connectionType === 'all-themes'
+									? __( 'All Themes', 'create-block-theme' )
+									: `${ theme.name }` ) }
+						</span>
+					</div>
+					<br />
+					<Button
+						variant="secondary"
+						onClick={ () => onSubmit( 'delete' ) }
+					>
+						{ __( 'Disconnect repository', 'create-block-theme' ) }
+					</Button>
+				</>
+			) : (
+				<>
+					<InputControl
+						label={ __( 'Repository Url', 'create-block-theme' ) }
+						required
+						value={ config.repositoryUrl }
+						placeholder="https://github.com/username/repository.git"
+						onChange={ ( value ) =>
+							setConfig( { ...config, repositoryUrl: value } )
+						}
+					/>
+					<br />
+					<InputControl
+						label={ __( 'Default Branch', 'create-block-theme' ) }
+						required
+						value={ config.defaultBranch }
+						placeholder="main / master / trunk"
+						onChange={ ( value ) =>
+							setConfig( { ...config, defaultBranch: value } )
+						}
+					/>
+					<br />
+					<RadioControl
+						selected={ config.connectionType }
+						options={ [
+							{
+								label: __(
+									'Connect with all themes',
+									'create-block-theme'
+								),
+								value: 'all-themes',
+							},
+							{
+								label:
+									__(
+										'Connect with active theme',
+										'create-block-theme'
+									) + ` ${ theme.name }`,
+								value: 'active-theme',
+							},
+						] }
+						onChange={ ( value ) =>
+							setConfig( {
+								...config,
+								connectionType: value,
+							} )
+						}
+					/>
+				</>
+			) }
+			<p>
+				{ __(
+					'Following options are required if the repository is private or if you want to commit theme changes to the repository.',
+					'create-block-theme'
+				) }
+			</p>
+			<InputControl
+				label={ __( 'Access Token', 'create-block-theme' ) }
+				required
+				value={ config.accessToken }
+				placeholder={ repository.accessToken ? '*****' : '' }
+				onChange={ ( value ) =>
+					setConfig( { ...config, accessToken: value } )
+				}
+			/>
+			<br />
+			<InputControl
+				label={ __( 'Author Name', 'create-block-theme' ) }
+				required
+				value={ config.authorName }
+				onChange={ ( value ) =>
+					setConfig( { ...config, authorName: value } )
+				}
+			/>
+			<br />
+			<InputControl
+				label={ __( 'Author Email', 'create-block-theme' ) }
+				required
+				value={ config.authorEmail }
+				onChange={ ( value ) =>
+					setConfig( { ...config, authorEmail: value } )
+				}
+			/>
+			<br />
+			{ error && (
+				<>
+					<Notice
+						isDismissible={ false }
+						status="error"
+						className={ styles.notice }
+					>
+						{ error }
+					</Notice>
+					<br />
+				</>
+			) }
+			<div>
+				<Button
+					variant="primary"
+					onClick={ () => onSubmit( editMode ? 'update' : 'create' ) }
+				>
+					{ editMode
+						? __(
+								'Update repository connection',
+								'create-block-theme'
+						  )
+						: __( 'Connect Repository', 'create-block-theme' ) }
+				</Button>
+				<Button
+					variant="secondary"
+					onClick={ () => onChange( 'canceled' ) }
+					style={ { marginLeft: '0.5rem' } }
+				>
+					Cancel
+				</Button>
+			</div>
+			<br />
+		</div>
+	);
+}
+
+function ConnectedRepositories( { repos, onChange } ) {
+	return (
+		<div>
+			<div className={ styles.sectionHeader }>
+				<h3>
+					{ __( 'Connected repositories', 'create-block-theme' ) }
+				</h3>
+				<Button variant="primary" onClick={ () => onChange( 'new' ) }>
+					{ ! repos.length
+						? __( 'Connect a Repository', 'create-block-theme' )
+						: __(
+								'Connect Another Repository',
+								'create-block-theme'
+						  ) }
+				</Button>
+			</div>
+			{ ! Array.isArray( repos ) || ! repos.length ? (
+				<>
+					<p>
+						{ __(
+							'Site is not connected to any repository.',
+							'create-block-theme'
+						) }
+					</p>
+				</>
+			) : (
+				<>
+					<div className={ styles.repoTable }>
+						<div className={ styles.connectedRepoHeader }></div>
+						<div className={ styles.connectedRepoHeader }>
+							Repository Url
+						</div>
+						<div className={ styles.connectedRepoHeader }>
+							Default Branch
+						</div>
+						<div className={ styles.connectedRepoHeader }>
+							Access Token
+						</div>
+						<div className={ styles.connectedRepoHeader }>
+							Author
+						</div>
+						<div className={ styles.connectedRepoHeader }>
+							Connected Theme
+						</div>
+						{ repos.map( ( repo, index ) => (
+							<Fragment key={ index }>
+								<div className={ styles.connectedRepoItem }>
+									<div
+										className={ styles.editLink }
+										onClick={ () =>
+											onChange( 'update', repo )
+										}
+										onKeyUp={ () =>
+											onChange( 'update', repo )
+										}
+										tabIndex="0"
+										role="link"
+									>
+										Edit
+									</div>
+								</div>
+								<div className={ styles.connectedRepoItem }>
+									{ repo.repositoryUrl }
+								</div>
+								<div className={ styles.connectedRepoItem }>
+									{ repo.defaultBranch }
+								</div>
+								<div className={ styles.connectedRepoItem }>
+									{ repo.accessToken ? '✅' : '' }
+								</div>
+								<div className={ styles.connectedRepoItem }>
+									{ repo.authorName }
+									{ repo.authorEmail
+										? ` <${ repo.authorEmail }>`
+										: '' }
+								</div>
+								<div className={ styles.connectedRepoItem }>
+									{ repo.themeName || 'All Themes' }
+								</div>
+							</Fragment>
+						) ) }
+					</div>
+				</>
+			) }
+		</div>
+	);
+}

--- a/src/git-integration/admin/styles.module.css
+++ b/src/git-integration/admin/styles.module.css
@@ -1,0 +1,57 @@
+.pageLayout {
+	padding: 1rem 2rem;
+	padding-bottom: 0;
+	height: calc(100% - 2rem);
+	display: flex;
+	flex-direction: column;
+}
+.pageHeader {
+	border-bottom: 1px solid #e2e2e2;
+	margin-bottom: 0.5rem;
+}
+.pageContainer {
+	flex-grow: 1;
+}
+.repoForm {
+	max-width: 400px;
+}
+.notice {
+	margin: 0;
+}
+.connectionDetails {
+	display: grid;
+	grid-template-columns: 140px auto;
+}
+
+.sectionHeader {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+.repoTable {
+	width: 100%;
+	margin-top: 0.5rem;
+	display: grid;
+	grid-template-columns: 60px 5fr 1.5fr 1.5fr 2fr 1.5fr;
+	border-left: 1px solid #c3c4c7;
+	border-top: 1px solid #c3c4c7;
+}
+.connectedRepoHeader {
+	background-color: #f6f7f7;
+	padding: 1rem;
+	border-right: 1px solid #c3c4c7;
+	border-bottom: 1px solid #c3c4c7;
+	color: #2c3338;
+	font-weight: 700;
+}
+.connectedRepoItem {
+	padding: 0.5rem 1rem;
+	border-right: 1px solid #c3c4c7;
+	border-bottom: 1px solid #c3c4c7;
+}
+.editLink {
+	cursor: pointer;
+}
+.editLink:hover {
+	text-decoration: underline;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { render, createRoot } from '@wordpress/element';
 import ManageFonts from './manage-fonts';
 import GoogleFonts from './google-fonts';
 import LocalFonts from './local-fonts';
+import GitIntegrationAdminPage from './git-integration/admin';
 import { ManageFontsProvider } from './fonts-context';
 import './index.scss';
 
@@ -19,6 +20,9 @@ function App() {
 			break;
 		case 'add-local-font-to-theme-json':
 			PageComponent = LocalFonts;
+			break;
+		case 'themes-git-integration':
+			PageComponent = GitIntegrationAdminPage;
 			break;
 		default:
 			PageComponent = () => <h1>This page is not implemented yet.</h1>;


### PR DESCRIPTION
This adds Admin menu for git repository configuration.

It enables to add settings such as Repository URL, Access Token etc.. and Disconnect repository.
It saves the set configuration using 'update_option'.

Note: This just saves and deletes the settings. Does not clone the actual repository.

<img width="855" alt="image" src="https://github.com/WordPress/create-block-theme/assets/1935113/33dec4ec-650f-4f78-b519-7a61c24ca975">

<img width="855" alt="image" src="https://github.com/WordPress/create-block-theme/assets/1935113/6539a5f9-f5c0-4bdf-bc81-12357dbb810c">

