### PR TITLE
Fix/child export

### DIFF
--- a/admin/class-create-theme.php
+++ b/admin/class-create-theme.php
@@ -79,7 +79,13 @@ class Create_Block_Theme_Admin {
 	 * Export activated child theme
 	 */
 	function export_child_theme( $theme ) {
-		$theme['slug'] = Theme_Utils::get_theme_slug( $theme['name'] );
+		if ( $theme['name'] ) {
+			// Used when CREATING a child theme
+			$theme['slug'] = Theme_Utils::get_theme_slug( $theme['name'] );
+		} else {
+			// Used with EXPORTING a child theme
+			$theme['slug'] = wp_get_theme()->get( 'TextDomain' );
+		}
 
 		// Create ZIP file in the temporary directory.
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -339,8 +339,14 @@ class Create_Block_Theme_API {
 		$zip      = Theme_Zip::create_zip( $filename );
 
 		$zip = Theme_Zip::copy_theme_to_zip( $zip, null, null );
-		$zip = Theme_Zip::add_templates_to_zip( $zip, 'all', null );
-		$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'all' );
+
+		if ( is_child_theme() ) {
+			$zip = Theme_Zip::add_templates_to_zip( $zip, 'current', $theme_slug );
+			$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'current' );
+		} else {
+			$zip = Theme_Zip::add_templates_to_zip( $zip, 'all', null );
+			$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'all' );
+		}
 
 		$zip->close();
 


### PR DESCRIPTION
Fixes issues described in the forum here: https://wordpress.org/support/topic/resulting-zip-file-has-no-name/

This change fixes two issues, both related to exporting CHILD themes.

### Testing

* Activate a CHILD theme.  For my testing I activated Twenty Twenty Three, changed a background color and (using the CBT `wp-admin` menu) created a Child Theme of Twenty Twenty Three (called `TT Child`).  I then imported and activated this new child theme.
* Make changes to the newly activated child theme's Global Styles (such as changing the background color).

#### Scenario 1 (`wp-admin` interface)

* From the `wp-admin` CBT menu export the current theme.
* The theme exported should have the correct filename (such as `tt4child.zip`) rather than an incomplete file (such as `.zip` as was reported).
* The contents of the .zip file should be ONLY those resources necessary for the child theme (no unnecessary templates, etc that are contained in the parent theme). (This had previously worked as expected, there should be no change here.)

#### Scenario 2 (`Site Editor` interface)

* From the `Site Editor` CBT menu export the current theme.
* The theme exported should have the correct filename.  (This previously worked as expected, there should be no change here.)
* The contents of the .zip file should be ONLY those resources necessary for the child theme (no unnecessary templates, etc that are contained in the parent theme).