### PR TITLE
GitHub Actions: Add JavaScript Unit Test

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,7 +5,8 @@ on:
         branches:
             - trunk
 jobs:
-    Lint:
+    lint:
+        name: Lint
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -42,7 +43,8 @@ jobs:
               if: success() || failure()
               run: npm run lint:pkg-json
 
-    Unit-test-js:
+    unit-test-js:
+        name: JavaScript Unit Test
         runs-on: ubuntu-latest
         steps:
             - name: Checkout

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -41,3 +41,24 @@ jobs:
             - name: Run package.json Lint
               if: success() || failure()
               run: npm run lint:pkg-json
+
+    Unit-test-js:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Setup Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: npm
+
+            - name: Install Dependencies
+              run: npm i
+
+            - name: Compile JavaScript App
+              run: npm run build
+
+            - name: Run JavaScript unit tests
+              run: npm run test:unit


### PR DESCRIPTION
This PR runs existing JavaScript unit tests on GitHub Actions.

Currently, unit tests are not run unless you run `npm run test:unit` locally. By incorporating it into GitHub Actions, we will be able to prevent regressions in advance, at least in the function that is the target of the tests.

GitHub Actions are already running in this PR. You will be able to see the test results under "Show al checks".