### PR TITLE
Removed backup code when WP_HTM_Tag_Processor is missing

### DIFF
--- a/admin/create-theme/theme-media.php
+++ b/admin/create-theme/theme-media.php
@@ -21,102 +21,46 @@ class Theme_Media {
 	public static function get_media_absolute_urls_from_blocks( $flatten_blocks ) {
 		$media = array();
 
-		// If WP_HTML_Tag_Processor is available, use it to get the absolute URLs of img and background images
-		// This class is available in core yet, but it will be available in the future (6.2)
-		// see https://github.com/WordPress/gutenberg/pull/42485
-		if ( class_exists( 'WP_HTML_Tag_Processor' ) ) {
-			foreach ( $flatten_blocks as $block ) {
-				// Gets the absolute URLs of img in these blocks
-				if ( 'core/image' === $block['blockName'] ||
-					'core/video' === $block['blockName'] ||
-					'core/cover' === $block['blockName'] ||
-					'core/media-text' === $block['blockName']
-				) {
-					$html = new WP_HTML_Tag_Processor( $block['innerHTML'] );
-					while ( $html->next_tag( 'img' ) ) {
-						$url = $html->get_attribute( 'src' );
-						if ( Theme_Utils::is_absolute_url( $url ) ) {
-							$media[] = $url;
-						}
-					}
-					$html = new WP_HTML_Tag_Processor( $html->__toString() );
-					while ( $html->next_tag( 'video' ) ) {
-						$url = $html->get_attribute( 'src' );
-						if ( Theme_Utils::is_absolute_url( $url ) ) {
-							$media[] = $url;
-						}
-						$poster_url = $html->get_attribute( 'poster' );
-						if ( Theme_Utils::is_absolute_url( $poster_url ) ) {
-							$media[] = $poster_url;
-						}
+		foreach ( $flatten_blocks as $block ) {
+			// Gets the absolute URLs of img in these blocks
+			if (
+				'core/image' === $block['blockName'] ||
+				'core/video' === $block['blockName'] ||
+				'core/cover' === $block['blockName'] ||
+				'core/media-text' === $block['blockName']
+			) {
+				$html = new WP_HTML_Tag_Processor( $block['innerHTML'] );
+				while ( $html->next_tag( 'img' ) ) {
+					$url = $html->get_attribute( 'src' );
+					if ( Theme_Utils::is_absolute_url( $url ) ) {
+						$media[] = $url;
 					}
 				}
-
-				// Gets the absolute URLs of background images in these blocks
-				if ( 'core/cover' === $block['blockName'] ) {
-					$html = new WP_HTML_Tag_Processor( $block['innerHTML'] );
-					while ( $html->next_tag( 'div' ) ) {
-						$style = $html->get_attribute( 'style' );
-						if ( $style ) {
-							$matches = array();
-							preg_match( '/background-image: url\((.*)\)/', $style, $matches );
-							if ( isset( $matches[1] ) ) {
-								$url = $matches[1];
-								if ( Theme_Utils::is_absolute_url( $url ) ) {
-									$media[] = $url;
-								}
-							}
-						}
+				$html = new WP_HTML_Tag_Processor( $html->__toString() );
+				while ( $html->next_tag( 'video' ) ) {
+					$url = $html->get_attribute( 'src' );
+					if ( Theme_Utils::is_absolute_url( $url ) ) {
+						$media[] = $url;
+					}
+					$poster_url = $html->get_attribute( 'poster' );
+					if ( Theme_Utils::is_absolute_url( $poster_url ) ) {
+						$media[] = $poster_url;
 					}
 				}
 			}
-		}
 
-		// Fallback to DOMDocument.
-		// TODO: When WP_HTML_Tag_Processor is availabe in core (6.2) we can remove this implementation entirely.
-		if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
-			foreach ( $flatten_blocks as $block ) {
-				if ( 'core/image' === $block['blockName'] ||
-						'core/video' === $block['blockName'] ||
-						'core/cover' === $block['blockName'] ||
-						'core/media-text' === $block['blockName']
-					) {
-					$doc = new DOMDocument();
-					// TODO: do not silence errors, show in UI
-					// @codingStandardsIgnoreLine
-					@$doc->loadHTML( $block['innerHTML'], LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-
-					// Get the media urls from img tags
-					$tags = $doc->getElementsByTagName( 'img' );
-					foreach ( $tags as $tag ) {
-						$image_url = $tag->getAttribute( 'src' );
-						if ( Theme_Utils::is_absolute_url( $image_url ) ) {
-							$media[] = $tag->getAttribute( 'src' );
-						}
-					}
-					// Get the media urls from video tags
-					$tags = $doc->getElementsByTagName( 'video' );
-					foreach ( $tags as $tag ) {
-						$video_url = $tag->getAttribute( 'src' );
-						if ( Theme_Utils::is_absolute_url( $video_url ) ) {
-							$media[] = $tag->getAttribute( 'src' );
-						}
-						$poster_url = $tag->getAttribute( 'poster' );
-						if ( Theme_Utils::is_absolute_url( $poster_url ) ) {
-							$media[] = $tag->getAttribute( 'poster' );
-						}
-					}
-					// Get the media urls from div style tags (used in cover blocks)
-					$div_tags = $doc->getElementsByTagName( 'div' );
-					foreach ( $div_tags as $tag ) {
-						$style = $tag->getAttribute( 'style' );
-						if ( $style ) {
-							preg_match_all( '#\bhttps?://[^,\s()<>]+(?:\([\w\d]+\)|([^,[:punct:]\s]|/))#', $style, $match );
-							$urls = $match[0];
-							foreach ( $urls as $url ) {
-								if ( Theme_Utils::is_absolute_url( $url ) ) {
-									$media[] = $url;
-								}
+			// Gets the absolute URLs of background images in these blocks
+			if ( 'core/cover' === $block['blockName'] ) {
+				$html = new WP_HTML_Tag_Processor( $block['innerHTML'] );
+				while ( $html->next_tag( 'div' ) ) {
+					$style = $html->get_attribute( 'style' );
+					if ( $style ) {
+						$matches = array();
+						preg_match( '/background-image: url\((.*)\)/', $style, $matches );
+						if ( isset( $matches[1] ) ) {
+							$url = $matches[1];
+							if ( Theme_Utils::is_absolute_url( $url ) ) {
+								$media[] = $url;
 							}
 						}
 					}

--- a/admin/create-theme/theme-patterns.php
+++ b/admin/create-theme/theme-patterns.php
@@ -26,34 +26,14 @@ class Theme_Patterns {
 			return $html;
 		}
 
-		// Use WP_HTML_Tag_Processor if available
-		// see: https://github.com/WordPress/gutenberg/pull/42485
-		if ( class_exists( 'WP_HTML_Tag_Processor' ) ) {
-			$html = new WP_HTML_Tag_Processor( $html );
-			while ( $html->next_tag( 'img' ) ) {
-				$alt_attribute = $html->get_attribute( 'alt' );
-				if ( ! empty( $alt_attribute ) ) {
-					$html->set_attribute( 'alt', self::escape_text_for_pattern( $alt_attribute ) );
-				}
+		$html = new WP_HTML_Tag_Processor( $html );
+		while ( $html->next_tag( 'img' ) ) {
+			$alt_attribute = $html->get_attribute( 'alt' );
+			if ( ! empty( $alt_attribute ) ) {
+				$html->set_attribute( 'alt', self::escape_text_for_pattern( $alt_attribute ) );
 			}
-			return $html->__toString();
 		}
-
-		// Fallback to regex
-		// TODO: When WP_HTML_Tag_Processor is availabe in core (6.2) we can remove this implementation entirely.
-		if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
-			preg_match( '@alt="([^"]+)"@', $html, $match );
-			if ( isset( $match[0] ) ) {
-				$alt_attribute = $match[0];
-				$alt_value     = $match[1];
-				$html          = str_replace(
-					$alt_attribute,
-					'alt="' . self::escape_text_for_pattern( $alt_value ) . '"',
-					$html
-				);
-			}
-			return $html;
-		}
+		return $html->__toString();
 	}
 
 	static function escape_text_for_pattern( $text ) {

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Create Block Theme ===
 Contributors: wordpressdotorg, mikachan, onemaggie, pbking, scruffian, mmaattiiaass, jffng, madhudollu, egregor, vcanales, jeffikus, cwhitmore
 Tags: themes, theme, block-theme
-Requires at least: 6.0
-Tested up to: 6.4
+Requires at least: 6.5
+Tested up to: 6.5
 Stable tag: 1.13.8
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
Removed backup code when WP_HTM_Tag_Processor is missing and raised minimum version to 6.5

Since 6.5 will be the minimum required version for this plugin (for font support) the fallback code for 6.0 can be removed.