### PR TITLE
Code Quality: Remove `no-undef` eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,13 @@
 {
 	"extends": "plugin:@wordpress/eslint-plugin/recommended",
-	"rules": {
-		"no-undef": "off"
-	}
+	"globals": {
+		"FileReader": true,
+		"FontFace": true
+	},
+	"overrides": [
+		{
+			"files": [ "**/test/**/*.js" ],
+			"extends": [ "plugin:@wordpress/eslint-plugin/test-unit" ]
+		}
+	]
 }

--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 import {
 	// eslint-disable-next-line
 	__experimentalVStack as VStack,
@@ -27,6 +28,8 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 		tags_custom: '',
 		recommended_plugins: '',
 	} );
+
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	useSelect( async ( select ) => {
 		const themeData = select( 'core' ).getCurrentTheme();

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -1,5 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 import apiFetch from '@wordpress/api-fetch';
 import {
 	// eslint-disable-next-line
@@ -23,6 +25,8 @@ export const SaveThemePanel = () => {
 		localizeText: false,
 		localizeImages: false,
 	} );
+
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const handleSaveClick = () => {
 		apiFetch( {

--- a/src/fonts-context.js
+++ b/src/fonts-context.js
@@ -5,17 +5,19 @@ export const ManageFontsContext = createContext();
 
 export function ManageFontsProvider( { children } ) {
 	const [ demoType, setDemoType ] = useState(
-		localStorage.getItem( 'cbt_default-demo-type' ) || DEFAULT_DEMO_TYPE
+		window.localStorage.getItem( 'cbt_default-demo-type' ) ||
+			DEFAULT_DEMO_TYPE
 	);
 
 	const [ demoText, setDemoText ] = useState(
-		localStorage.getItem( 'cbt_default-demo-text' ) ||
+		window.localStorage.getItem( 'cbt_default-demo-text' ) ||
 			DEMO_DEFAULTS[ demoType ].text
 	);
 
 	const [ demoFontSize, setDemoFontSize ] = useState(
-		parseInt( localStorage.getItem( 'cbt_default-demo-font-size' ) ) ||
-			DEMO_DEFAULTS[ demoType ].size
+		parseInt(
+			window.localStorage.getItem( 'cbt_default-demo-font-size' )
+		) || DEMO_DEFAULTS[ demoType ].size
 	);
 
 	const [ axes, setAxes ] = useState( {} );
@@ -32,18 +34,21 @@ export function ManageFontsProvider( { children } ) {
 
 	const handleDemoTextChange = ( newDemoText ) => {
 		setDemoText( newDemoText );
-		localStorage.setItem( 'cbt_default-demo-text', newDemoText );
+		window.localStorage.setItem( 'cbt_default-demo-text', newDemoText );
 	};
 
 	const handleDemoTypeChange = ( newDemoType ) => {
 		setDemoType( newDemoType );
-		localStorage.setItem( 'cbt_default-demo-type', newDemoType );
+		window.localStorage.setItem( 'cbt_default-demo-type', newDemoType );
 		resetDefaults( newDemoType );
 	};
 
 	const handleDemoFontSizeChange = ( newDemoFontSize ) => {
 		setDemoFontSize( newDemoFontSize );
-		localStorage.setItem( 'cbt_default-demo-font-size', newDemoFontSize );
+		window.localStorage.setItem(
+			'cbt_default-demo-font-size',
+			newDemoFontSize
+		);
 	};
 
 	const resetDefaults = ( newDemoType ) => {
@@ -55,7 +60,7 @@ export function ManageFontsProvider( { children } ) {
 
 	// The list of families that are open (showing the list of font faces) in the font manager.
 	const [ familiesOpen, setFamiliesOpen ] = useState(
-		JSON.parse( localStorage.getItem( 'cbt_families-open' ) ) || []
+		JSON.parse( window.localStorage.getItem( 'cbt_families-open' ) ) || []
 	);
 
 	const handleToggleFamily = ( familyName ) => {
@@ -68,7 +73,7 @@ export function ManageFontsProvider( { children } ) {
 			newFamiliesOpen = [ ...familiesOpen, familyName ];
 		}
 		setFamiliesOpen( newFamiliesOpen );
-		localStorage.setItem(
+		window.localStorage.setItem(
 			'cbt_families-open',
 			JSON.stringify( newFamiliesOpen )
 		);

--- a/src/fonts-sidebar/index.js
+++ b/src/fonts-sidebar/index.js
@@ -1,4 +1,4 @@
-import { __, _n } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { trash } from '@wordpress/icons';

--- a/src/google-fonts/index.js
+++ b/src/google-fonts/index.js
@@ -143,7 +143,7 @@ function GoogleFonts() {
 	useEffect( () => {
 		( async () => {
 			const responseData = await fetch(
-				createBlockTheme.googleFontsDataUrl
+				window.createBlockTheme.googleFontsDataUrl
 			);
 			const parsedData = await responseData.json();
 			setGoogleFontsData( parsedData );

--- a/src/manage-fonts/back-button.js
+++ b/src/manage-fonts/back-button.js
@@ -3,7 +3,7 @@ import { chevronLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 function BackButton() {
-	const { adminUrl } = createBlockTheme;
+	const { adminUrl } = window.createBlockTheme;
 	return (
 		<Button
 			varint="secondary"

--- a/src/manage-fonts/font-family.js
+++ b/src/manage-fonts/font-family.js
@@ -2,7 +2,7 @@ import { useContext } from '@wordpress/element';
 import { Button, Icon } from '@wordpress/components';
 import FontFace from './font-face';
 import { ManageFontsContext } from '../fonts-context';
-import { __, _n } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { chevronUp, chevronDown } from '@wordpress/icons';
 
 function FontFamily( { fontFamily, deleteFont } ) {

--- a/src/manage-fonts/page-header.js
+++ b/src/manage-fonts/page-header.js
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { Button, Icon } from '@wordpress/components';
 
 function PageHeader( { toggleIsHelpOpen } ) {
-	const { adminUrl } = createBlockTheme;
+	const { adminUrl } = window.createBlockTheme;
 
 	return (
 		<>

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,7 +47,7 @@ export function localFileAsThemeAssetUrl( url ) {
 	if ( ! url ) {
 		return url;
 	}
-	return url.replace( 'file:./', createBlockTheme.themeUrl + '/' );
+	return url.replace( 'file:./', window.createBlockTheme.themeUrl + '/' );
 }
 
 export async function downloadFile( response ) {
@@ -57,9 +57,10 @@ export async function downloadFile( response ) {
 		.split( 'filename=' )[ 1 ];
 
 	// Check if the browser supports navigator.msSaveBlob or navigator.saveBlob
-	if ( navigator.msSaveBlob || navigator.saveBlob ) {
-		const saveBlob = navigator.msSaveBlob || navigator.saveBlob;
-		saveBlob.call( navigator, blob, filename );
+	if ( window.navigator.msSaveBlob || window.navigator.saveBlob ) {
+		const saveBlob =
+			window.navigator.msSaveBlob || window.navigator.saveBlob;
+		saveBlob.call( window.navigator, blob, filename );
 	} else {
 		// Fall back to creating an object URL and triggering a download using an anchor element
 		const url = URL.createObjectURL( blob );


### PR DESCRIPTION
This PR removes the disabled `no-undef` rule in the eslint rules and fixes the lint errors that occurred with it.

Disabling the `no-undef` rule globally is dangerous. This is because you can use variables and functions that have not been previously defined or imported, making it easier to overlook critical errors.

In fact, there were already variables and functions that were not defined. The reason these didn't cause an error was probably because the variable or function happened to be defined in another JavaScript.

Instead of removing the `no-undef` rule, I added the following configuration to the eslint:

- `globals`: Suppresses warning errors that occur in the two constructors `FontFace` and `FileReader`.
- `overrides`: To prevent `it` and `describe` from causing warning errors in unit tests, add unit test rules to the javascript files in the `test` directory.

## Testing Instructions

This PR does not add or change any functionality, so it should work correctly as before, but please test the following:

- Write code that does not follow the eslint rules to ensure that the eslint itself works as before. For example, inject a component like `<Test />` that doesn't exist. When you run `npm run lint:js` you should get the following error:
  `error  'Test' is not defined  react/jsx-no-undef`
- Write a function like `test()` that is not predefined. trunk does not warn this statement as an error, but when you run `npm run :lint` on this PR, you should get the following error:
  `error  'test' is not defined  no-undef`