### PR TITLE
Editor Sidebar: Improve screen header UI

### DIFF
--- a/src/editor-sidebar/create-panel.js
+++ b/src/editor-sidebar/create-panel.js
@@ -19,7 +19,9 @@ import {
 	TextControl,
 	TextareaControl,
 } from '@wordpress/components';
-import { chevronLeft, addCard, copy } from '@wordpress/icons';
+import { addCard, copy } from '@wordpress/icons';
+
+import ScreenHeader from './screen-header';
 
 export const CreateThemePanel = ( { createType } ) => {
 	const { createErrorNotice } = useDispatch( noticesStore );
@@ -148,12 +150,9 @@ export const CreateThemePanel = ( { createType } ) => {
 
 	return (
 		<PanelBody>
-			<Heading>
-				<NavigatorToParentButton icon={ chevronLeft }>
-					{ __( 'Create Theme', 'create-block-theme' ) }
-				</NavigatorToParentButton>
-			</Heading>
-
+			<ScreenHeader
+				title={ __( 'Create Theme', 'create-block-theme' ) }
+			/>
 			<VStack>
 				<TextControl
 					label={ __( 'Theme name', 'create-block-theme' ) }

--- a/src/editor-sidebar/create-variation-panel.js
+++ b/src/editor-sidebar/create-variation-panel.js
@@ -15,8 +15,10 @@ import {
 	Button,
 	TextControl,
 } from '@wordpress/components';
-import { chevronLeft, copy } from '@wordpress/icons';
+import { copy } from '@wordpress/icons';
 import { postCreateThemeVariation } from '../resolvers';
+
+import ScreenHeader from './screen-header';
 
 export const CreateVariationPanel = () => {
 	const { createErrorNotice } = useDispatch( noticesStore );
@@ -50,12 +52,9 @@ export const CreateVariationPanel = () => {
 
 	return (
 		<PanelBody>
-			<Heading>
-				<NavigatorToParentButton icon={ chevronLeft }>
-					{ __( 'Create Variation', 'create-block-theme' ) }
-				</NavigatorToParentButton>
-			</Heading>
-
+			<ScreenHeader
+				title={ __( 'Create Variation', 'create-block-theme' ) }
+			/>
 			<VStack>
 				<Text>
 					{ __(

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -14,7 +14,9 @@ import {
 	Button,
 	CheckboxControl,
 } from '@wordpress/components';
-import { chevronLeft, archive } from '@wordpress/icons';
+import { archive } from '@wordpress/icons';
+
+import ScreenHeader from './screen-header';
 
 export const SaveThemePanel = () => {
 	const [ saveOptions, setSaveOptions ] = useState( {
@@ -61,12 +63,9 @@ export const SaveThemePanel = () => {
 
 	return (
 		<PanelBody>
-			<Heading>
-				<NavigatorToParentButton icon={ chevronLeft }>
-					{ __( 'Save Changes', 'create-block-theme' ) }
-				</NavigatorToParentButton>
-			</Heading>
-
+			<ScreenHeader
+				title={ __( 'Save Changes', 'create-block-theme' ) }
+			/>
 			<VStack>
 				<CheckboxControl
 					label="Save Fonts"

--- a/src/editor-sidebar/screen-header.js
+++ b/src/editor-sidebar/screen-header.js
@@ -1,0 +1,42 @@
+import {
+	// eslint-disable-next-line
+	__experimentalHStack as HStack,
+	// eslint-disable-next-line
+	__experimentalVStack as VStack,
+	// eslint-disable-next-line
+	__experimentalSpacer as Spacer,
+	// eslint-disable-next-line
+	__experimentalHeading as Heading,
+	// eslint-disable-next-line
+	__experimentalNavigatorToParentButton as NavigatorToParentButton,
+} from '@wordpress/components';
+import { isRTL, __ } from '@wordpress/i18n';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
+
+const ScreenHeader = ( { title, onBack } ) => {
+	return (
+		<Spacer marginBottom={ 0 } paddingBottom={ 4 }>
+			<HStack spacing={ 2 }>
+				<NavigatorToParentButton
+					style={ { minWidth: 24, padding: 0 } }
+					icon={ isRTL() ? chevronRight : chevronLeft }
+					size="small"
+					label={ __( 'Back', 'create-block-theme' ) }
+					onClick={ onBack }
+				/>
+				<Spacer>
+					<Heading
+						level={ 2 }
+						size={ 13 }
+						// Need to override the too specific bottom margin for complementary areas.
+						style={ { margin: 0 } }
+					>
+						{ title }
+					</Heading>
+				</Spacer>
+			</HStack>
+		</Spacer>
+	);
+};
+
+export default ScreenHeader;

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -35,7 +35,6 @@ import {
 	edit,
 	code,
 	chevronRight,
-	chevronLeft,
 	addCard,
 	blockMeta,
 } from '@wordpress/icons';
@@ -45,6 +44,7 @@ import ThemeJsonEditorModal from './editor-sidebar/json-editor-modal';
 import { SaveThemePanel } from './editor-sidebar/save-panel';
 import { CreateVariationPanel } from './editor-sidebar/create-variation-panel';
 import { ThemeMetadataEditorModal } from './editor-sidebar/metadata-editor-modal';
+import ScreenHeader from './editor-sidebar/screen-header';
 import { downloadExportedTheme } from './resolvers';
 
 const CreateBlockThemePlugin = () => {
@@ -181,14 +181,12 @@ const CreateBlockThemePlugin = () => {
 
 					<NavigatorScreen path="/clone">
 						<PanelBody>
-							<Heading>
-								<NavigatorToParentButton icon={ chevronLeft }>
-									{ __(
-										'Create Block Theme',
-										'create-block-theme'
-									) }
-								</NavigatorToParentButton>
-							</Heading>
+							<ScreenHeader
+								title={ __(
+									'Create Block Theme',
+									'create-block-theme'
+								) }
+							/>
 							<VStack>
 								<Text>
 									{ __(


### PR DESCRIPTION
Fixes #604

This PR improves the UI in the title section of the editor sidebar and accomplishes the following:

- The header UI mostly matches the Global Styles header.
- Separate button and h2 title. This separates the button's focus outline from the title and also makes it suitable as markup.
- Screen readers correctly say "Back" when the button has focus.
- If it is an RTL language, the chevron icon changes from left to right.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/create-block-theme/assets/54422211/27b7d008-b96c-47a6-9c4f-301df85ebe18) | ![image](https://github.com/WordPress/create-block-theme/assets/54422211/fd6c4466-8edf-494a-a665-72b52787929b) | 

In implementing these, I mimicked [ScreenHeader component](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/global-styles/header.js) in Gutenberg repo.
