### PR TITLE
Removed unnecessary filter rejecting unsafe URLs

### DIFF
--- a/admin/create-theme/theme-media.php
+++ b/admin/create-theme/theme-media.php
@@ -97,14 +97,6 @@ class Theme_Media {
 	 */
 	public static function add_media_to_local( $media ) {
 
-		//TODO: Hack to allow http localhost (a common environment...)
-		function turn_off_reject_unsafe_urls( $args ) {
-			$args['reject_unsafe_urls'] = false;
-			$args['sslverify']          = false;
-			return $args;
-		}
-		add_filter( 'http_request_args', 'turn_off_reject_unsafe_urls' );
-
 		foreach ( $media as $url ) {
 
 			$download_file = download_url( $url );
@@ -128,6 +120,7 @@ class Theme_Media {
 				rename( $download_file, $media_path . basename( $url ) );
 			}
 		}
+
 	}
 
 


### PR DESCRIPTION
It seems that the filter to allow unsafe URLs was unnecessary.  I believe it was added to get the plugin to work as expected in a docker container (wp-env) and another solution was ultimately used to make that work anyway.

With this filter removed there should be no more problems as described in #584

Fixes #584 

NOTE: I was unable to reproduce this with the steps provided in #584.  However I'm sure it could be triggered given the function could be constructed multiple times with that logic.

To Test:
* Edit a template with media to be saved. (For example add an image block to the index template)
* Save the template
* Save the theme (make sure "Localize Images" is selected).
* Note that the image asset is saved in the `/asset` folder and referenced from the pattern

Since this was originally added to support the plugin in a docker environment (wp-env) that environment was used to verify that it is working as expected.