### PR TITLE
Allow spaces in theme slugs

### DIFF
--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -6,23 +6,7 @@ class Theme_Utils {
 	}
 
 	public static function get_theme_slug( $new_theme_name ) {
-		$theme = wp_get_theme();
-
-		// If the source theme has a single-word slug but the new theme has a multi-word slug
-		// then function will look like: function apple-bumpkin_support() and that won't work.
-		// There are no issues if it is multi-word>single-word or multi>multi or single>single.
-		// Due to the complexity of this situation (compared to the simplicity of the others)
-		// this will enforce the usage of a singleword slug for those themes.
-
-		$old_slug = $theme->get( 'TextDomain' );
-		$new_slug = sanitize_title( $new_theme_name );
-		$new_slug = preg_replace( '/\s+/', '', $new_slug ); // Remove spaces
-
-		if ( ! str_contains( $old_slug, '-' ) && str_contains( $new_slug, '-' ) ) {
-			return str_replace( '-', '', $new_slug );
-		}
-
-		return $new_slug;
+		return sanitize_title( $new_theme_name );
 	}
 
 	public static function get_file_extension_from_url( $url ) {
@@ -31,8 +15,8 @@ class Theme_Utils {
 	}
 
 	public static function replace_namespace( $content, $old_slug, $new_slug, $old_name, $new_name ) {
-		$new_slug_underscore = str_replace( '-', '_', $new_slug );
-		$old_slug_underscore = str_replace( '-', '_', $old_slug );
+		$new_slug_underscore = str_replace( '-', '_', $new_slug ) . '_';
+		$old_slug_underscore = str_replace( '-', '_', $old_slug ) . '_';
 
 		// Generate placeholders
 		$placeholder_slug            = md5( $old_slug );
@@ -40,13 +24,13 @@ class Theme_Utils {
 		$placeholder_name            = md5( $old_name );
 
 		// Replace old values with placeholders
-		$content = str_replace( $old_slug, $placeholder_slug, $content );
 		$content = str_replace( $old_slug_underscore, $placeholder_slug_underscore, $content );
+		$content = str_replace( $old_slug, $placeholder_slug, $content );
 		$content = str_replace( $old_name, $placeholder_name, $content );
 
 		// Replace placeholders with new values
-		$content = str_replace( $placeholder_slug, $new_slug, $content );
 		$content = str_replace( $placeholder_slug_underscore, $new_slug_underscore, $content );
+		$content = str_replace( $placeholder_slug, $new_slug, $content );
 		$content = str_replace( $placeholder_name, $new_name, $content );
 
 		return $content;

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -484,7 +484,7 @@ class Create_Block_Theme_API {
 		$sanitized_theme['subfolder']           = sanitize_text_field( $theme['subfolder'] );
 		$sanitized_theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
 		$sanitized_theme['template']            = '';
-		$sanitized_theme['slug']                = Theme_Utils::get_theme_slug( $theme['name'] );
+		$sanitized_theme['slug']                = sanitize_title( $theme['name'] );
 		$sanitized_theme['text_domain']         = $sanitized_theme['slug'];
 		return $sanitized_theme;
 	}

--- a/tests/test-theme-utils.php
+++ b/tests/test-theme-utils.php
@@ -57,10 +57,10 @@ if ( ! function_exists( 'oldslug_support' ) ) :
 	function oldslug_support() {
 ";
 
-		$updated_code_string = Theme_Utils::replace_namespace( $code_string, 'oldslug', Theme_Utils::get_theme_slug( 'New Slug' ), 'OldSlug', 'New Slug' );
-		$this->assertStringContainsString( '@package newslug', $updated_code_string );
+		$updated_code_string = Theme_Utils::replace_namespace( $code_string, 'oldslug', sanitize_title( 'New Slug' ), 'OldSlug', 'New Slug' );
+		$this->assertStringContainsString( '@package new-slug', $updated_code_string );
 		$this->assertStringNotContainsString( 'old-slug', $updated_code_string );
-		$this->assertStringContainsString( 'function newslug_support', $updated_code_string );
-		$this->assertStringContainsString( "function_exists( 'newslug_support' )", $updated_code_string );
+		$this->assertStringContainsString( 'function new_slug_support', $updated_code_string );
+		$this->assertStringContainsString( "function_exists( 'new_slug_support' )", $updated_code_string );
 	}
 }


### PR DESCRIPTION
This change allows spaces in theme slugs.

(I thought this would be a much harder problem, but it was actually pretty easy.)

I realized that any time a slug with _'s needed to be replaced it was ALSO followed by a _  ( i.e. slug_name_function and never just slug_name).  So replacing `old_slug_` with `new_slug_` was the answer.

The order of replacement (replacing slugs with _'s first) had to be changed to make sure that when cloning a theme without _'s in the slug that the functions were correctly changed.

Fixes #228 

To Test: 
* Using the CBT interface in the Editor
* Create a Blank theme with a name that contains spaces, dashes and/or underscores
* Clone a theme with a name spaces, dashes and/or underscores

Observe that the new theme has the correct textdomain and it is used correctly throughout the theme (especially in PHP files with functions that use the theme slug such as `functions.php`).