### PR TITLE
Bump "tested up to" to 6.4

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg, mikachan, onemaggie, pbking, scruffian, mmaattiiaass, jffng, madhudollu, egregor
 Tags: themes, theme, block-theme
 Requires at least: 6.0
-Tested up to: 6.3
+Tested up to: 6.4
 Stable tag: 1.13.3
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
I've been working on CBT, including solving PHP 8.1 bugs, always on the latest WordPress trunk. I'm giving this my thumbs up for bumping the version :)