### PR TITLE
Update wp-env package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"@wordpress/base-styles": "^4.28.0",
 		"@wordpress/browserslist-config": "^5.16.0",
 		"@wordpress/element": "^5.10.0",
-		"@wordpress/env": "^8.3.0",
+		"@wordpress/env": "^9.9.0",
 		"@wordpress/eslint-plugin": "^17.2.0",
 		"@wordpress/prettier-config": "^2.25.13",
 		"@wordpress/scripts": "^26.16.0",


### PR DESCRIPTION
## What?
Update wp-env package version.

## Why?
To use th latest relase of the package.

I've been getting errors running unit tests for Create Block Theme on Linux. Using the latest version seems to fix the problem.