### PR TITLE
Metadata screenshot

### DIFF
--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -228,7 +228,10 @@ class Theme_Utils {
 		$processed_screenshot_location = Theme_Utils::process_screenshot( $new_screenshot_path );
 
 		// Remove the old screenshot
-		unlink( path_join( get_stylesheet_directory(), wp_get_theme()->get_screenshot( 'relative' ) ) );
+		$old_screenshot = wp_get_theme()->get_screenshot( 'relative' );
+		if ( $old_screenshot ) {
+			unlink( path_join( get_stylesheet_directory(), $old_screenshot ) );
+		}
 
 		// Copy the new screenshot
 		$new_screenshot_filetype = Theme_Utils::get_screenshot_file_extension( $new_screenshot_path );

--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -185,4 +185,55 @@ class Theme_Utils {
 		return 0;
 	}
 
+	public static function is_valid_screenshot_file( $file_path ) {
+		return Theme_Utils::get_screenshot_file_extension( $file_path ) !== null;
+	}
+
+	public static function get_screenshot_file_extension( $file_path ) {
+		$allowed_screenshot_types = array(
+			'png'  => 'image/png',
+			'gif'  => 'image/gif',
+			'jpg'  => 'image/jpeg',
+			'jpeg' => 'image/jpeg',
+			'webp' => 'image/webp',
+			'avif' => 'image/avif',
+		);
+		$filetype                 = wp_check_filetype( $file_path, $allowed_screenshot_types );
+		if ( in_array( $filetype['type'], $allowed_screenshot_types, true ) ) {
+			return $filetype['ext'];
+		}
+		return null;
+	}
+
+	public static function process_screenshot( $file_path ) {
+		$new_screeenshot_id      = attachment_url_to_postid( $file_path );
+		$new_screenshot_metadata = wp_get_attachment_metadata( $new_screeenshot_id );
+		$upload_dir              = wp_get_upload_dir();
+
+		$new_screenshot_location = path_join( $upload_dir['basedir'], $new_screenshot_metadata['file'] );
+
+		// TODO: We're not actually processing anything.  The image might be of the wrong dimensions, too large, etc.
+		// We're just getting the file location so that we can copy it.
+		// Should we process it?  Or just enforce that the screenshot is the correct size?
+
+		return $new_screenshot_location;
+	}
+
+	public static function replace_screenshot( $new_screenshot_path ) {
+		if ( ! Theme_Utils::is_valid_screenshot_file( $new_screenshot_path ) ) {
+			return new \WP_Error( 'invalid_screenshot', __( 'Invalid screenshot file', 'create-block-theme' ) );
+		}
+
+		// Clean up, resize or compress the screenshot if necessary
+		$processed_screenshot_location = Theme_Utils::process_screenshot( $new_screenshot_path );
+
+		// Remove the old screenshot
+		unlink( path_join( get_stylesheet_directory(), wp_get_theme()->get_screenshot( 'relative' ) ) );
+
+		// Copy the new screenshot
+		$new_screenshot_filetype = Theme_Utils::get_screenshot_file_extension( $new_screenshot_path );
+		$new_location            = path_join( get_stylesheet_directory(), 'screenshot.' . $new_screenshot_filetype );
+		copy( $processed_screenshot_location, $new_location );
+	}
+
 }

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -418,6 +418,11 @@ class Create_Block_Theme_API {
 			Theme_Readme::update_readme_txt( $theme )
 		);
 
+		// Replace Screenshot
+		if ( wp_get_theme()->get_screenshot() !== $theme['screenshot'] ) {
+			Theme_Utils::replace_screenshot( $theme['screenshot'] );
+		}
+
 		// Relocate the theme to a new folder
 		$response = Theme_Utils::relocate_theme( $theme['subfolder'] );
 

--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -226,7 +226,7 @@ Plugin Description`,
 							render={ ( { open } ) => (
 								<>
 									{ theme.screenshot ? (
-										<VStack>
+										<VStack alignment="left">
 											<img
 												src={ theme.screenshot }
 												style={ {
@@ -237,29 +237,30 @@ Plugin Description`,
 												} }
 												alt=""
 											/>
-											<HStack justify="flex-start">
-												<Button
-													size="small"
-													onClick={ open }
-												>
-													{ __(
-														'Replace',
-														'create-block-theme'
-													) }
-												</Button>
-											</HStack>
+											<Button
+												variant="secondary"
+												size="compact"
+												onClick={ open }
+											>
+												{ __(
+													'Replace',
+													'create-block-theme'
+												) }
+											</Button>
 										</VStack>
 									) : (
-										<Button
-											variant="secondary"
-											size="compact"
-											onClick={ open }
-										>
-											{ __(
-												'Add screenshot',
-												'create-block-theme'
-											) }
-										</Button>
+										<HStack alignment="left">
+											<Button
+												variant="secondary"
+												size="compact"
+												onClick={ open }
+											>
+												{ __(
+													'Add screenshot',
+													'create-block-theme'
+												) }
+											</Button>
+										</HStack>
 									) }
 								</>
 							) }

--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useState, useRef } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import {
@@ -50,7 +50,6 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 	} );
 
 	const { createErrorNotice } = useDispatch( noticesStore );
-	const screenshotRemoveButtonRef = useRef();
 
 	useSelect( async ( select ) => {
 		const themeData = select( 'core' ).getCurrentTheme();
@@ -95,6 +94,11 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 				createErrorNotice( errorMessage, { type: 'snackbar' } );
 			} );
 	};
+
+	const onUpdateImage = ( image ) => {
+		setTheme( { ...theme, screenshot: image.url } );
+	};
+
 	return (
 		<Modal
 			isFullScreen
@@ -217,7 +221,7 @@ Plugin Description`,
 					<MediaUploadCheck>
 						<MediaUpload
 							title={ __( 'Screenshot', 'create-block-theme' ) }
-							// onSelect={ onUpdateImage }
+							onSelect={ onUpdateImage }
 							allowedTypes={ ALLOWED_SCREENSHOT_MEDIA_TYPES }
 							render={ ( { open } ) => (
 								<>
@@ -240,19 +244,6 @@ Plugin Description`,
 												>
 													{ __(
 														'Replace',
-														'create-block-theme'
-													) }
-												</Button>
-												<Button
-													isDestructive
-													size="small"
-													onClick={ () => {
-														// TODO: Remove Image
-														screenshotRemoveButtonRef.current.focus();
-													} }
-												>
-													{ __(
-														'Remove',
 														'create-block-theme'
 													) }
 												</Button>


### PR DESCRIPTION
Add ability for user to manage the theme's screenshot from Editor on Metadata Modal.

Fixes: #560

<img width="245" alt="image" src="https://github.com/WordPress/create-block-theme/assets/146530/0956ce31-44b6-4b2f-b9fd-53cd3ca8b538">

To Test:

* From the Editor open the CBT Metadata Editor Modal
* Click "Replace" and choose another image to replace the screenshot with
* Click "Update"

The image should be replaced in the theme folder and sized to 1200 x 900 px.

If a screenshot existed prior it should be removed. (Especially if the previous screenshot was another file type)
