### PR TITLE
Don't Clobber Metadata

### DIFF
--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -21,11 +21,19 @@ class CBT_Theme_Styles {
 		$requires_php  = $current_theme->get( 'RequiresPHP' );
 		$template      = $current_theme->get( 'Template' );
 		$text_domain   = $theme['slug'];
+		$license       = 'GNU General Public License v2 or later';
+		$license_uri   = 'http://www.gnu.org/licenses/gpl-2.0.html';
+		$tags          = CBT_Theme_Tags::theme_tags_list( $theme );
 
-		//TODO: These items don't seem to be available via ->get('License') calls
-		$license      = 'GNU General Public License v2 or later';
-		$license_uri  = 'http://www.gnu.org/licenses/gpl-2.0.html';
-		$tags         = CBT_Theme_Tags::theme_tags_list( $theme );
+		preg_match( '/License: (.+)/', $style_css, $matches );
+		if ( isset( $matches[1] ) ) {
+			$license = $matches[1];
+		}
+		preg_match( '/License URI: (.+)/', $style_css, $matches );
+		if ( isset( $matches[1] ) ) {
+			$license_uri = $matches[1];
+		}
+
 		$css_metadata = "/*
 Theme Name: {$name}
 Theme URI: {$uri}

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -28,19 +28,19 @@ class CBT_Theme_Styles {
 		$wp_min        = $current_theme->get( 'RequiresWP' );
 		$version       = $theme['version'];
 		$requires_php  = $current_theme->get( 'RequiresPHP' );
-		$template      = $current_theme->get( 'Template' );
 		$text_domain   = $theme['slug'];
+		$template      = $current_theme->get( 'Template' ) ? "\n" . 'Template: ' . $current_theme->get( 'Template' ) : '';
 		$license       = $style_data['License'] ? $style_data['License'] : 'GNU General Public License v2 or later';
 		$license_uri   = $style_data['LicenseURI'] ? $style_data['LicenseURI'] : 'http://www.gnu.org/licenses/gpl-2.0.html';
 		$tags          = CBT_Theme_Tags::theme_tags_list( $theme );
+		$css_contents  = $css_contents ? "\n\n" . $css_contents : '';
 		$copyright     = '';
-
 		preg_match( '/^\s*\n((?s).*?)\*\/\s*$/m', $style_css, $matches );
 		if ( isset( $matches[1] ) ) {
-			$copyright = $matches[1];
+			$copyright = "\n" . $matches[1];
 		}
 
-		$css_metadata = "/*
+		return "/*
 Theme Name: {$name}
 Theme URI: {$uri}
 Author: {$author}
@@ -51,20 +51,11 @@ Tested up to: {$wp_version}
 Requires PHP: {$requires_php}
 Version: {$version}
 License: {$license}
-License URI: {$license_uri}
-";
-
-		if ( ! empty( $template ) ) {
-			$css_metadata .= "Template: {$template}\n";
-		}
-
-		$css_metadata .= "Text Domain: {$text_domain}
+License URI: {$license_uri}{$template}
+Text Domain: {$text_domain}
 Tags: {$tags}
-
-{$copyright}*/
-
+{$copyright}*/{$css_contents}
 ";
-		return $css_metadata . $css_contents;
 	}
 
 	/**

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -17,6 +17,7 @@ class CBT_Theme_Styles {
 		$author        = stripslashes( $theme['author'] );
 		$author_uri    = $theme['author_uri'];
 		$wp_version    = get_bloginfo( 'version' );
+		$wp_min        = $current_theme->get( 'RequiresWP' );
 		$version       = $theme['version'];
 		$requires_php  = $current_theme->get( 'RequiresPHP' );
 		$template      = $current_theme->get( 'Template' );
@@ -45,7 +46,7 @@ Theme URI: {$uri}
 Author: {$author}
 Author URI: {$author_uri}
 Description: {$description}
-Requires at least: 6.0
+Requires at least: {$wp_min}
 Tested up to: {$wp_version}
 Requires PHP: {$requires_php}
 Version: {$version}

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -24,6 +24,7 @@ class CBT_Theme_Styles {
 		$license       = 'GNU General Public License v2 or later';
 		$license_uri   = 'http://www.gnu.org/licenses/gpl-2.0.html';
 		$tags          = CBT_Theme_Tags::theme_tags_list( $theme );
+		$copyright     = '';
 
 		preg_match( '/License: (.+)/', $style_css, $matches );
 		if ( isset( $matches[1] ) ) {
@@ -32,6 +33,10 @@ class CBT_Theme_Styles {
 		preg_match( '/License URI: (.+)/', $style_css, $matches );
 		if ( isset( $matches[1] ) ) {
 			$license_uri = $matches[1];
+		}
+		preg_match( '/^\s*\n((?s).*?)\*\/\s*$/m', $style_css, $matches );
+		if ( isset( $matches[1] ) ) {
+			$copyright = $matches[1];
 		}
 
 		$css_metadata = "/*
@@ -54,7 +59,8 @@ License URI: {$license_uri}
 
 		$css_metadata .= "Text Domain: {$text_domain}
 Tags: {$tags}
-*/
+
+{$copyright}*/
 
 ";
 		return $css_metadata . $css_contents;

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -9,6 +9,14 @@ class CBT_Theme_Styles {
 	 */
 	public static function update_style_css( $style_css, $theme ) {
 
+		$style_data = get_file_data(
+			path_join( get_stylesheet_directory(), 'style.css' ),
+			array(
+				'License'    => 'License',
+				'LicenseURI' => 'License URI',
+			)
+		);
+
 		$current_theme = wp_get_theme();
 		$css_contents  = trim( substr( $style_css, strpos( $style_css, '*/' ) + 2 ) );
 		$name          = stripslashes( $theme['name'] );
@@ -22,19 +30,11 @@ class CBT_Theme_Styles {
 		$requires_php  = $current_theme->get( 'RequiresPHP' );
 		$template      = $current_theme->get( 'Template' );
 		$text_domain   = $theme['slug'];
-		$license       = 'GNU General Public License v2 or later';
-		$license_uri   = 'http://www.gnu.org/licenses/gpl-2.0.html';
+		$license       = $style_data['License'] ? $style_data['License'] : 'GNU General Public License v2 or later';
+		$license_uri   = $style_data['LicenseURI'] ? $style_data['LicenseURI'] : 'http://www.gnu.org/licenses/gpl-2.0.html';
 		$tags          = CBT_Theme_Tags::theme_tags_list( $theme );
 		$copyright     = '';
 
-		preg_match( '/License: (.+)/', $style_css, $matches );
-		if ( isset( $matches[1] ) ) {
-			$license = $matches[1];
-		}
-		preg_match( '/License URI: (.+)/', $style_css, $matches );
-		if ( isset( $matches[1] ) ) {
-			$license_uri = $matches[1];
-		}
 		preg_match( '/^\s*\n((?s).*?)\*\/\s*$/m', $style_css, $matches );
 		if ( isset( $matches[1] ) ) {
 			$copyright = $matches[1];

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -483,14 +483,14 @@ class CBT_Theme_API {
 
 	private function sanitize_theme_data( $theme ) {
 		$sanitized_theme['name']                = sanitize_text_field( $theme['name'] );
-		$sanitized_theme['description']         = sanitize_text_field( $theme['description'] );
-		$sanitized_theme['uri']                 = sanitize_text_field( $theme['uri'] );
-		$sanitized_theme['author']              = sanitize_text_field( $theme['author'] );
-		$sanitized_theme['author_uri']          = sanitize_text_field( $theme['author_uri'] );
-		$sanitized_theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
-		$sanitized_theme['subfolder']           = sanitize_text_field( $theme['subfolder'] );
-		$sanitized_theme['version']             = sanitize_text_field( $theme['version'] );
-		$sanitized_theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
+		$sanitized_theme['description']         = sanitize_text_field( $theme['description'] ?? '' );
+		$sanitized_theme['uri']                 = sanitize_text_field( $theme['uri'] ?? '' );
+		$sanitized_theme['author']              = sanitize_text_field( $theme['author'] ?? '' );
+		$sanitized_theme['author_uri']          = sanitize_text_field( $theme['author_uri'] ?? '' );
+		$sanitized_theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] ?? '' );
+		$sanitized_theme['subfolder']           = sanitize_text_field( $theme['subfolder'] ?? '' );
+		$sanitized_theme['version']             = sanitize_text_field( $theme['version'] ?? '' );
+		$sanitized_theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] ?? '' );
 		$sanitized_theme['template']            = '';
 		$sanitized_theme['slug']                = sanitize_title( $theme['name'] );
 		$sanitized_theme['text_domain']         = $sanitized_theme['slug'];

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -489,6 +489,7 @@ class CBT_Theme_API {
 		$sanitized_theme['author_uri']          = sanitize_text_field( $theme['author_uri'] );
 		$sanitized_theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
 		$sanitized_theme['subfolder']           = sanitize_text_field( $theme['subfolder'] );
+		$sanitized_theme['version']             = sanitize_text_field( $theme['version'] );
 		$sanitized_theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
 		$sanitized_theme['template']            = '';
 		$sanitized_theme['slug']                = sanitize_title( $theme['name'] );


### PR DESCRIPTION
When saving metadata to style.css a number of default values are written without considering the existing values.

This change keeps those values, copying them from the old style.css file to what is generated.

Specifically:

Copyright information
License/License URI
WordPress minimum version

This also fixes a bug where the VERSION was being wiped when updating metadata.


To Test:
Activate a theme that has things that could be changed. (Ames is a good theme to test with, it has all of the above)
Using CBT 'Edit Theme Metadata' and 'Update' without changing anything.

Note how the style.css changed.  ONLY the "Tested up to" value should be different.