### PR TITLE
Set page titles that set only within CBT

### DIFF
--- a/admin/class-manage-fonts.php
+++ b/admin/class-manage-fonts.php
@@ -31,25 +31,41 @@ class Manage_Fonts_Admin {
 			return;
 		}
 
+		$manage_font_page_slug     = 'manage-fonts';
+		$add_google_font_page_slug = 'add-google-font-to-theme-json';
+		$add_local_font_page_slug  = 'add-local-font-to-theme-json';
+
 		$manage_fonts_page_title = _x( 'Manage Theme Fonts', 'UI String', 'create-block-theme' );
 		$manage_fonts_menu_title = $manage_fonts_page_title;
-		add_theme_page( $manage_fonts_page_title, $manage_fonts_menu_title, 'edit_theme_options', 'manage-fonts', array( 'Fonts_Page', 'manage_fonts_admin_page' ) );
+		add_theme_page( $manage_fonts_page_title, $manage_fonts_menu_title, 'edit_theme_options', $manage_font_page_slug, array( 'Fonts_Page', 'manage_fonts_admin_page' ) );
 
 		// Check if the admin page title is set, and if not, set one.
 		// This is needed to avoid a warning in the admin menu, due to the admin page title not being set in
 		// the add_submenu_page() function for the Google Fonts and Local Fonts pages.
 		global $title;
-		if ( ! isset( $title ) ) {
+
+		// Check if current admin page is a create block theme page.
+		// Context: https://github.com/WordPress/create-block-theme/issues/478
+		$admin_page        = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+		$manage_font_pages = array(
+			$manage_font_page_slug,
+			$add_google_font_page_slug,
+			$add_local_font_page_slug,
+		);
+
+		$is_manage_fonts_page = in_array( $admin_page, $manage_font_pages, true );
+
+		if ( ! isset( $title ) && $is_manage_fonts_page ) {
 			$title = $manage_fonts_page_title;
 		}
 
 		$google_fonts_page_title = _x( 'Embed Google font in the active theme', 'UI String', 'create-block-theme' );
 		$google_fonts_menu_title = $google_fonts_page_title;
-		add_submenu_page( '', $google_fonts_page_title, $google_fonts_menu_title, 'edit_theme_options', 'add-google-font-to-theme-json', array( 'Google_Fonts', 'google_fonts_admin_page' ) );
+		add_submenu_page( '', $google_fonts_page_title, $google_fonts_menu_title, 'edit_theme_options', $add_google_font_page_slug, array( 'Google_Fonts', 'google_fonts_admin_page' ) );
 
 		$local_fonts_page_title = _x( 'Embed local font in the active theme', 'UI String', 'create-block-theme' );
 		$local_fonts_menu_title = $local_fonts_page_title;
-		add_submenu_page( '', $local_fonts_page_title, $local_fonts_menu_title, 'edit_theme_options', 'add-local-font-to-theme-json', array( 'Local_Fonts', 'local_fonts_admin_page' ) );
+		add_submenu_page( '', $local_fonts_page_title, $local_fonts_menu_title, 'edit_theme_options', $add_local_font_page_slug, array( 'Local_Fonts', 'local_fonts_admin_page' ) );
 	}
 
 	function has_file_and_user_permissions() {


### PR DESCRIPTION
When setting a page title within the Manage Fonts page, we were leaking out of the plugin and setting the page title for any plugin admin pages with no title; this ensures that we only do it within the pages belonging to the Manage Fonts Admin class.

Fixes: https://github.com/WordPress/create-block-theme/issues/478