### PR TITLE
Make form files more specific to form page

### DIFF
--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -276,10 +276,12 @@ class Theme_Form {
 	}
 
 	public static function form_script() {
-		wp_enqueue_script( 'form-script', plugin_dir_url( dirname( __FILE__ ) ) . 'js/form-script.js' );
-		wp_enqueue_style( 'form-style', plugin_dir_url( dirname( __FILE__ ) ) . 'css/form.css' );
+		if ( ! empty( $_GET['page'] ) && 'create-block-theme' === $_GET['page'] ) {
+			wp_enqueue_script( 'form-script', plugin_dir_url( dirname( __FILE__ ) ) . 'js/form-script.js' );
+			wp_enqueue_style( 'form-style', plugin_dir_url( dirname( __FILE__ ) ) . 'css/form.css' );
 
-		// Enable localization in the form.
-		wp_set_script_translations( 'form-script', 'create-block-theme' );
+			// Enable localization in the form.
+			wp_set_script_translations( 'form-script', 'create-block-theme' );
+		}
 	}
 }

--- a/admin/css/form.css
+++ b/admin/css/form.css
@@ -1,12 +1,12 @@
-h2 {
+.appearance_page_create-block-theme h2 {
 	margin-bottom: 0;
 }
 
-p.description {
+.appearance_page_create-block-theme p.description {
 	margin-bottom: 1rem;
 }
 
-.submit {
+.appearance_page_create-block-theme .submit {
 	clear: both;
 }
 


### PR DESCRIPTION
This is a quick fix to make the plugin form styles more specific, and only allow the form.css and form-script.js files to load on the CBT plugin page.