### PR TITLE
Use npx for commit linting scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 	},
 	"lint-staged": {
 		"*.{js,json,yml}": [
-			"wp-scripts format"
+			"npx wp-scripts format"
 		],
 		"*.js": [
 			"npm run lint:js"
@@ -68,7 +68,7 @@
 			"npm run lint:php"
 		],
 		"package.json": [
-			"wp-scripts lint-pkg-json"
+			"npx wp-scripts lint-pkg-json"
 		]
 	}
 }


### PR DESCRIPTION
This update the package.json config for pre-commit hooks to use `npx`.

This prevents errors when committing if you don't have `wp-scripts` installed globally, and makes sure to use the version specified by package.json.

### Testing instructions

Make a commit locally on this branch and make sure pre-commit hooks run as expected.

Since this PR is from a fork, you may want to use `github-cli` to test, e.g. `gh pr checkout 467` (https://cli.github.com/manual/gh_pr_checkout)