### PR TITLE
Replace font management with screen pointing to native font library

### DIFF
--- a/src/manage-fonts/index.js
+++ b/src/manage-fonts/index.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import FontFamily from './font-family';
 
 import DemoTextInput from '../demo-text-input';
@@ -222,16 +222,34 @@ export default function () {
 				} }
 			>
 				<h1 style={ { width: '400px', lineHeight: 1.4 } }>
-					The new Font Library is now available in the WordPress
-					editor.{ ' ' }
+					{ __(
+						'The new Font Library is now available in the WordPress editor.',
+						'create-block-theme'
+					) }
 				</h1>
-				<p>You can manage your theme fonts directly from the editor.</p>
+				<p>
+					{ __(
+						'You can manage your theme fonts directly from the',
+						'create-block-theme'
+					) }{ ' ' }
+					<a href="/wp-admin/site-editor.php?canvas=edit">
+						{ _x(
+							'editor',
+							'Link to the site editor',
+							'create-block-theme'
+						) }
+					</a>
+					.
+				</p>
 				<img
 					src="https://i0.wp.com/wordpress.org/news/files/2024/04/Font-Manager-2.png?w=620&ssl=1"
 					alt="WordPress 6.5 Font Library"
 				/>
 				<p>
-					For more information, please visit the{ ' ' }
+					{ __(
+						'For more information, please check out',
+						'create-block-theme'
+					) }{ ' ' }
 					<a href="https://wordpress.org/news/2024/04/regina/">{ `What's inside 6.5` }</a>
 					.
 				</p>

--- a/src/manage-fonts/index.js
+++ b/src/manage-fonts/index.js
@@ -11,7 +11,7 @@ import ConfirmDeleteModal from './confirm-delete-modal';
 import { localFileAsThemeAssetUrl } from '../utils';
 import './manage-fonts.css';
 
-function ManageFonts() {
+export function ManageFonts() {
 	const nonce = document.querySelector( '#nonce' ).value;
 
 	// The element where the list of theme fonts is rendered coming from the server as JSON
@@ -200,4 +200,42 @@ function ManageFonts() {
 	);
 }
 
-export default ManageFonts;
+// export default ManageFonts;
+
+export default function () {
+	return (
+		<div
+			style={ {
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+			} }
+		>
+			<div
+				style={ {
+					width: '600px',
+					marginTop: '2rem',
+					display: 'flex',
+					flexDirection: 'column',
+					alignItems: 'center',
+					textAlign: 'center',
+				} }
+			>
+				<h1 style={ { width: '400px', lineHeight: 1.4 } }>
+					The new Font Library is now available in the WordPress
+					editor.{ ' ' }
+				</h1>
+				<p>You can manage your theme fonts directly from the editor.</p>
+				<img
+					src="https://i0.wp.com/wordpress.org/news/files/2024/04/Font-Manager-2.png?w=620&ssl=1"
+					alt="WordPress 6.5 Font Library"
+				/>
+				<p>
+					For more information, please visit the{ ' ' }
+					<a href="https://wordpress.org/news/2024/04/regina/">{ `What's inside 6.5` }</a>
+					.
+				</p>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
This change replaces the font management screen with links pointing to native font library.

<img width="1512" alt="image" src="https://github.com/WordPress/create-block-theme/assets/1935113/902c5869-f5bc-419b-8352-d75fd1210508">

This is an immediate change for 2.0
Clean up of the font management code is being done in #528