### PR TITLE
Add files and directories not needed for release to `.distignore`

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,11 +1,13 @@
 # Files to be ignored in the plugin release
 
 node_modules/
+vendor/
 .gitignore
 update-google-fonts-json-file.js
 update-version-and-changelog.js
 package.json
 src/
+test/
 .git
 .github
 .wordpress-org

--- a/.distignore
+++ b/.distignore
@@ -20,6 +20,7 @@ src/
 .prettierrc.js
 .stylelintignore
 .stylelintrc.json
+.wp-env.json
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 README.md


### PR DESCRIPTION
I noticed that this plugin published in the plugin directory has `.wp-env.json` file.

https://plugins.trac.wordpress.org/browser/create-block-theme/trunk

![image](https://github.com/WordPress/create-block-theme/assets/54422211/07048949-bcfa-4e7f-ad0f-f26d92055948)

I believe this is unnecessary for published plugins.