### PR TITLE
Fix browser warning error when clicking the reset button

### DIFF
--- a/src/demo-text-input/index.js
+++ b/src/demo-text-input/index.js
@@ -82,7 +82,7 @@ function DemoTextInput( { axes, setAxes, resetAxes } ) {
 						onClick={ () => {
 							resetDefaults( 'sentence' );
 							handleDemoTypeChange( 'sentence' );
-							resetAxes();
+							resetAxes?.();
 						} }
 					>
 						{ __( 'Reset', 'create-block-theme' ) }


### PR DESCRIPTION
This PR fixes warning error when clicking the reset button.

![image](https://github.com/WordPress/create-block-theme/assets/54422211/0aa22c4f-781c-4529-8bbc-1ef31baf1e2e)

`resetAxes()` is called to reset these two controls for variable fonts in the font file preview settings.

![resetAxes](https://github.com/WordPress/create-block-theme/assets/54422211/79e522f2-41ec-4e94-a42c-ab758c7d87a6)

However, on the "Manage Theme Fonts" and "Add Google Fonts" pages, these two components related to variable fonts are not rendered. In other words, the `<DemoTextInput>` component is not passed props(`axes`, `setAxes`, `resetAxes` ) regarding variable fonts.

https://github.com/WordPress/create-block-theme/blob/cef22d8a4f622589df4f486a2315141650f80cc9/src/google-fonts/index.js#L266

https://github.com/WordPress/create-block-theme/blob/cef22d8a4f622589df4f486a2315141650f80cc9/src/manage-fonts/index.js#L161

As a result, `resetAxes()` is undefined and causes an error.

To avoid this error I used optional chaining (`?.`).