### PR TITLE
Adds error handling for themes.svn.wordpress.org request

### DIFF
--- a/admin/js/form-script.js
+++ b/admin/js/form-script.js
@@ -202,7 +202,7 @@ function isThemeNameValid( themeName ) {
 	// Check if the theme name is available
 	const isNameAvailable = () => {
 		// default to empty array if the unavailable theme names are not loaded yet from the API
-		const notAvailableSlugs = wpOrgThemeDirectory.themeSlugs || [];
+		const notAvailableSlugs = window.wpOrgThemeDirectory.themeSlugs || [];
 
 		// Compare the theme name to the list of unavailable theme names using several different slug formats
 		return ! notAvailableSlugs.some(

--- a/admin/wp-org-theme-directory.php
+++ b/admin/wp-org-theme-directory.php
@@ -28,7 +28,11 @@ class WP_Theme_Directory {
 	}
 
 	public static function get_theme_names() {
-		$html = wp_remote_get( self::THEME_NAMES_ENDPOINT );
+		$html = wp_safe_remote_get( self::THEME_NAMES_ENDPOINT );
+
+		if ( is_wp_error( $html ) ) {
+			return $html;
+		}
 
 		// parse the html response extracting all the a inside li elements
 		$pattern = '/<li><a href=".*?">(.*?)<\/a><\/li>/';
@@ -71,5 +75,3 @@ class WP_Theme_Directory {
 	}
 
 }
-
-

--- a/src/wp-org-theme-directory.js
+++ b/src/wp-org-theme-directory.js
@@ -4,8 +4,14 @@ async function loadUnavailableThemeNames() {
 	const requestOptions = {
 		path: '/create-block-theme/v1/wp-org-theme-names',
 	};
-	const request = await apiFetch( requestOptions );
-	wpOrgThemeDirectory.themeSlugs = request.names;
+
+	try {
+		const request = await apiFetch( requestOptions );
+		window.wpOrgThemeDirectory.themeSlugs = request.names;
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( error );
+	}
 }
 
 window.addEventListener( 'load', loadUnavailableThemeNames );


### PR DESCRIPTION
Adds error handling so that if the request to themes.svn.wordpress.org to check theme names fails for some reason, the request fails gracefully and outputs the error to the JS console.

### Testing instructions

- Spoof an error when making request to themes.svn.wordpress.org, e.g. add domain to /etc/hosts file or manually return a WP_Error from `WP_Theme_Directory::get_theme_names`
- See that the with this change, the error is logged to the JS console, rather than being unhandled.