### PR TITLE
Fix/un transposed patterns

### DIFF
--- a/admin/create-theme/theme-templates.php
+++ b/admin/create-theme/theme-templates.php
@@ -131,10 +131,10 @@ class Theme_Templates {
 	 * @param object $template The template to extract content from.
 	 * @return object The template with the patternized content.
 	 */
-	public static function paternize_template( $template ) {
+	public static function paternize_template( $template, $slug = null ) {
 		// If there is any PHP in the template then paternize
 		if ( str_contains( $template->content, '<?php' ) ) {
-			$pattern                 = Theme_Patterns::pattern_from_template( $template );
+			$pattern                 = Theme_Patterns::pattern_from_template( $template, $slug );
 			$pattern_link_attributes = array(
 				'slug' => $pattern['slug'],
 			);
@@ -173,11 +173,11 @@ class Theme_Templates {
 			$template = Theme_Media::make_template_images_local( $template );
 		}
 
-		$template = self::paternize_template( $template );
-
 		if ( $slug ) {
 			$template = self::replace_template_namespace( $template, $slug );
 		}
+
+		$template = self::paternize_template( $template, $slug );
 
 		return $template;
 	}

--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -30,12 +30,9 @@ class Theme_Utils {
 		return $extension;
 	}
 
-	public static function replace_namespace( $content, $new_slug, $new_name ) {
-		$theme               = wp_get_theme();
-		$old_slug            = $theme->get( 'TextDomain' );
+	public static function replace_namespace( $content, $old_slug, $new_slug, $old_name, $new_name ) {
 		$new_slug_underscore = str_replace( '-', '_', $new_slug );
 		$old_slug_underscore = str_replace( '-', '_', $old_slug );
-		$old_name            = $theme->get( 'Name' );
 
 		// Generate placeholders
 		$placeholder_slug            = md5( $old_slug );
@@ -56,6 +53,10 @@ class Theme_Utils {
 	}
 
 	public static function clone_theme_to_folder( $location, $new_slug, $new_name ) {
+
+		$theme    = wp_get_theme();
+		$old_slug = $theme->get( 'TextDomain' );
+		$old_name = $theme->get( 'Name' );
 
 		// Get real path for our folder
 		$theme_path = get_stylesheet_directory();
@@ -97,7 +98,7 @@ class Theme_Utils {
 			if ( preg_match( "/\.({$valid_extensions_regex})$/", $relative_path ) ) {
 				// Replace namespace values if provided
 				if ( $new_slug ) {
-					$contents = self::replace_namespace( $contents, $new_slug, $new_name );
+					$contents = self::replace_namespace( $contents, $old_slug, $new_slug, $old_name, $new_name );
 				}
 			}
 

--- a/admin/create-theme/theme-zip.php
+++ b/admin/create-theme/theme-zip.php
@@ -31,6 +31,10 @@ class Theme_Zip {
 
 	public static function copy_theme_to_zip( $zip, $new_slug, $new_name ) {
 
+		$theme    = wp_get_theme();
+		$old_slug = $theme->get( 'TextDomain' );
+		$old_name = $theme->get( 'Name' );
+
 		// Get real path for our folder
 		$theme_path = get_stylesheet_directory();
 
@@ -72,7 +76,7 @@ class Theme_Zip {
 
 					// Replace namespace values if provided
 					if ( $new_slug ) {
-						$contents = Theme_Utils::replace_namespace( $contents, $new_slug, $new_name );
+						$contents = Theme_Utils::replace_namespace( $contents, $old_slug, $new_slug, $old_name, $new_name );
 					}
 
 					// Add current file to archive

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -462,7 +462,7 @@ class Create_Block_Theme_API {
 		$sanitized_theme['subfolder']           = sanitize_text_field( $theme['subfolder'] );
 		$sanitized_theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
 		$sanitized_theme['template']            = '';
-		$sanitized_theme['slug']                = sanitize_title( $theme['name'] );
+		$sanitized_theme['slug']                = Theme_Utils::get_theme_slug( $theme['name'] );
 		$sanitized_theme['text_domain']         = $sanitized_theme['slug'];
 		return $sanitized_theme;
 	}

--- a/tests/test-theme-utils.php
+++ b/tests/test-theme-utils.php
@@ -21,4 +21,46 @@ class Test_Create_Block_Theme_Utils extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'old-slug', $updated_pattern_string );
 
 	}
+
+	public function test_replace_namespace_in_code() {
+		$code_string = "<?php
+/**
+ * old-slug functions and definitions
+ *
+ * @package old-slug
+ * @since old-slug 1.0
+ */
+
+if ( ! function_exists( 'old_slug_support' ) ) :
+
+	function old_slug_support() {
+";
+
+		$updated_code_string = Theme_Utils::replace_namespace( $code_string, 'old-slug', 'new-slug', 'Old Name', 'New Name' );
+		$this->assertStringContainsString( '@package new-slug', $updated_code_string );
+		$this->assertStringNotContainsString( 'old-slug', $updated_code_string );
+		$this->assertStringContainsString( 'function new_slug_support', $updated_code_string );
+		$this->assertStringContainsString( "function_exists( 'new_slug_support' )", $updated_code_string );
+	}
+
+	public function test_replace_namespace_in_code_with_single_word_slug() {
+		$code_string = "<?php
+/**
+ * oldslug functions and definitions
+ *
+ * @package oldslug
+ * @since oldslug 1.0
+ */
+
+if ( ! function_exists( 'oldslug_support' ) ) :
+
+	function oldslug_support() {
+";
+
+		$updated_code_string = Theme_Utils::replace_namespace( $code_string, 'oldslug', Theme_Utils::get_theme_slug( 'New Slug' ), 'OldSlug', 'New Slug' );
+		$this->assertStringContainsString( '@package newslug', $updated_code_string );
+		$this->assertStringNotContainsString( 'old-slug', $updated_code_string );
+		$this->assertStringContainsString( 'function newslug_support', $updated_code_string );
+		$this->assertStringContainsString( "function_exists( 'newslug_support' )", $updated_code_string );
+	}
 }

--- a/tests/test-theme-utils.php
+++ b/tests/test-theme-utils.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @package Create_Block_Theme
+ */
+class Test_Create_Block_Theme_Utils extends WP_UnitTestCase {
+
+	public function test_replace_namespace_in_pattern() {
+		$pattern_string = '<?php
+/**
+ * Title: index
+ * Slug: old-slug/index
+ * Categories: hidden
+ * Inserter: no
+ */
+?>
+<!-- wp:template-part {"slug":"header-minimal","tagName":"header"} /-->
+';
+
+		$updated_pattern_string = Theme_Utils::replace_namespace( $pattern_string, 'old-slug', 'new-slug', 'Old Name', 'New Name' );
+		$this->assertStringContainsString( 'Slug: new-slug/index', $updated_pattern_string );
+		$this->assertStringNotContainsString( 'old-slug', $updated_pattern_string );
+
+	}
+}


### PR DESCRIPTION
When a pattern is created during the cloning action (for example if the source theme has templates with text content and the template is processed to localize the text) then the patterns that are created have the SOURCE theme's namespace rather than the new theme.

This change passes that new slug value when creating the pattern so that it is used instead.

To test:
* Activate the Programme theme (which has un-localized content in the index template)
* Create a CLONE of Programme using CBT.  When the cloned theme is activated it should work as expected.
* Observe all of the created patterns and note that the namespace is correct (the slug based on the name given when cloning the theme)

Also the slug generated from the new theme name is no longer using -'s to fix the issue noted below. Fixes: #566