### PR TITLE
Include activated Fonts on theme zip export functions

### DIFF
--- a/admin/class-create-theme.php
+++ b/admin/class-create-theme.php
@@ -109,7 +109,7 @@ class Create_Block_Theme_Admin {
 
 		$zip = Theme_Zip::copy_theme_to_zip( $zip, null, null );
 		$zip = Theme_Zip::add_templates_to_zip( $zip, 'current', $theme['slug'] );
-		$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'current' );
+		$zip = Theme_Zip::add_theme_json_to_zip( $zip, MY_Theme_JSON_Resolver::export_theme_data( 'current' ) );
 
 		$zip->close();
 
@@ -144,7 +144,7 @@ class Create_Block_Theme_Admin {
 
 		$zip = Theme_Zip::copy_theme_to_zip( $zip, $theme['slug'], $theme['name'] );
 		$zip = Theme_Zip::add_templates_to_zip( $zip, 'current', $theme['slug'] );
-		$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'current' );
+		$zip = Theme_Zip::add_theme_json_to_zip( $zip, MY_Theme_JSON_Resolver::export_theme_data( 'current' ) );
 
 		// Add readme.txt.
 		$zip->addFromStringToTheme(
@@ -213,7 +213,7 @@ class Create_Block_Theme_Admin {
 		$zip = Theme_Zip::copy_theme_to_zip( $zip, $theme['slug'], $theme['name'] );
 
 		$zip = Theme_Zip::add_templates_to_zip( $zip, 'all', $theme['slug'] );
-		$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'all' );
+		$zip = Theme_Zip::add_theme_json_to_zip( $zip, MY_Theme_JSON_Resolver::export_theme_data( 'all' ) );
 
 		// Add readme.txt.
 		$zip->addFromStringToTheme(
@@ -277,7 +277,7 @@ class Create_Block_Theme_Admin {
 		$zip      = Theme_Zip::create_zip( $filename );
 
 		$zip = Theme_Zip::add_templates_to_zip( $zip, 'user', $theme['slug'] );
-		$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'user' );
+		$zip = Theme_Zip::add_theme_json_to_zip( $zip, MY_Theme_JSON_Resolver::export_theme_data( 'user' ) );
 
 		// Add readme.txt.
 		$zip->addFromStringToTheme(
@@ -321,7 +321,7 @@ class Create_Block_Theme_Admin {
 
 		$zip = Theme_Zip::copy_theme_to_zip( $zip, null, null );
 		$zip = Theme_Zip::add_templates_to_zip( $zip, 'all', null );
-		$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'all' );
+		$zip = Theme_Zip::add_theme_json_to_zip( $zip, MY_Theme_JSON_Resolver::export_theme_data( 'all' ) );
 
 		$zip->close();
 

--- a/admin/create-theme/theme-fonts.php
+++ b/admin/create-theme/theme-fonts.php
@@ -22,7 +22,12 @@ class Theme_Fonts {
 	}
 
 	public static function copy_activated_fonts_to_theme() {
-		$font_families_to_copy = static::get_user_activated_fonts();
+		$user_settings = MY_Theme_JSON_Resolver::get_user_data()->get_settings();
+		if ( ! isset( $user_settings['typography']['fontFamilies']['custom'] ) ) {
+			return null;
+		}
+
+		$font_families_to_copy = $user_settings['typography']['fontFamilies']['custom'];
 
 		// If there are no custom fonts, bounce out
 		if ( is_null( $font_families_to_copy ) ) {

--- a/admin/create-theme/theme-fonts.php
+++ b/admin/create-theme/theme-fonts.php
@@ -12,17 +12,24 @@ class Theme_Fonts {
 		static::copy_activated_fonts_to_theme();
 	}
 
-	public static function copy_activated_fonts_to_theme() {
-
+	public static function get_user_activated_fonts() {
 		$user_settings = MY_Theme_JSON_Resolver::get_user_data()->get_settings();
-		$theme_json    = MY_Theme_JSON_Resolver::get_theme_file_contents();
+		if ( ! isset( $user_settings['typography']['fontFamilies']['custom'] ) ) {
+			return null;
+		}
+
+		return $user_settings['typography']['fontFamilies']['custom'];
+	}
+
+	public static function copy_activated_fonts_to_theme() {
+		$font_families_to_copy = static::get_user_activated_fonts();
 
 		// If there are no custom fonts, bounce out
-		if ( ! isset( $user_settings['typography']['fontFamilies']['custom'] ) ) {
+		if ( is_null( $font_families_to_copy ) ) {
 			return;
 		}
 
-		$font_families_to_copy = $user_settings['typography']['fontFamilies']['custom'];
+		$theme_json = MY_Theme_JSON_Resolver::get_theme_file_contents();
 
 		// copy font face assets to theme and change the src to the new location
 		require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -269,10 +269,14 @@ class Create_Block_Theme_API {
 		// Create ZIP file in the temporary directory.
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
 		$zip      = Theme_Zip::create_zip( $filename, $theme['slug'] );
+		$zip      = Theme_Zip::copy_theme_to_zip( $zip, $theme['slug'], $theme['name'] );
+		$zip      = Theme_Zip::add_templates_to_zip( $zip, 'all', $theme['slug'] );
 
-		$zip = Theme_Zip::copy_theme_to_zip( $zip, $theme['slug'], $theme['name'] );
-		$zip = Theme_Zip::add_templates_to_zip( $zip, 'all', $theme['slug'] );
-		$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'all' );
+		//TODO: Should the font persistent be optional?
+		// If so then the Font Library fonts will need to be removed from the theme.json settings.
+		$theme_json = MY_Theme_JSON_Resolver::export_theme_data( 'all' );
+		$theme_json = Theme_Zip::add_activated_fonts_to_zip( $zip, $theme_json );
+		$zip        = Theme_Zip::add_theme_json_to_zip( $zip, $theme_json );
 
 		// Add readme.txt.
 		$zip->addFromStringToTheme(
@@ -316,8 +320,11 @@ class Create_Block_Theme_API {
 		$filename = tempnam( get_temp_dir(), $theme['slug'] );
 		$zip      = Theme_Zip::create_zip( $filename, $theme['slug'] );
 
-		$zip = Theme_Zip::add_templates_to_zip( $zip, 'user', $theme['slug'] );
-		$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'variation' );
+		//TODO: Should the font persistent be optional?
+		// If so then the Font Library fonts will need to be removed from the theme.json settings.
+		$theme_json = MY_Theme_JSON_Resolver::export_theme_data( 'variation' );
+		$theme_json = Theme_Zip::add_activated_fonts_to_zip( $zip, $theme_json );
+		$zip        = Theme_Zip::add_theme_json_to_zip( $zip, $theme_json );
 
 		// Add readme.txt.
 		$zip->addFromStringToTheme(
@@ -369,12 +376,16 @@ class Create_Block_Theme_API {
 		$zip = Theme_Zip::copy_theme_to_zip( $zip, null, null );
 
 		if ( is_child_theme() ) {
-			$zip = Theme_Zip::add_templates_to_zip( $zip, 'current', $theme_slug );
-			$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'current' );
+			$zip        = Theme_Zip::add_templates_to_zip( $zip, 'current', $theme_slug );
+			$theme_json = MY_Theme_JSON_Resolver::export_theme_data( 'current' );
 		} else {
-			$zip = Theme_Zip::add_templates_to_zip( $zip, 'all', null );
-			$zip = Theme_Zip::add_theme_json_to_zip( $zip, 'all' );
+			$zip        = Theme_Zip::add_templates_to_zip( $zip, 'all', null );
+			$theme_json = MY_Theme_JSON_Resolver::export_theme_data( 'all' );
 		}
+
+		$theme_json = Theme_Zip::add_activated_fonts_to_zip( $zip, $theme_json );
+
+		$zip = Theme_Zip::add_theme_json_to_zip( $zip, $theme_json );
 
 		$zip->close();
 


### PR DESCRIPTION
Previously fonts were only "managed" with Create Block Theme on the "save" action.

This change includes the activated fonts in the exported zip action.

To test activate a font using the Font Manager.

Do NOT 'Save' the theme (that font will be persisted in the theme and this isn't the functionality we're adding).

Export the theme.  Note that any font that is active is included in the exported theme's `theme.json` and the assets it is referencing are included in `/assets/fonts/*`.

Fixes: #558 