### PR TITLE
Add/child theme creation

### DIFF
--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -62,10 +62,12 @@ Tags: {$tags}
 		$author      = stripslashes( $theme['author'] );
 		$author_uri  = $theme['author_uri'];
 		$wp_version  = get_bloginfo( 'version' );
-		$template    = $theme['template'];
 		$text_domain = sanitize_title( $name );
-		$version     = '1.0.0';
-		$tags        = Theme_Tags::theme_tags_list( $theme );
+		if ( isset( $theme['template'] ) ) {
+			$template = $theme['template'];
+		}
+		$version = '1.0.0';
+		$tags    = Theme_Tags::theme_tags_list( $theme );
 
 		if ( isset( $theme['version'] ) ) {
 			$version = $theme['version'];

--- a/admin/create-theme/theme-templates.php
+++ b/admin/create-theme/theme-templates.php
@@ -186,19 +186,14 @@ class Theme_Templates {
 		$template_part_dir = $base_dir . DIRECTORY_SEPARATOR . $template_folders['wp_template_part'];
 		$patterns_dir      = $base_dir . DIRECTORY_SEPARATOR . 'patterns';
 
-		// If there is no templates folder, create it.
-		if ( ! is_dir( $template_dir ) ) {
+		// If there is no templates folder, and it is needed, create it.
+		if ( ! is_dir( $template_dir ) && count( $theme_templates->templates ) > 0 ) {
 			wp_mkdir_p( $template_dir );
 		}
 
-		// If there is no parts folder, create it.
-		if ( ! is_dir( $template_part_dir ) ) {
+		// If there is no parts folder, and it is needed, create it.
+		if ( ! is_dir( $template_part_dir ) && count( $theme_templates->parts ) > 0 ) {
 			wp_mkdir_p( $template_part_dir );
-		}
-
-		// If there is no patterns folder, create it.
-		if ( ! is_dir( $patterns_dir ) ) {
-			wp_mkdir_p( $patterns_dir );
 		}
 
 		foreach ( $theme_templates->templates as $template ) {
@@ -218,6 +213,10 @@ class Theme_Templates {
 
 			// Write the pattern if it exists
 			if ( isset( $template->pattern ) ) {
+				// If there is no patterns folder, create it.
+				if ( ! is_dir( $patterns_dir ) ) {
+					wp_mkdir_p( $patterns_dir );
+				}
 				file_put_contents(
 					$patterns_dir . DIRECTORY_SEPARATOR . $template->slug . '.php',
 					$template->pattern
@@ -242,6 +241,10 @@ class Theme_Templates {
 
 			// Write the pattern if it exists
 			if ( isset( $template->pattern ) ) {
+				// If there is no patterns folder, create it.
+				if ( ! is_dir( $patterns_dir ) ) {
+					wp_mkdir_p( $patterns_dir );
+				}
 				file_put_contents(
 					$patterns_dir . DIRECTORY_SEPARATOR . $template->slug . '.php',
 					$template->pattern

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -99,6 +99,17 @@ class Create_Block_Theme_API {
 		);
 		register_rest_route(
 			'create-block-theme/v1',
+			'/export-child-clone',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'rest_export_child_cloned_theme' ),
+				'permission_callback' => function () {
+					return current_user_can( 'edit_theme_options' );
+				},
+			)
+		);
+		register_rest_route(
+			'create-block-theme/v1',
 			'/get-readme-data',
 			array(
 				'methods'             => 'GET',
@@ -224,6 +235,56 @@ class Create_Block_Theme_API {
 		if ( Theme_Utils::is_valid_screenshot( $screenshot ) ) {
 			$zip->addFileToTheme(
 				$screenshot['tmp_name'],
+				'screenshot.png'
+			);
+		}
+
+		$zip->close();
+
+		header( 'Content-Type: application/zip' );
+		header( 'Content-Disposition: attachment; filename=' . $theme['slug'] . '.zip' );
+		header( 'Content-Length: ' . filesize( $filename ) );
+		flush();
+		echo readfile( $filename );
+	}
+
+	function rest_export_child_cloned_theme( $request ) {
+
+		//TODO: Handle Screenshots
+		$screenshot = null;
+		$theme      = $this->sanitize_theme_data( $request->get_params() );
+
+		// Create ZIP file in the temporary directory.
+		$filename = tempnam( get_temp_dir(), $theme['slug'] );
+		$zip      = Theme_Zip::create_zip( $filename, $theme['slug'] );
+
+		$zip = Theme_Zip::add_templates_to_zip( $zip, 'user', $theme['slug'] );
+		$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'variation' );
+
+		// Add readme.txt.
+		$zip->addFromStringToTheme(
+			'readme.txt',
+			Theme_Readme::build_readme_txt( $theme )
+		);
+
+		// Build style.css with new theme metadata
+		$theme['template'] = wp_get_theme()->get( 'TextDomain' );
+		$css_contents      = Theme_Styles::build_style_css( $theme );
+		$zip->addFromStringToTheme(
+			'style.css',
+			$css_contents
+		);
+
+		// Add / replace screenshot.
+		if ( Theme_Utils::is_valid_screenshot( $screenshot ) ) {
+			$zip->addFileToTheme(
+				$screenshot['tmp_name'],
+				'screenshot.png'
+			);
+		} else {
+			$source = plugin_dir_path( __DIR__ ) . 'assets/boilerplate/screenshot.png';
+			$zip->addFileToTheme(
+				$source,
 				'screenshot.png'
 			);
 		}

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -77,6 +77,17 @@ class Create_Block_Theme_API {
 		);
 		register_rest_route(
 			'create-block-theme/v1',
+			'/create-child',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'rest_create_child_theme' ),
+				'permission_callback' => function () {
+					return current_user_can( 'edit_theme_options' );
+				},
+			)
+		);
+		register_rest_route(
+			'create-block-theme/v1',
 			'/export-clone',
 			array(
 				'methods'             => 'POST',
@@ -131,6 +142,26 @@ class Create_Block_Theme_API {
 			array(
 				'status'  => 'SUCCESS',
 				'message' => __( 'Cloned Theme Created.', 'create-block-theme' ),
+			)
+		);
+	}
+
+	function rest_create_child_theme( $request ) {
+
+		$theme = $this->sanitize_theme_data( $request->get_params() );
+		//TODO: Handle screenshots
+		$screenshot = null;
+
+		$response = Theme_Create::create_child_theme( $theme, $screenshot );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return new WP_REST_Response(
+			array(
+				'status'  => 'SUCCESS',
+				'message' => __( 'Child Theme Created.', 'create-block-theme' ),
 			)
 		);
 	}

--- a/src/editor-sidebar/create-panel.js
+++ b/src/editor-sidebar/create-panel.js
@@ -82,6 +82,36 @@ export const CreateThemePanel = () => {
 		exportCloneTheme();
 	};
 
+	const handleExportChildClick = () => {
+		const fetchOptions = {
+			path: '/create-block-theme/v1/export-child-clone',
+			method: 'POST',
+			data: theme,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			parse: false,
+		};
+
+		async function exportCloneTheme() {
+			try {
+				const response = await apiFetch( fetchOptions );
+				downloadFile( response );
+			} catch ( error ) {
+				const errorMessage =
+					error.message && error.code !== 'unknown_error'
+						? error.message
+						: __(
+								'An error occurred while attempting to export the child theme.',
+								'create-block-theme'
+						  );
+				createErrorNotice( errorMessage, { type: 'snackbar' } );
+			}
+		}
+
+		exportCloneTheme();
+	};
+
 	const handleCreateBlankClick = () => {
 		apiFetch( {
 			path: '/create-block-theme/v1/create-blank',
@@ -294,6 +324,22 @@ export const CreateThemePanel = () => {
 			<Text variant="muted">
 				{ __(
 					'Export a copy of this theme as a .zip file. The user changes will be preserved in the new theme.',
+					'create-block-theme'
+				) }
+			</Text>
+			<hr></hr>
+			<Spacer />
+			<Button
+				icon={ download }
+				variant="secondary"
+				onClick={ handleExportChildClick }
+			>
+				{ __( 'Export Child Theme', 'create-block-theme' ) }
+			</Button>
+			<Spacer />
+			<Text variant="muted">
+				{ __(
+					'Export a child of this theme as a .zip file. The user changes will be preserved in the new theme.',
 					'create-block-theme'
 				) }
 			</Text>

--- a/src/editor-sidebar/create-panel.js
+++ b/src/editor-sidebar/create-panel.js
@@ -142,6 +142,36 @@ export const CreateThemePanel = () => {
 			} );
 	};
 
+	const handleCreateChildClick = () => {
+		apiFetch( {
+			path: '/create-block-theme/v1/create-child',
+			method: 'POST',
+			data: theme,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		} )
+			.then( () => {
+				// eslint-disable-next-line
+				alert(
+					__(
+						'Child theme created successfully. The editor will now reload.',
+						'create-block-theme'
+					)
+				);
+				window.location.reload();
+			} )
+			.catch( ( error ) => {
+				const errorMessage =
+					error.message ||
+					__(
+						'An error occurred while attempting to create the theme.',
+						'create-block-theme'
+					);
+				createErrorNotice( errorMessage, { type: 'snackbar' } );
+			} );
+	};
+
 	return (
 		<PanelBody>
 			<Heading>
@@ -234,6 +264,23 @@ export const CreateThemePanel = () => {
 					'create-block-theme'
 				) }
 			</Text>
+			<hr></hr>
+			<Spacer />
+			<Button
+				icon={ copy }
+				variant="secondary"
+				onClick={ handleCreateChildClick }
+			>
+				{ __( 'Create Child Theme', 'create-block-theme' ) }
+			</Button>
+			<Spacer />
+			<Text variant="muted">
+				{ __(
+					'Create a child theme on the server and activate it. The user changes will be preserved in the new theme.',
+					'create-block-theme'
+				) }
+			</Text>
+
 			<hr></hr>
 			<Spacer />
 			<Button


### PR DESCRIPTION
Does what it says on the tin.

<img width="283" alt="image" src="https://github.com/WordPress/create-block-theme/assets/146530/6f43fdb5-3ab7-4475-a89a-d2cced64ac0f">

To Test:

Make changes to your theme using the Site Editor.  (Do not persist them to your theme with CBT).  Changes should include style changes and template changes.

Export a Child Theme using the new interface

Review the contents of the child theme.  ONLY the CHANGED Global Styles values should be in the theme.json file.  Only templates that have been changed should be included.

Create a Child Theme using the new interface

Ensure that the created child theme is automatically activated

Review the contents of the child theme.  ONLY the CHANGED Global Styles values should be in the theme.json file.  Only templates that have been changed should be included.



Fixes: #530 

Should not be merged until #522 lands