### PR TITLE
Tests: use tests-wordpress wp-env for phpunit

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"lint:php:fix": "composer run-script format",
 		"lint:md-docs": "wp-scripts lint-md-docs",
 		"lint:pkg-json": "wp-scripts lint-pkg-json",
-		"test:php": "npm run test:php:setup && wp-env run cli --env-cwd='wp-content/plugins/create-block-theme' composer run-script test",
+		"test:php": "npm run test:php:setup && wp-env run tests-wordpress --env-cwd='wp-content/plugins/create-block-theme' composer run-script test",
 		"test:php:watch": "wp-env run cli --env-cwd='wp-content/plugins/create-block-theme' composer run-script test:watch",
 		"test:php:setup": "wp-env start",
 		"packages-update": "wp-scripts packages-update",


### PR DESCRIPTION
Running tests on the `cli` environment causes conflicts with the `dev` environment; the tests will log you out, modify the theme, etc.

Running tests on `tests-wordpress` will allow you to run tests along with the `dev` environment without interference.


## Testing:
1. Run `npm run wp-env start` to start a WordPress environment.
2. Log into the dev environment and see that everything is working normally.
3. Running `npm run test:php` will work as before, and will not mess with the dev environment.
Before applying this branch, running `npm run test:php` would log you out and activate an invalid theme on your dev environment.