### PR TITLE
Proposal: remove the development-only warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Welcome to Create Block Theme - a WordPress plugin to create block themes from w
 
 It works alongside features that are already available in the Site Editor to enhance the workflow for creating block themes. After being tested in this plugin, some of the features included here may be moved into the Site Editor itself.
 
+*Disclaimer:* Create Block Theme enables development features and thus is a tool that should be treated like as such; you can think of it as a Development Mode for WordPress, and you should keep in mind that changes made through this plugin could change your site and/or theme permanently.
+
 This plugin allows you to:
 
 - Export your existing theme with all customizations made in the Site Editor

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Welcome to Create Block Theme - a WordPress plugin to create block themes from w
 
 It works alongside features that are already available in the Site Editor to enhance the workflow for creating block themes. After being tested in this plugin, some of the features included here may be moved into the Site Editor itself.
 
-_The plugin is for development only — it is not intended for use on production websites, but to be used as a tool to create new themes._
-
 This plugin allows you to:
 
 - Export your existing theme with all customizations made in the Site Editor


### PR DESCRIPTION
It feels like the warning might be a deterrent for some folks. While it's true that the plugin is intended for the development of themes, it doesn't seem like there's a risk behind installing the plugin in a production site, or, if there are any — eg. if the plugin would replace the active theme — we should warn the user before the action is taken.