### PR TITLE
ESLint: Add new rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,16 @@
 		"FileReader": true,
 		"FontFace": true
 	},
+	"rules": {
+		"@wordpress/dependency-group": "error",
+		"@wordpress/i18n-text-domain": [
+			"error",
+			{
+				"allowedTextDomain": "create-block-theme"
+			}
+		],
+		"react/jsx-boolean-value": "error"
+	},
 	"overrides": [
 		{
 			"files": [ "**/test/**/*.js" ],

--- a/src/editor-sidebar/create-panel.js
+++ b/src/editor-sidebar/create-panel.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -21,6 +24,9 @@ import {
 } from '@wordpress/components';
 import { addCard, copy } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
 import ScreenHeader from './screen-header';
 
 export const CreateThemePanel = ( { createType } ) => {

--- a/src/editor-sidebar/create-variation-panel.js
+++ b/src/editor-sidebar/create-variation-panel.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
@@ -16,8 +19,11 @@ import {
 	TextControl,
 } from '@wordpress/components';
 import { copy } from '@wordpress/icons';
-import { postCreateThemeVariation } from '../resolvers';
 
+/**
+ * Internal dependencies
+ */
+import { postCreateThemeVariation } from '../resolvers';
 import ScreenHeader from './screen-header';
 
 export const CreateVariationPanel = () => {

--- a/src/editor-sidebar/json-editor-modal.js
+++ b/src/editor-sidebar/json-editor-modal.js
@@ -1,9 +1,20 @@
+/**
+ * External dependencies
+ */
+import CodeMirror from '@uiw/react-codemirror';
+import { json } from '@codemirror/lang-json';
+
+/**
+ * WordPress dependencies
+ */
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { Modal } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import CodeMirror from '@uiw/react-codemirror';
-import { json } from '@codemirror/lang-json';
+
+/**
+ * Internal dependencies
+ */
 import { fetchThemeJson } from '../resolvers';
 
 const ThemeJsonEditorModal = ( { onRequestClose } ) => {
@@ -34,7 +45,7 @@ const ThemeJsonEditorModal = ( { onRequestClose } ) => {
 				extensions={ [ json() ] }
 				value={ themeData }
 				onChange={ handleSave }
-				readOnly={ true }
+				readOnly
 			/>
 		</Modal>
 	);

--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -15,6 +18,10 @@ import {
 	TextareaControl,
 	ExternalLink,
 } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import { postUpdateThemeMetadata } from '../resolvers';
 
 export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
@@ -92,7 +99,7 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 				</Text>
 				<Spacer />
 				<TextControl
-					disabled={ true }
+					disabled
 					label={ __( 'Theme name', 'create-block-theme' ) }
 					value={ theme.name }
 				/>

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -16,6 +19,9 @@ import {
 import { archive } from '@wordpress/icons';
 import { store as preferencesStore } from '@wordpress/preferences';
 
+/**
+ * Internal dependencies
+ */
 import ScreenHeader from './screen-header';
 
 const PREFERENCE_SCOPE = 'create-block-theme';

--- a/src/editor-sidebar/screen-header.js
+++ b/src/editor-sidebar/screen-header.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import {
 	// eslint-disable-next-line
 	__experimentalHStack as HStack,

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-site';
@@ -39,6 +42,9 @@ import {
 	blockMeta,
 } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
 import { CreateThemePanel } from './editor-sidebar/create-panel';
 import ThemeJsonEditorModal from './editor-sidebar/json-editor-modal';
 import { SaveThemePanel } from './editor-sidebar/save-panel';

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
 
 export async function fetchThemeJson() {

--- a/src/wp-org-theme-directory.js
+++ b/src/wp-org-theme-directory.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
 
 async function loadUnavailableThemeNames() {

--- a/update-version-and-changelog.js
+++ b/update-version-and-changelog.js
@@ -1,4 +1,8 @@
 /* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
 const fs = require( 'fs' );
 const core = require( '@actions/core' );
 const simpleGit = require( 'simple-git' );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config.js' );
 


### PR DESCRIPTION
This PR adds three new rules to ESLint that are [also introduced in the Gutenberg project](https://github.com/WordPress/gutenberg/blob/3bed311299ae15a8562a8ad502870f9fa55130b3/.eslintrc.js#L105-L114).

I believe these rules will improve code quality, prevent unintended problems, and make it easier for contributors.

## Rules

### @wordpress/dependency-group

Force import statements to add `External`, `WordPress`, and `Internal` as comments to indicate what they depend on.

#### ❌

```javascript
import CodeMirror from '@uiw/react-codemirror';
import { __, sprintf } from '@wordpress/i18n';
import { fetchThemeJson } from '../resolvers';
```

#### ✅

```javascript
/**
 * External dependencies
 */
import CodeMirror from '@uiw/react-codemirror';

/**
 * WordPress dependencies
 */
import { __, sprintf } from '@wordpress/i18n';

/**
 * Internal dependencies
 */
import { fetchThemeJson } from '../resolvers';
```

### @wordpress/i18n-text-domain

Forces the text domain called `create-block-theme` in the translation function.

#### ❌

```javascript
__( 'Hello World' )
__( 'Hello World', 'create-block' )
```

#### ✅

```javascript
__( 'Hello World', 'create-block-theme' )
```

### react/jsx-boolean-value

Forces the value to be omitted if the value of props is `true`.

#### ❌

```javascript
<TextControl
	disabled={ true }
/>
```

#### ✅

```javascript
<TextControl
	disabled
/>
```

## Testing Instructions

- Enter a code that does not follow the rules above.
- ESLint should give you a warning.
- If you have the eslint extension installed in your code editor, it will automatically format your code according to these rules.