### PR TITLE
Remove CODE_OF_CONDUCT.md from .distignore.

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -23,7 +23,6 @@ test/
 .stylelintignore
 .stylelintrc.json
 .wp-env.json
-CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 README.md
 babel.config.js


### PR DESCRIPTION
Follow up to #514. See https://github.com/WordPress/.github/pull/1.