### PR TITLE
Fix manage fonts page

### DIFF
--- a/src/fonts-sidebar/index.js
+++ b/src/fonts-sidebar/index.js
@@ -1,9 +1,9 @@
-import { _n } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
-import { bytesToSize, localizeFontStyle } from '../utils';
-import './fonts-sidebar.css';
 import { Button } from '@wordpress/components';
 import { trash } from '@wordpress/icons';
+import { bytesToSize, localizeFontStyle } from '../utils';
+import './fonts-sidebar.css';
 
 function FontsSidebar( {
 	title,


### PR DESCRIPTION
Adds missing import that is breaking the manage fonts page.

Reported here: https://wordpress.org/support/topic/manage-theme-fonts/#post-17247382