### PR TITLE
Process group background image when saving theme

### DIFF
--- a/admin/create-theme/theme-media.php
+++ b/admin/create-theme/theme-media.php
@@ -73,6 +73,13 @@ class Theme_Media {
 					}
 				}
 			}
+
+			// Gets the absolute URLs of background images in these blocks
+			if ( 'core/group' === $block['blockName'] ) {
+				if ( isset( $block['attrs']['style']['background']['backgroundImage']['url'] ) && Theme_Utils::is_absolute_url( $block['attrs']['style']['background']['backgroundImage']['url'] ) ) {
+					$media[] = $block['attrs']['style']['background']['backgroundImage']['url'];
+				}
+			}
 		}
 
 		return $media;

--- a/tests/test-theme-media.php
+++ b/tests/test-theme-media.php
@@ -60,4 +60,24 @@ class Test_Create_Block_Theme_Media extends WP_UnitTestCase {
 
 	}
 
+	public function test_make_group_block_local() {
+		$template          = new stdClass();
+		$template->slug    = 'test-template';
+		$template->content = '
+			<!-- wp:group {"style":{"background":{"backgroundImage":{"url":"http://example.com/image.jpg","id":31,"source":"file","title":"Screenshot 2024-04-18 at 14-08-49 Blog Home ‹ Template ‹ a8c-wp-env ‹ Editor — WordPress"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group"></div>
+			<!-- /wp:group -->
+		';
+		$new_template      = Theme_Templates::prepare_template_for_export( $template );
+
+		// Content should be replaced with a pattern block
+		$this->assertStringContainsString( '<!-- wp:pattern', $new_template->content );
+
+		// The media to install should be in the collection
+		$this->assertContains( 'http://example.com/image.jpg', $new_template->media );
+
+		// The pattern is correctly encoded
+		$this->assertStringContainsString( '{"backgroundImage":{"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/image.jpg"', $new_template->pattern );
+
+	}
 }


### PR DESCRIPTION
When saving a theme with "localize images" selected the background image of a group block should be included.

To test:

* Edit a template in a theme and add a group block
* Add a background image to that group block
* Save your changes (to the user space)
* Using CBT save your changes (to the theme).  Make sure "Localize Images" is selected
* Observe our theme files.  Note that the template that was edited uses a pattern, the pattern has the group block with an image referenced from the /assets folder
* Export the theme.  Note that the template, pattern and assets are correct