### PR TITLE
Add/create theme variation to site editor interface

### DIFF
--- a/admin/create-theme/theme-json.php
+++ b/admin/create-theme/theme-json.php
@@ -10,33 +10,27 @@ class Theme_Json {
 	}
 
 	public static function add_theme_json_variation_to_local( $export_type, $theme ) {
-		$variation_slug = sanitize_title( $theme['variation'] );
 		$variation_path = get_stylesheet_directory() . DIRECTORY_SEPARATOR . 'styles' . DIRECTORY_SEPARATOR;
-		$file_counter   = 0;
 
 		if ( ! file_exists( $variation_path ) ) {
 			wp_mkdir_p( $variation_path );
 		}
 
-		if ( file_exists( $variation_path . $variation_slug . '.json' ) ) {
-			$file_counter++;
-			while ( file_exists( $variation_path . $variation_slug . '_' . $file_counter . '.json' ) ) {
-				$file_counter++;
-			}
-			$variation_slug = $variation_slug . '_' . $file_counter;
+		if ( file_exists( $variation_path . $theme['slug'] . '.json' ) ) {
+			return new WP_Error( 'variation_already_exists', __( 'Variation already exists.', 'create-block-theme' ) );
 		}
 
-		$_POST['theme']['variation_slug'] = $variation_slug;
+		$_POST['theme']['variation_slug'] = $theme['slug'];
 
 		$extra_theme_data = array(
 			'version' => WP_Theme_JSON::LATEST_SCHEMA,
-			'title'   => $theme['variation'],
+			'title'   => $theme['name'],
 		);
 
 		$variation_theme_json = MY_Theme_JSON_Resolver::export_theme_data( $export_type, $extra_theme_data );
 
 		file_put_contents(
-			$variation_path . $variation_slug . '.json',
+			$variation_path . $theme['slug'] . '.json',
 			$variation_theme_json
 		);
 	}

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -66,6 +66,17 @@ class Create_Block_Theme_API {
 		);
 		register_rest_route(
 			'create-block-theme/v1',
+			'/create-variation',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'rest_create_variation' ),
+				'permission_callback' => function () {
+					return current_user_can( 'edit_theme_options' );
+				},
+			)
+		);
+		register_rest_route(
+			'create-block-theme/v1',
 			'/create-blank',
 			array(
 				'methods'             => 'POST',
@@ -173,6 +184,22 @@ class Create_Block_Theme_API {
 			array(
 				'status'  => 'SUCCESS',
 				'message' => __( 'Child Theme Created.', 'create-block-theme' ),
+			)
+		);
+	}
+
+	function rest_create_variation( $request ) {
+
+		$response = Theme_Json::add_theme_json_variation_to_local( 'variation', $this->sanitize_theme_data( $request->get_params() ) );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return new WP_REST_Response(
+			array(
+				'status'  => 'SUCCESS',
+				'message' => __( 'Theme Variation Created.', 'create-block-theme' ),
 			)
 		);
 	}

--- a/src/editor-sidebar/create-panel.js
+++ b/src/editor-sidebar/create-panel.js
@@ -202,6 +202,36 @@ export const CreateThemePanel = () => {
 			} );
 	};
 
+	const handleCreateVariationClick = () => {
+		apiFetch( {
+			path: '/create-block-theme/v1/create-variation',
+			method: 'POST',
+			data: theme,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		} )
+			.then( () => {
+				// eslint-disable-next-line
+				alert(
+					__(
+						'Theme variation created successfully. The editor will now reload.',
+						'create-block-theme'
+					)
+				);
+				window.location.reload();
+			} )
+			.catch( ( error ) => {
+				const errorMessage =
+					error.message ||
+					__(
+						'An error occurred while attempting to create the theme variation.',
+						'create-block-theme'
+					);
+				createErrorNotice( errorMessage, { type: 'snackbar' } );
+			} );
+	};
+
 	return (
 		<PanelBody>
 			<Heading>
@@ -307,6 +337,23 @@ export const CreateThemePanel = () => {
 			<Text variant="muted">
 				{ __(
 					'Create a child theme on the server and activate it. The user changes will be preserved in the new theme.',
+					'create-block-theme'
+				) }
+			</Text>
+
+			<hr></hr>
+			<Spacer />
+			<Button
+				icon={ copy }
+				variant="secondary"
+				onClick={ handleCreateVariationClick }
+			>
+				{ __( 'Create Theme Variation', 'create-block-theme' ) }
+			</Button>
+			<Spacer />
+			<Text variant="muted">
+				{ __(
+					'Save the Global Styles changes as a theme variation.',
 					'create-block-theme'
 				) }
 			</Text>


### PR DESCRIPTION
Fixes #529

Adds ability to create a theme variation from the site editor interface:

<img width="280" alt="image" src="https://github.com/WordPress/create-block-theme/assets/146530/4293798f-fe0f-498f-9ab1-9ee3ace4c8a4">

To Test:

Make changes to Global Styles using the Global Styles interface.  (Do not persist those changes to your theme).

Save a theme variation using the new interface.  

Ensure that the name given the variation (using the form above it) is reflected in the JSON.
Ensure that the styles changed are present in the JSON.
Ensure that the style variation is available to the user in the Global Styles panel.

Should not be merged until https://github.com/WordPress/create-block-theme/pull/522 lands