### PR TITLE
Make sure code is being deployed to the directory only on Release PR Merge

### DIFF
--- a/.github/workflows/deploy-to-dotorg.yml
+++ b/.github/workflows/deploy-to-dotorg.yml
@@ -1,16 +1,6 @@
 name: Deploy to WordPress.org
 
 on:
-    workflow_dispatch:
-        inputs:
-            release_type:
-                description: 'Release type'
-                required: true
-                type: choice
-                options:
-                    - major
-                    - minor
-                    - patch
     pull_request:
         types: [closed]
         branches:

--- a/.github/workflows/deploy-to-dotorg.yml
+++ b/.github/workflows/deploy-to-dotorg.yml
@@ -12,8 +12,8 @@ jobs:
             github.event_name == 'pull_request' &&
             github.event.pull_request.merged == true &&
             startsWith(github.event.pull_request.head.ref, 'release/') &&
-            contains(github.event.pull_request.head.ref, '/major') || contains(github.event.pull_request.head.ref, '/minor') || contains(github.event.pull_request.head.ref, '/patch') &&
-            (github.event.pull_request.user.login == 'github-actions[bot]')
+            ( contains(github.event.pull_request.head.ref, '/major') || contains(github.event.pull_request.head.ref, '/minor') || contains(github.event.pull_request.head.ref, '/patch') ) &&
+            ( github.event.pull_request.user.login == 'github-actions[bot]' )
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3


### PR DESCRIPTION
An error in the logic made the Deploy to dotOrg workflow run even if the release PR was closed without merging it.

I've also removed the ability to manually deploy, which was left there unintentionally.