### PR TITLE
Fix hardcoded wp-admin URLs

### DIFF
--- a/admin/create-theme/theme-form.php
+++ b/admin/create-theme/theme-form.php
@@ -21,7 +21,7 @@ class Theme_Form {
 				printf(
 					/* translators: %s: editor link. */
 					esc_html__( 'This page is deprecated and will be removed in the next release. Please try exporting from the Create Block Theme menu of the %s instead.', 'create-block-theme' ),
-					' <a href="' . esc_url( '/wp-admin/site-editor.php?canvas=edit' ) . '">' . __( 'editor', 'create-block-theme' ) . '</a>'
+					' <a href="' . esc_url( admin_url( 'site-editor.php?canvas=edit' ) ) . '">' . __( 'editor', 'create-block-theme' ) . '</a>'
 				);
 			?>
 		</p>

--- a/src/manage-fonts/index.js
+++ b/src/manage-fonts/index.js
@@ -240,14 +240,17 @@ export default function () {
 						{
 							a: (
 								// eslint-disable-next-line jsx-a11y/anchor-has-content
-								<a href="/wp-admin/site-editor.php?canvas=edit" />
+								<a href="site-editor.php?canvas=edit" />
 							),
 						}
 					) }
 				</p>
 				<img
 					src="https://i0.wp.com/wordpress.org/news/files/2024/04/Font-Manager-2.png?w=620&ssl=1"
-					alt="WordPress 6.5 Font Library"
+					alt={ __(
+						'WordPress 6.5 Font Library',
+						'create-block-theme'
+					) }
 				/>
 				<p>
 					{ createInterpolateElement(


### PR DESCRIPTION
Fixes #561

This PR fixes the following two links so that they work correctly in an environment installed in a subdirectory.

http://localhost:8888/wp-admin/themes.php?page=manage-fonts

![manage-fonts](https://github.com/WordPress/create-block-theme/assets/54422211/f6c20423-d1c0-4171-991c-2f2e23e6c937)

http://localhost:8888/wp-admin/themes.php?page=create-block-theme

![create-block-theme](https://github.com/WordPress/create-block-theme/assets/54422211/3dc264b2-4382-4e85-ac2b-ce3260abbb93)

## Testing Instructions

It's a bit complicated, but in order to actually test this PR, you'll need an environment with WordPress installed in a subdirectory. There are several ways to do this, but [this handbook page](https://developer.wordpress.org/advanced-administration/server/wordpress-in-directory/) will help you set up your environment.