### PR TITLE
Add text domain to translation target

### DIFF
--- a/src/editor-sidebar/create-panel.js
+++ b/src/editor-sidebar/create-panel.js
@@ -72,7 +72,8 @@ export const CreateThemePanel = () => {
 					error.message && error.code !== 'unknown_error'
 						? error.message
 						: __(
-								'An error occurred while attempting to export the theme.'
+								'An error occurred while attempting to export the theme.',
+								'create-block-theme'
 						  );
 				createErrorNotice( errorMessage, { type: 'snackbar' } );
 			}

--- a/src/editor-sidebar/update-panel.js
+++ b/src/editor-sidebar/update-panel.js
@@ -200,7 +200,8 @@ export const UpdateThemePanel = () => {
 					help={
 						<>
 							{ __(
-								'List the recommended plugins for this theme. e.g. contact forms, social media. Plugins must be from the WordPress.org plugin repository.'
+								'List the recommended plugins for this theme. e.g. contact forms, social media. Plugins must be from the WordPress.org plugin repository.',
+								'create-block-theme'
 							) }
 							<br />
 							<ExternalLink href="https://make.wordpress.org/themes/handbook/review/required/#6-plugins">
@@ -211,7 +212,7 @@ export const UpdateThemePanel = () => {
 					// eslint-disable-next-line @wordpress/i18n-no-collapsible-whitespace
 					placeholder={ __( `Plugin Name
 https://wordpress.org/plugins/plugin-name/
-Plugin Description` ) }
+Plugin Description`, 'create-block-theme' ) }
 					value={ theme.recommended_plugins }
 					onChange={ ( value ) =>
 						setTheme( { ...theme, recommended_plugins: value } )

--- a/src/editor-sidebar/update-panel.js
+++ b/src/editor-sidebar/update-panel.js
@@ -210,9 +210,12 @@ export const UpdateThemePanel = () => {
 						</>
 					}
 					// eslint-disable-next-line @wordpress/i18n-no-collapsible-whitespace
-					placeholder={ __( `Plugin Name
+					placeholder={ __(
+						`Plugin Name
 https://wordpress.org/plugins/plugin-name/
-Plugin Description`, 'create-block-theme' ) }
+Plugin Description`,
+						'create-block-theme'
+					) }
 					value={ theme.recommended_plugins }
 					onChange={ ( value ) =>
 						setTheme( { ...theme, recommended_plugins: value } )


### PR DESCRIPTION
When I was using the plugin in a Japanese environment, I found a few points that were translated but not adapted.

After checking the source code, I found that the text domain was not described in the corresponding sections, so I added them.

I also found a few other cases, so we took the same measures.