### PR TITLE
Proposal: Use non-default port for wp-env

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,7 @@
 {
 	"core": "WordPress/WordPress",
+	"port": 8988,
+	"testsPort": 8989,
 	"plugins": [ "." ],
 	"config": {
 		"WP_UPLOAD_MAX_FILESIZE": "128M",


### PR DESCRIPTION
I find myself having to stop my Gutenberg environment, which uses the default port, when working on both at around the same time. This change should make it easier to have both environments running in parallel.

I realize I could choose to run a .wp-env.override.json file as well, but I think this might benefit other folks as well.