### PR TITLE
Check ZipArchive class before zip export

### DIFF
--- a/admin/class-create-theme.php
+++ b/admin/class-create-theme.php
@@ -462,6 +462,9 @@ class Create_Block_Theme_Admin {
 				$this->create_blank_theme( $_POST['theme'], $_FILES['screenshot'] );
 
 				add_action( 'admin_notices', array( 'Form_Messages', 'admin_notice_blank_success' ) );
+			} elseif ( ! class_exists( 'ZipArchive' ) ) {
+				// Avoid running if ZipArchive is not enabled.
+				add_action( 'admin_notices', array( 'Form_Messages', 'admin_notice_error_unsupported_zip_archive' ) );
 			} elseif ( is_child_theme() ) {
 				if ( 'sibling' === $_POST['theme']['type'] ) {
 					if ( '' === $_POST['theme']['name'] ) {

--- a/admin/create-theme/form-messages.php
+++ b/admin/create-theme/form-messages.php
@@ -103,4 +103,13 @@ class Form_Messages {
 			</div>
 		<?php
 	}
+
+	public static function admin_notice_error_unsupported_zip_archive() {
+		$themes_dir = get_theme_root();
+		?>
+			<div class="notice notice-error">
+				<p><?php _e( 'Unable to create a zip file. ZipArchive not available.', 'create-block-theme' ); ?></p>
+			</div>
+		<?php
+	}
 }

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -367,6 +367,13 @@ class Create_Block_Theme_API {
 	 * Export the theme as a ZIP file.
 	 */
 	function rest_export_theme( $request ) {
+		if ( ! class_exists( 'ZipArchive' ) ) {
+			return new WP_Error(
+				'missing_zip_package',
+				__( 'Unable to create a zip file. ZipArchive not available.', 'create-block-theme' ),
+			);
+		}
+
 		$theme_slug = wp_get_theme()->get( 'TextDomain' );
 
 		// Create ZIP file in the temporary directory.

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -46,6 +46,7 @@ import { CreateVariationPanel } from './editor-sidebar/create-variation-panel';
 import { ThemeMetadataEditorModal } from './editor-sidebar/metadata-editor-modal';
 import ScreenHeader from './editor-sidebar/screen-header';
 import { downloadExportedTheme } from './resolvers';
+import { downloadFile } from './utils';
 
 const CreateBlockThemePlugin = () => {
 	const [ isEditorOpen, setIsEditorOpen ] = useState( false );
@@ -56,8 +57,12 @@ const CreateBlockThemePlugin = () => {
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 
-	const handleExportClick = () => {
-		downloadExportedTheme().catch( ( error ) => {
+	const handleExportClick = async () => {
+		try {
+			const response = await downloadExportedTheme();
+			downloadFile( response );
+		} catch ( errorResponse ) {
+			const error = await errorResponse.json();
 			const errorMessage =
 				error.message && error.code !== 'unknown_error'
 					? error.message
@@ -66,7 +71,7 @@ const CreateBlockThemePlugin = () => {
 							'create-block-theme'
 					  );
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
-		} );
+		}
 	};
 
 	return (

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,5 +1,4 @@
 import apiFetch from '@wordpress/api-fetch';
-import { downloadFile } from './utils';
 
 export async function fetchThemeJson() {
 	const fetchOptions = {
@@ -57,7 +56,5 @@ export async function downloadExportedTheme() {
 			'Content-Type': 'application/json',
 		},
 		parse: false,
-	} ).then( ( response ) => {
-		downloadFile( response );
 	} );
 }


### PR DESCRIPTION
Fixes #492

This PR displays an appropriate error message when a process that creates a zip file requires the ZipArchive class and the class does not exist.

Suggestions for displayed text are also welcome!

![image](https://github.com/WordPress/create-block-theme/assets/54422211/d4a7e196-ff4d-4a51-9689-41effa837962)

![image](https://github.com/WordPress/create-block-theme/assets/54422211/a4194323-4452-4478-aea6-0c0b95695d96)

## Testing Instructions

To test this PR, you need to disable the zip extension locally. For wp-env, please follow the steps below.

- Run wp-env: `npm run wp-env start`
- Check the container name: `docker ps`
- Go inside the container: `docker exec -it {YOUR-CONTAINER-NAME}-wordpress-1 bash`
- Remove zip extension: `rm /usr/local/etc/php/conf.d/docker-php-ext-zip.ini`
- Restart Apache: `/etc/init.d/apache2 reload`
- Exit the container: `exit`
- Check the Site Health page to make sure the zip extension is disabled:

After that, confirm that an error message is displayed when you perform the following operations:

- Site Editor
  - Create Block Theme Option > Export Zip
- Appearance > Create Block Theme
  - Export {themeName}
  - Create sibling of {themeName}
  - Create child of {themeName}
  - Clone {themeName}

P.S. Restart wp-env and the zip extension will be automatically enabled again.

## Supplement 

In addition to the REST API endpoint that this PR changes, the ZipArchive class is also used in the callback functions of the following two endpoints. However, these two endpoints currently don't seem to be called from anywhere.

| Endpoint                                  | Callback function              |
| ----------------------------------------- | ------------------------------ |
| create-block-theme/v1/export-clone/       | rest_export_cloned_theme       |
| create-block-theme/v1/export-child-clone/ | rest_export_child_cloned_theme |

