### PR TITLE
add deprecation notice in theme export admin screen

### DIFF
--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -15,6 +15,17 @@ class Theme_Form {
 		}
 		?>
 <div class="wrap">
+	<div class="notice notice-warning">
+		<p>
+			<?php
+				printf(
+					/* translators: %s: editor link. */
+					esc_html__( 'This page is deprecated and will be removed in the next release. Please try exporting from the Create Block Theme menu of the %s instead.', 'create-block-theme' ),
+					' <a href="' . esc_url( '/wp-admin/site-editor.php?canvas=edit' ) . '">' . __( 'editor', 'create-block-theme' ) . '</a>'
+				);
+			?>
+		</p>
+	</div>
 	<h1><?php _ex( 'Create Block Theme', 'UI String', 'create-block-theme' ); ?></h1>
 	<p>
 		<?php


### PR DESCRIPTION
This PR introduces a notice about removal of theme export options from admin screen.

<img width="1512" alt="image" src="https://github.com/WordPress/create-block-theme/assets/1935113/394c6456-5650-448e-a19f-bbc5562b1653">

