### PR TITLE
Improve tags UI

### DIFF
--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -189,6 +189,16 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 					}
 					onChange={ onChangeTags }
 				/>
+				<ExternalLink
+					href="https://make.wordpress.org/themes/handbook/review/required/theme-tags/"
+					style={ {
+						fontSize: '12px',
+						marginTop: '-20px',
+						marginBottom: '1rem',
+					} }
+				>
+					{ __( 'Read more.', 'create-block-theme' ) }
+				</ExternalLink>
 				<TextareaControl
 					label={ __( 'Recommended Plugins', 'create-block-theme' ) }
 					help={

--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -191,16 +191,19 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 					}
 					onChange={ onChangeTags }
 				/>
-				<ExternalLink
-					href="https://make.wordpress.org/themes/handbook/review/required/theme-tags/"
+				<HStack
 					style={ {
-						fontSize: '12px',
 						marginTop: '-20px',
 						marginBottom: '1rem',
 					} }
 				>
-					{ __( 'Read more.', 'create-block-theme' ) }
-				</ExternalLink>
+					<ExternalLink
+						href="https://make.wordpress.org/themes/handbook/review/required/theme-tags/"
+						style={ { fontSize: '12px' } }
+					>
+						{ __( 'Read more.', 'create-block-theme' ) }
+					</ExternalLink>
+				</HStack>
 				<TextareaControl
 					label={ __( 'Recommended Plugins', 'create-block-theme' ) }
 					help={

--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -15,6 +15,7 @@ import {
 	// eslint-disable-next-line
 	__experimentalText as Text,
 	BaseControl,
+	FormTokenField,
 	Modal,
 	Button,
 	TextControl,
@@ -93,6 +94,10 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 					);
 				createErrorNotice( errorMessage, { type: 'snackbar' } );
 			} );
+	};
+
+	const onChangeTags = ( newTags ) => {
+		setTheme( { ...theme, tags_custom: newTags.join( ', ' ) } );
 	};
 
 	const onUpdateImage = ( image ) => {
@@ -177,16 +182,12 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 						'create-block-theme'
 					) }
 				/>
-				<TextareaControl
+				<FormTokenField
 					label={ __( 'Theme tags', 'create-block-theme' ) }
-					value={ theme.tags_custom }
-					onChange={ ( value ) =>
-						setTheme( { ...theme, tags_custom: value } )
+					value={
+						theme.tags_custom ? theme.tags_custom.split( ', ' ) : []
 					}
-					placeholder={ __(
-						'A comma-separated collection of tags',
-						'create-block-theme'
-					) }
+					onChange={ onChangeTags }
 				/>
 				<TextareaControl
 					label={ __( 'Recommended Plugins', 'create-block-theme' ) }


### PR DESCRIPTION
Inspired by #495

This PR replaces the tag's input UI from a text field to a `FormTokenField` component.

https://github.com/WordPress/create-block-theme/assets/54422211/5fd13b2b-2162-490c-9e4d-3500f3af4467

I believe this UI will have the following benefits:

- Tags have a background color, improving visibility
- In addition to commas, you can use the enter key to complete tag entry.
- Can prevent registration of duplicate tags

Also, this PR is intended to change only the UI, so there are no internal changes. If this PR is considered the first step in improving the UI, I think the ideal UI logic is as follows:

- Show theme tag _label_ instead of theme tag _slug_
- Sort the existing tag list into theme tags and custom tags and separate input fields.
- Regarding theme tags, those that are equal to the array obtained from the `get_theme_feature_list()` function are displayed as candidates, and tags that are not included in that array are not allowed.

Below is a mockup suggestion.

![image](https://github.com/WordPress/create-block-theme/assets/54422211/a659dea0-4740-4e12-91f3-e3b51af92340)

## Testing Instructions

- In the trunk branch, register some tags.
- If you switch to this branch, your tags should remain fine.
- Verify that entering and saving tags work correctly in this branch.