### PR TITLE
i18n: Make modal titles translatable

### DIFF
--- a/src/editor-sidebar/json-editor-modal.js
+++ b/src/editor-sidebar/json-editor-modal.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { Modal } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -22,7 +23,11 @@ const ThemeJsonEditorModal = ( { onRequestClose } ) => {
 	return (
 		<Modal
 			isFullScreen
-			title={ `theme.json for ${ themeName }` }
+			title={ sprintf(
+				// translators: %s: theme name.
+				__( 'theme.json for %s', 'create-block-theme' ),
+				themeName
+			) }
 			onRequestClose={ onRequestClose }
 		>
 			<CodeMirror

--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
@@ -73,7 +73,11 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 	return (
 		<Modal
 			isFullScreen
-			title={ `Metadata for ${ theme?.name }` }
+			title={ sprintf(
+				// translators: %s: theme name.
+				__( 'Metadata for %s', 'create-block-theme' ),
+				theme?.name
+			) }
 			onRequestClose={ onRequestClose }
 		>
 			<VStack>


### PR DESCRIPTION
This PR makes the titles of metadata modals and theme.json modals translatable.

![image](https://github.com/WordPress/create-block-theme/assets/54422211/fb8a9d4c-cf2c-4c2a-b7b4-30d37612229e)
![image](https://github.com/WordPress/create-block-theme/assets/54422211/2402cb4f-efc9-487b-adc2-6bfe4e281d33)
