### PR TITLE
Save only templates that have been changed

### DIFF
--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -438,11 +438,7 @@ class Create_Block_Theme_API {
 		}
 
 		if ( isset( $options['saveTemplates'] ) && true === $options['saveTemplates'] ) {
-			if ( is_child_theme() ) {
-				Theme_Templates::add_templates_to_local( 'current', null, null, $options );
-			} else {
-				Theme_Templates::add_templates_to_local( 'all', null, null, $options );
-			}
+			Theme_Templates::add_templates_to_local( 'user', null, null, $options );
 			Theme_Templates::clear_user_templates_customizations();
 		}
 

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -438,7 +438,15 @@ class Create_Block_Theme_API {
 		}
 
 		if ( isset( $options['saveTemplates'] ) && true === $options['saveTemplates'] ) {
-			Theme_Templates::add_templates_to_local( 'user', null, null, $options );
+			if ( true === $options['processOnlySavedTemplates'] ) {
+				Theme_Templates::add_templates_to_local( 'user', null, null, $options );
+			} else {
+				if ( is_child_theme() ) {
+					Theme_Templates::add_templates_to_local( 'current', null, null, $options );
+				} else {
+					Theme_Templates::add_templates_to_local( 'all', null, null, $options );
+				}
+			}
 			Theme_Templates::clear_user_templates_customizations();
 		}
 

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -18,6 +18,7 @@ export const SaveThemePanel = () => {
 	const [ saveOptions, setSaveOptions ] = useState( {
 		saveStyle: true,
 		saveTemplates: true,
+		processOnlySavedTemplates: true,
 		saveFonts: true,
 		removeNavRefs: false,
 		localizeText: false,
@@ -93,6 +94,22 @@ export const SaveThemePanel = () => {
 						setSaveOptions( {
 							...saveOptions,
 							saveTemplates: ! saveOptions.saveTemplates,
+						} );
+					} }
+				/>
+				<CheckboxControl
+					label="Process Only Saved Templates"
+					help="Process only templates you have modified in the Editor. Any templates you have not modified will be left as is."
+					disabled={ ! saveOptions.saveTemplates }
+					checked={
+						saveOptions.saveTemplates &&
+						saveOptions.processOnlySavedTemplates
+					}
+					onChange={ () => {
+						setSaveOptions( {
+							...saveOptions,
+							processOnlySavedTemplates:
+								! saveOptions.processOnlySavedTemplates,
 						} );
 					} }
 				/>

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -98,7 +98,7 @@ export const SaveThemePanel = () => {
 					} }
 				/>
 				<CheckboxControl
-					label="Process Only Saved Templates"
+					label="Process Only Modified Templates"
 					help="Process only templates you have modified in the Editor. Any templates you have not modified will be left as is."
 					disabled={ ! saveOptions.saveTemplates }
 					checked={


### PR DESCRIPTION
This change ONLY persists CHANGED templates on the SAVE action.

This allows a user to make changes to the template OUTSIDE of the Editor (if desired).  Re-processing of these templates might not be desired.

Note: The downside of the way this currently works is that any processing actions the user has selected (such as localizing text or media assets) will ONLY be done on templates that have been changed by the user in some way.

To Test:

* Activate a theme.
* Change a template directly (not using the Site Editor) in a way that may be processed (such as adding a paragraph tag)
* Save the Theme using Create Block Theme with "localize text" selected.
* Note that the template remains unmodified.
* Change the template with the site editor (for example, changing the content of the paragraph tag)
* Save the Theme using Create Block Theme with "localize text" selected.
* Note that the template has been changed (it points to a pattern and the pattern contains localized text).

