### PR TITLE
Fix/metadata saving

### DIFF
--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -12,7 +12,7 @@ class Theme_Readme {
 		$author              = $theme['author'];
 		$author_uri          = $theme['author_uri'];
 		$copy_year           = gmdate( 'Y' );
-		$wp_version          = get_bloginfo( 'version' );
+		$wp_version          = Theme_Utils::get_current_wordpress_version();
 		$image_credits       = $theme['image_credits'] ?? '';
 		$recommended_plugins = $theme['recommended_plugins'] ?? '';
 		$is_parent_theme     = $theme['is_parent_theme'] ?? false;
@@ -209,7 +209,7 @@ GNU General Public License for more details.";
 	public static function update_readme_txt( $theme ) {
 		$description         = $theme['description'];
 		$author              = $theme['author'];
-		$wp_version          = get_bloginfo( 'version' );
+		$wp_version          = Theme_Utils::get_current_wordpress_version();
 		$image_credits       = $theme['image_credits'] ?? '';
 		$recommended_plugins = $theme['recommended_plugins'] ?? '';
 		$updated_readme      = '';

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -34,7 +34,11 @@ class Theme_Styles {
 		if ( isset( $matches[1] ) ) {
 			$license_uri = $matches[1];
 		}
-
+		$copyright = '';
+		preg_match( '/^\s*\n((?s).*?)\*\/\s*$/m', $style_css, $matches );
+		if ( isset( $matches[1] ) ) {
+			$copyright = $matches[1];
+		}
 		$css_metadata = "/*
 Theme Name: {$name}
 Theme URI: {$uri}
@@ -55,9 +59,8 @@ License URI: {$license_uri}
 
 		$css_metadata .= "Text Domain: {$text_domain}
 Tags: {$tags}
-*/
 
-";
+{$copyright}*/";
 		return $css_metadata . $css_contents;
 	}
 

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -16,23 +16,32 @@ class Theme_Styles {
 		$uri           = $theme['uri'];
 		$author        = stripslashes( $theme['author'] );
 		$author_uri    = $theme['author_uri'];
-		$wp_version    = get_bloginfo( 'version' );
+		$wp_version    = Theme_Utils::get_current_wordpress_version();
+		$wp_min        = $current_theme->get( 'RequiresWP' );
 		$version       = $theme['version'];
 		$requires_php  = $current_theme->get( 'RequiresPHP' );
 		$template      = $current_theme->get( 'Template' );
 		$text_domain   = $theme['slug'];
+		$tags          = Theme_Tags::theme_tags_list( $theme );
+		//These items don't seem to be available via ->get('License') calls
+		$license     = 'GNU General Public License v2 or later';
+		$license_uri = 'http://www.gnu.org/licenses/gpl-2.0.html';
+		preg_match( '/License: (.+)/', $style_css, $matches );
+		if ( isset( $matches[1] ) ) {
+			$license = $matches[1];
+		}
+		preg_match( '/License URI: (.+)/', $style_css, $matches );
+		if ( isset( $matches[1] ) ) {
+			$license_uri = $matches[1];
+		}
 
-		//TODO: These items don't seem to be available via ->get('License') calls
-		$license      = 'GNU General Public License v2 or later';
-		$license_uri  = 'http://www.gnu.org/licenses/gpl-2.0.html';
-		$tags         = Theme_Tags::theme_tags_list( $theme );
 		$css_metadata = "/*
 Theme Name: {$name}
 Theme URI: {$uri}
 Author: {$author}
 Author URI: {$author_uri}
 Description: {$description}
-Requires at least: 6.0
+Requires at least: {$wp_min}
 Tested up to: {$wp_version}
 Requires PHP: {$requires_php}
 Version: {$version}
@@ -61,7 +70,8 @@ Tags: {$tags}
 		$uri         = $theme['uri'];
 		$author      = stripslashes( $theme['author'] );
 		$author_uri  = $theme['author_uri'];
-		$wp_version  = get_bloginfo( 'version' );
+		$wp_version  = Theme_Utils::get_current_wordpress_version();
+		$wp_min      = wp_get_theme()->get( 'RequiresWP' );
 		$text_domain = sanitize_title( $name );
 		if ( isset( $theme['template'] ) ) {
 			$template = $theme['template'];
@@ -79,7 +89,7 @@ Theme URI: {$uri}
 Author: {$author}
 Author URI: {$author_uri}
 Description: {$description}
-Requires at least: 6.0
+Requires at least: {$wp_min}
 Tested up to: {$wp_version}
 Requires PHP: 5.7
 Version: {$version}

--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -228,4 +228,12 @@ class Theme_Utils {
 		return Theme_Utils::copy_screenshot( $new_screenshot_path );
 	}
 
+	public static function get_current_wordpress_version() {
+		$wp_version = get_bloginfo( 'version' );
+		if ( preg_match( '/^\d+\.\d+/', $wp_version, $matches ) ) {
+			$wp_version = $matches[0];
+		}
+		return $wp_version;
+	}
+
 }

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -407,7 +407,7 @@ class Create_Block_Theme_API {
 	 * Update the theme metadata and relocate the theme.
 	 */
 	function rest_update_theme( $request ) {
-		$theme = $request->get_params();
+		$theme = $this->sanitize_theme_data( $request->get_params() );
 
 		// Update the metadata of the theme in the style.css file
 		$style_css = file_get_contents( get_stylesheet_directory() . '/style.css' );
@@ -487,6 +487,7 @@ class Create_Block_Theme_API {
 		$sanitized_theme['author_uri']          = sanitize_text_field( $theme['author_uri'] );
 		$sanitized_theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
 		$sanitized_theme['subfolder']           = sanitize_text_field( $theme['subfolder'] );
+		$sanitized_theme['version']             = sanitize_text_field( $theme['version'] );
 		$sanitized_theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
 		$sanitized_theme['template']            = '';
 		$sanitized_theme['slug']                = sanitize_title( $theme['name'] );


### PR DESCRIPTION
Fixes the following issues:

* Retain copyright text in style.css when updating metadata
* Uses only major/minor version of wordpress for "tested up to" value
* Use existing license in style.css instead of overwriting. 
* Use existing Requires WP in style.css instead of overwriting.

Fixes #523 

To test:

Click "Update" on the Metadata modal of CBT.

Note that the "Tested Up to" value is only major.minor
Note that the license values remain unchanged (set it to something noticeable before saving to ensure this is true)
Note that the Requires WP in style css remains unchanged (set it to something noticeable before saving to ensure this is true)
Note that the license text remains after saving. 