### PR TITLE
Reset changelog and version on clone and theme creation

### DIFF
--- a/admin/create-theme/theme-create.php
+++ b/admin/create-theme/theme-create.php
@@ -8,6 +8,9 @@ class Theme_Create {
 
 	public static function clone_current_theme( $theme ) {
 
+		$theme['version']     = '1.0';
+		$theme['tags_custom'] = implode( ', ', wp_get_theme()->get( 'Tags' ) );
+
 		// Create theme directory.
 		$new_theme_path = get_theme_root() . DIRECTORY_SEPARATOR . $theme['slug'];
 
@@ -29,7 +32,9 @@ class Theme_Create {
 		);
 		Theme_Utils::clone_theme_to_folder( $new_theme_path, $theme['slug'], $theme['name'] );
 		Theme_Templates::add_templates_to_local( 'all', $new_theme_path, $theme['slug'], $template_options );
-		file_put_contents( $new_theme_path . DIRECTORY_SEPARATOR . 'theme.json', MY_Theme_JSON_Resolver::export_theme_data( 'all' ) );
+		file_put_contents( path_join( $new_theme_path, 'theme.json' ), MY_Theme_JSON_Resolver::export_theme_data( 'all' ) );
+		file_put_contents( path_join( $new_theme_path, 'readme.txt' ), Theme_Readme::build_readme_txt( $theme ) );
+		file_put_contents( path_join( $new_theme_path, 'style.css' ), Theme_Styles::update_style_css( file_get_contents( path_join( $new_theme_path, 'style.css' ) ), $theme ) );
 
 		if ( $theme['subfolder'] ) {
 			switch_theme( $theme['subfolder'] . '/' . $theme['slug'] );

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -40,7 +40,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Changelog ==
 
-= 1.0.0 =
+= 1.0 =
 * Initial release
 {$recommended_plugins_section}
 {$copyright_section}

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -11,7 +11,7 @@ class Theme_Styles {
 
 		$current_theme = wp_get_theme();
 		$css_contents  = trim( substr( $style_css, strpos( $style_css, '*/' ) + 2 ) );
-		$name          = $current_theme->get( 'Name' );
+		$name          = stripslashes( $theme['name'] );
 		$description   = stripslashes( $theme['description'] );
 		$uri           = $theme['uri'];
 		$author        = stripslashes( $theme['author'] );
@@ -20,7 +20,7 @@ class Theme_Styles {
 		$version       = $theme['version'];
 		$requires_php  = $current_theme->get( 'RequiresPHP' );
 		$template      = $current_theme->get( 'Template' );
-		$text_domain   = $current_theme->get( 'TextDomain' );
+		$text_domain   = $theme['slug'];
 
 		//TODO: These items don't seem to be available via ->get('License') calls
 		$license      = 'GNU General Public License v2 or later';
@@ -66,7 +66,7 @@ Tags: {$tags}
 		if ( isset( $theme['template'] ) ) {
 			$template = $theme['template'];
 		}
-		$version = '1.0.0';
+		$version = '1.0';
 		$tags    = Theme_Tags::theme_tags_list( $theme );
 
 		if ( isset( $theme['version'] ) ) {


### PR DESCRIPTION
style.css and readme.txt should be bare (having only the values defined when creating the theme), changelog should be removed (with only the first "initial release" included) for cloned themes.

To test: clone a theme, create a child theme and create a blank theme

Observe the style.css and readme.txt files and ensure that the version is as expected.

NOTE: For CLONED themes the TAGS value in the style.css is copied over.  This is expected.

Fixes #613 
Fixes #570 