### PR TITLE
Add `.wp-env.override.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ vendor/
 
 # plugin build folder
 build/
+
+# Ignore local override files
+.wp-env.override.json


### PR DESCRIPTION
Follow-up on: #417

If the developers involved in this project are using wp-env, I think it would be useful to be able to add `.wp-env.override.json` and change the environment according to their use case.

This definition also exists in the Gutenberg project:
https://github.com/WordPress/gutenberg/blob/5fe62fdbf0a9f4fe946c49e5c620f99afb78e633/.gitignore#L41
