### PR TITLE
Add Repository Management section to contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,11 @@ Welcome to Create Block Theme! All are welcome here.
 
 We welcome contributions in all forms, including code, design, documentation, and triage.
 
-There is a [GitHub project board](https://github.com/orgs/WordPress/projects/188/views/1) which is used to plan and track the progress of the plugin.
+### Discussions
+
+Contributors can be found in the [#core-editor](https://make.wordpress.org/chat/) and [#outreach](https://wordpress.slack.com/archives/C015GUFFC00) channels in [Make WordPress Slack](https://make.wordpress.org/chat).
+
+There is also a [GitHub project board](https://github.com/orgs/WordPress/projects/188/views/1) which is used to plan and track the progress of the plugin.
 
 ### Development Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Members of the [Block Themers GitHub team](https://github.com/orgs/WordPress/tea
 - Demonstrated a commitment to improving how block themes are built in the editor
 - Made 2-3 meaningful contributions to the plugin (similar to the [Gutenberg team requirements](https://developer.wordpress.org/block-editor/contributors/repository-management/#teams))
 
-If you meet this criteria and would like to be added to the Block Themers team, feel free to ask in the [#core-editor](https://make.wordpress.org/chat/) or [#core-themes](https://wordpress.slack.com/archives/C02RP4VMP) Slack channels.
+If you meet this criteria and would like to be added to the Block Themers team, feel free to ask in the [#core-editor](https://make.wordpress.org/chat/) Slack channel.
 
 If you are not a member of the team, you can still contribute by forking the repository and submitting a pull request.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,14 @@ There are several linter commands available to help ensure the plugin follows th
 
 To test a WordPress plugin, you need to have WordPress itself installed. If you already have a WordPress environment setup, use the above Create Block Theme build as a standard WordPress plugin by putting the `create-block-theme` directory in your wp-content/plugins/ directory.
 
+### Repository Management
+
+Members of the [Block Themers GitHub team](https://github.com/orgs/WordPress/teams/block-themers) have write access to the repository. The team is made up of contributors who have demonstrated a commitment to the project by making 2-3 meaninful contributions (similar to the [Gutenberg team requirements](https://developer.wordpress.org/block-editor/contributors/repository-management/#teams)).
+
+If you meet this criterion of several meaningful contributions having been accepted into the repository and would like to be added to the Block Themers team, feel free to ask in the [#core-editor](https://make.wordpress.org/chat/) or [#core-themes](https://wordpress.slack.com/archives/C02RP4VMP) Slack channels.
+
+If you are not a member of the team, you can still contribute by forking the repository and submitting a pull request.
+
 ## Releasing a new version of Create Block Theme
 
 We have an automated process for the release of new versions of Create Block Theme to the public.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Members of the [Block Themers GitHub team](https://github.com/orgs/WordPress/tea
 - Demonstrated a commitment to improving how block themes are built in the editor
 - Made 2-3 meaningful contributions to the plugin (similar to the [Gutenberg team requirements](https://developer.wordpress.org/block-editor/contributors/repository-management/#teams))
 
-If you meet this criterion and would like to be added to the Block Themers team, feel free to ask in the [#core-editor](https://make.wordpress.org/chat/) or [#core-themes](https://wordpress.slack.com/archives/C02RP4VMP) Slack channels.
+If you meet this criteria and would like to be added to the Block Themers team, feel free to ask in the [#core-editor](https://make.wordpress.org/chat/) or [#core-themes](https://wordpress.slack.com/archives/C02RP4VMP) Slack channels.
 
 If you are not a member of the team, you can still contribute by forking the repository and submitting a pull request.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Welcome to Create Block Theme! All are welcome here.
 
 We welcome contributions in all forms, including code, design, documentation, and triage.
 
+There is a [GitHub project board](https://github.com/orgs/WordPress/projects/188/views/1) which is used to plan and track the progress of the plugin.
+
 ### Development Setup
 
 The basic setup for development is:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,9 +52,12 @@ To test a WordPress plugin, you need to have WordPress itself installed. If you 
 
 ### Repository Management
 
-Members of the [Block Themers GitHub team](https://github.com/orgs/WordPress/teams/block-themers) have write access to the repository. The team is made up of contributors who have demonstrated a commitment to the project by making 2-3 meaninful contributions (similar to the [Gutenberg team requirements](https://developer.wordpress.org/block-editor/contributors/repository-management/#teams)).
+Members of the [Block Themers GitHub team](https://github.com/orgs/WordPress/teams/block-themers) have write access to the repository. The team is made up of contributors who have:
 
-If you meet this criterion of several meaningful contributions having been accepted into the repository and would like to be added to the Block Themers team, feel free to ask in the [#core-editor](https://make.wordpress.org/chat/) or [#core-themes](https://wordpress.slack.com/archives/C02RP4VMP) Slack channels.
+- Demonstrated a commitment to improving how block themes are built in the editor
+- Made 2-3 meaningful contributions to the plugin (similar to the [Gutenberg team requirements](https://developer.wordpress.org/block-editor/contributors/repository-management/#teams))
+
+If you meet this criterion and would like to be added to the Block Themers team, feel free to ask in the [#core-editor](https://make.wordpress.org/chat/) or [#core-themes](https://wordpress.slack.com/archives/C02RP4VMP) Slack channels.
 
 If you are not a member of the team, you can still contribute by forking the repository and submitting a pull request.
 


### PR DESCRIPTION
This adds a "Repository Management" section to the contributing docs in CONTRIBUTING.md. It explains how contributors can gain write access to the repository, following similar guidelines to those used in the Gutenberg repo.

I've also added a link to the GitHub project board.