### PR TITLE
Fix error when exporting theme with no fonts

### DIFF
--- a/admin/create-theme/theme-zip.php
+++ b/admin/create-theme/theme-zip.php
@@ -37,6 +37,10 @@ class Theme_Zip {
 		$theme_font_asset_location = '/assets/fonts/';
 		$font_slugs_to_remove      = array();
 
+		if ( ! $font_families_to_copy ) {
+			return $theme_json_string;
+		}
+
 		foreach ( $font_families_to_copy as &$font_family ) {
 			if ( ! isset( $font_family['fontFace'] ) ) {
 				continue;


### PR DESCRIPTION
When there are no fonts to export an error is thrown (null ref).  
This change checks for fonts to copy to the theme zip before trying to.

Found the bug while testing [this reported issue](https://wordpress.org/support/topic/create-child-theme-bug/).

Fixes #585 

To test: 

* Activate Twenty Twenty Four
* Make a minor change with Global Styles (such as background color) and save Global Styles. (Do not add fonts.)
* Create a Child Theme (Create Theme > Create Child Theme)
* The theme should be successfully created.
* Export the Theme with CBT
* The theme should be successfully exported.