### PR TITLE
Replace dash icon with SVG icon

### DIFF
--- a/src/manage-fonts/font-family.js
+++ b/src/manage-fonts/font-family.js
@@ -3,6 +3,7 @@ import { Button, Icon } from '@wordpress/components';
 import FontFace from './font-face';
 import { ManageFontsContext } from '../fonts-context';
 import { __, _n } from '@wordpress/i18n';
+import { chevronUp, chevronDown } from '@wordpress/icons';
 
 function FontFamily( { fontFamily, deleteFont } ) {
 	const { familiesOpen, handleToggleFamily } =
@@ -70,11 +71,7 @@ function FontFamily( { fontFamily, deleteFont } ) {
 							</Button>
 							<Button onClick={ toggleIsOpen }>
 								<Icon
-									icon={
-										isOpen
-											? 'arrow-up-alt2'
-											: 'arrow-down-alt2'
-									}
+									icon={ isOpen ? chevronUp : chevronDown }
 								/>
 							</Button>
 						</div>


### PR DESCRIPTION

| Before | After |
|--------|--------|
|  ![image](https://github.com/WordPress/create-block-theme/assets/54422211/0575a283-4115-43c0-87c4-3e53fb26daa4)| ![image](https://github.com/WordPress/create-block-theme/assets/54422211/4d060d24-9099-4369-bf43-a5c04909863b) |

- It was suggested that dashicons strings be deprecated from the Icon component: https://github.com/WordPress/gutenberg/issues/43725
- SVG icons are cleaner and should match the @wordpress/components based UI.