### PR TITLE
Add blueprint.json file to enable plugin previews

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/themes.php?page=create-block-theme",
+	"features": {
+		"networking": true
+	},
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		},
+		{
+			"step": "installPlugin",
+			"pluginZipFile": {
+				"resource": "wordpress.org/plugins",
+				"slug": "create-block-theme"
+			}
+		}
+	]
+}


### PR DESCRIPTION
This PR adds a blueprint to enable the preview button in the plugin directory.

The behavior based on this definition should exactly match the URL below.

https://playground.wordpress.net/?plugin=create-block-theme&url=/wp-admin/admin.php?page=create-block-theme&networking=yes

There is currently no easy way to test this blueprint in advance, but the preview button is only visible to plugin committers. Therefore, if there is a problem, it will not affect users and can be fixed with follow-up.

I am not a committer of this plugin, so if this PR is merged, I would appreciate it if you could test whether the preview actually works.