### PR TITLE
Use only major.minor version in 'Tested up to' field

### DIFF
--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -49,7 +49,7 @@ class CBT_Theme_Readme {
 		$author               = $theme['author'] ?? '';
 		$author_uri           = $theme['author_uri'] ?? '';
 		$copy_year            = $theme['copyright_year'] ?? gmdate( 'Y' );
-		$wp_version           = $theme['wp_version'] ?? get_bloginfo( 'version' );
+		$wp_version           = $theme['wp_version'] ?? CBT_Theme_Utils::get_current_wordpress_version();
 		$required_php_version = $theme['required_php_version'] ?? '5.7';
 		$license              = $theme['license'] ?? 'GPLv2 or later';
 		$license_uri          = $theme['license_uri'] ?? 'http://www.gnu.org/licenses/gpl-2.0.html';
@@ -201,7 +201,7 @@ GNU General Public License for more details.
 		// Theme data.
 		$description         = $theme['description'] ?? '';
 		$author              = $theme['author'] ?? '';
-		$wp_version          = $theme['wp_version'] ?? get_bloginfo( 'version' );
+		$wp_version          = $theme['wp_version'] ?? CBT_Theme_Utils::get_current_wordpress_version();
 		$image_credits       = $theme['image_credits'] ?? '';
 		$recommended_plugins = $theme['recommended_plugins'] ?? '';
 

--- a/admin/create-theme/theme-styles.php
+++ b/admin/create-theme/theme-styles.php
@@ -16,7 +16,7 @@ class CBT_Theme_Styles {
 		$uri           = $theme['uri'];
 		$author        = stripslashes( $theme['author'] );
 		$author_uri    = $theme['author_uri'];
-		$wp_version    = get_bloginfo( 'version' );
+		$wp_version    = CBT_Theme_Utils::get_current_wordpress_version();
 		$version       = $theme['version'];
 		$requires_php  = $current_theme->get( 'RequiresPHP' );
 		$template      = $current_theme->get( 'Template' );
@@ -61,7 +61,7 @@ Tags: {$tags}
 		$uri         = $theme['uri'];
 		$author      = stripslashes( $theme['author'] );
 		$author_uri  = $theme['author_uri'];
-		$wp_version  = get_bloginfo( 'version' );
+		$wp_version  = CBT_Theme_Utils::get_current_wordpress_version();
 		$text_domain = sanitize_title( $name );
 		if ( isset( $theme['template'] ) ) {
 			$template = $theme['template'];

--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -208,6 +208,12 @@ class CBT_Theme_Utils {
 		return CBT_Theme_Utils::copy_screenshot( $new_screenshot_path );
 	}
 
+	/**
+	 * Get the current WordPress version.
+	 *
+	 * @return string The current WordPress in the format x.x (major.minor)
+	 * Example: 6.5
+	 */
 	public static function get_current_wordpress_version() {
 		$wp_version = get_bloginfo( 'version' );
 		if ( preg_match( '/^\d+\.\d+/', $wp_version, $matches ) ) {

--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -215,10 +215,8 @@ class CBT_Theme_Utils {
 	 * Example: 6.5
 	 */
 	public static function get_current_wordpress_version() {
-		$wp_version = get_bloginfo( 'version' );
-		if ( preg_match( '/^\d+\.\d+/', $wp_version, $matches ) ) {
-			$wp_version = $matches[0];
-		}
-		return $wp_version;
+		$wp_version       = get_bloginfo( 'version' );
+		$wp_version_parts = explode( '.', $wp_version );
+		return $wp_version_parts[0] . '.' . $wp_version_parts[1];
 	}
 }

--- a/admin/create-theme/theme-utils.php
+++ b/admin/create-theme/theme-utils.php
@@ -208,4 +208,11 @@ class CBT_Theme_Utils {
 		return CBT_Theme_Utils::copy_screenshot( $new_screenshot_path );
 	}
 
+	public static function get_current_wordpress_version() {
+		$wp_version = get_bloginfo( 'version' );
+		if ( preg_match( '/^\d+\.\d+/', $wp_version, $matches ) ) {
+			$wp_version = $matches[0];
+		}
+		return $wp_version;
+	}
 }

--- a/tests/CbtThemeReadme/create.php
+++ b/tests/CbtThemeReadme/create.php
@@ -25,7 +25,7 @@ class CBT_ThemeReadme_Create extends CBT_Theme_Readme_UnitTestCase {
 		$expected_uri                 = 'Theme URI: ' . $data['uri'];
 		$expected_author              = 'Contributors: ' . $data['author'];
 		$expected_author_uri          = 'Author URI: ' . $data['author_uri'];
-		$expected_wp_version          = 'Tested up to: ' . $data['wp_version'] ?? get_bloginfo( 'version' );
+		$expected_wp_version          = 'Tested up to: ' . $data['wp_version'] ?? CBT_Theme_Utils::get_current_wordpress_version();
 		$expected_php_version         = 'Requires PHP: ' . $data['required_php_version'];
 		$expected_license             = 'License: ' . $data['license'];
 		$expected_license_uri         = 'License URI: ' . $data['license_uri'];

--- a/tests/CbtThemeReadme/update.php
+++ b/tests/CbtThemeReadme/update.php
@@ -22,7 +22,7 @@ class CBT_ThemeReadme_Update extends CBT_Theme_Readme_UnitTestCase {
 		$readme_without_newlines = str_replace( "\n", '', $readme );
 
 		$expected_author              = 'Contributors: ' . $data['author'];
-		$expected_wp_version          = 'Tested up to: ' . $data['wp_version'] ?? get_bloginfo( 'version' );
+		$expected_wp_version          = 'Tested up to: ' . $data['wp_version'] ?? CBT_Theme_Utils::get_current_wordpress_version();
 		$expected_image_credits       = '== Images ==' . $data['image_credits'];
 		$expected_recommended_plugins = '== Recommended Plugins ==' . $data['recommended_plugins'];
 


### PR DESCRIPTION
Swap get_bloginfo('version') with custom function that supplies version with major.minor only.

Fixes #523 

To Test:
Using CBT update metadata.
Note that the "Tested Up to" shows the version of WordPress being used with only MAJOR.MINOR in style.css and readme.txt