### PR TITLE
Fix dynamic property deprecation

### DIFF
--- a/admin/create-theme/cbt-zip-archive.php
+++ b/admin/create-theme/cbt-zip-archive.php
@@ -6,6 +6,7 @@ if ( class_exists( 'ZipArchive' ) ) {
 	class CbtZipArchive extends ZipArchive {
 
 		private string $theme_slug;
+		private string $theme_folder;
 
 		function __construct( $theme_slug ) {
 			// If the original theme is in a subfolder the theme slug will be the last part of the path


### PR DESCRIPTION
This PR fixes a warning error that occurs when performing actions to download a zip file. This issue occurs when PHP version is 8.2 or higher and `WP_DEBUG` is enabled.

Dynamic properties are deprecated in PHP 8.2 and will cause a critical error in 9.0. Therefore, the properties must be declared in advance. This issue is also discussed in [the core ticket](https://core.trac.wordpress.org/ticket/56034).


https://github.com/WordPress/create-block-theme/assets/54422211/8a2a8ea5-197c-4a51-ad20-6dabc111d108

This PR should fix errors that occur in the following three actions:

- Export {theme name}
- Create child of {theme name}
- Clone {theme name}