### PR TITLE
Add markdown and package.json lint command

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,3 +33,11 @@ jobs:
             - name: Run CSS Lint
               if: success() || failure()
               run: npm run lint:css
+
+            - name: Run Markdown Lint
+              if: success() || failure()
+              run: npm run lint:md-docs
+
+            - name: Run package.json Lint
+              if: success() || failure()
+              run: npm run lint:pkg-json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,5 @@
+# Code of Conduct
+
 This project comes under the WordPress [Etiquette](https://wordpress.org/about/etiquette/):
 
 In the WordPress open source project, we realize that our biggest asset is the community that we foster. The project, as a whole, follows these basic philosophical principles from The Cathedral and The Bazaar.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,15 +27,15 @@ We recommend following the [Gutenberg code contribution guide](https://github.co
 
 [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the Create Block Theme repository, [clone it to your computer](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) and add the WordPress repository as [upstream](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-repository-for-a-fork)
 
-```
-$ git clone https://github.com/YOUR_GITHUB_USERNAME/create-block-theme.git
-$ cd create-block-theme
-$ git remote add upstream https://github.com/WordPress/create-block-theme.git
+```bash
+git clone https://github.com/YOUR_GITHUB_USERNAME/create-block-theme.git
+cd create-block-theme
+git remote add upstream https://github.com/WordPress/create-block-theme.git
 ```
 
 Run the following commands to install the plugin dependencies:
 
-```
+```bash
 npm install
 composer install
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This plugin allows you to:
 -   Embed local font assets in your theme
 
 Learn more about Create Block Theme:
+
 - [How to use the plugin](#how-to-use-the-plugin)
 - [How to contribute](#how-to-contribute)
 - [User FAQs](https://wordpress.org/plugins/create-block-theme/)

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
 		"lint:js:fix": "npm run lint:js -- --fix",
 		"lint:php": "composer run-script lint",
 		"lint:php:fix": "composer run-script format",
+		"lint:md-docs": "wp-scripts lint-md-docs",
+		"lint:pkg-json": "wp-scripts lint-pkg-json",
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start src/index.js src/plugin-sidebar.js src/wp-org-theme-directory.js",
 		"update-version": "node update-version-and-changelog.js",
@@ -69,8 +71,11 @@
 		"*.php": [
 			"npm run lint:php"
 		],
+		"*.md": [
+			"npm run lint:md-docs"
+		],
 		"package.json": [
-			"wp-scripts lint-pkg-json"
+			"npm run lint:pkg-json"
 		]
 	}
 }


### PR DESCRIPTION
This PR adds lint commands for markdown files and package.json to improve code quality.

- Can use the new `lint:md-docs` or `lint:pkg-json` commands.
- Updated some markdown files to fix errors found when running `lint:md-docs`
- Markdown files are also linted when you commit.
- GitHub Actions that run when a PR is submitted will lint the `.md` and `package.json` files.