### PR TITLE
Remove unused `@wordpress/base-styles`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
 			"devDependencies": {
 				"@actions/core": "^1.10.0",
 				"@emotion/babel-plugin": "^11.11.0",
-				"@wordpress/base-styles": "^4.28.0",
 				"@wordpress/browserslist-config": "^5.16.0",
 				"@wordpress/element": "^5.10.0",
 				"@wordpress/env": "^9.9.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
 	"devDependencies": {
 		"@actions/core": "^1.10.0",
 		"@emotion/babel-plugin": "^11.11.0",
-		"@wordpress/base-styles": "^4.28.0",
 		"@wordpress/browserslist-config": "^5.16.0",
 		"@wordpress/element": "^5.10.0",
 		"@wordpress/env": "^9.9.0",


### PR DESCRIPTION
This package was once added to introduce color schemes to the Manage Theme Fonts page (#419), but is no longer used anywhere.