### PR TITLE
Fix: Version field not updated

### DIFF
--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -487,6 +487,7 @@ class CBT_Theme_API {
 		$sanitized_theme['uri']                 = sanitize_text_field( $theme['uri'] );
 		$sanitized_theme['author']              = sanitize_text_field( $theme['author'] );
 		$sanitized_theme['author_uri']          = sanitize_text_field( $theme['author_uri'] );
+		$sanitized_theme['version']             = sanitize_text_field( $theme['version'] );
 		$sanitized_theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
 		$sanitized_theme['subfolder']           = sanitize_text_field( $theme['subfolder'] );
 		$sanitized_theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );

--- a/tests/test-theme-fonts.php
+++ b/tests/test-theme-fonts.php
@@ -121,6 +121,7 @@ class Test_Create_Block_Theme_Fonts extends WP_UnitTestCase {
 		$request->set_param( 'uri', '' );
 		$request->set_param( 'author', '' );
 		$request->set_param( 'author_uri', '' );
+		$request->set_param( 'version', '' );
 		$request->set_param( 'tags_custom', '' );
 		$request->set_param( 'subfolder', '' );
 		$request->set_param( 'recommended_plugins', '' );


### PR DESCRIPTION
I noticed that the version field was not taken into account in the `sanitize_theme_data` method, so we couldn't update this field.

![image](https://github.com/WordPress/create-block-theme/assets/54422211/3dfa5a75-1bdd-420c-a8ac-7877abc6d295)

This PR should also resolve the following PHP error that is logged when updating metadata.

```
PHP Warning:  Undefined array key "version" in /var/www/html/wp-content/plugins/create-block-theme/admin/create-theme/theme-styles.php on line 20
```

## Testing Instructions

- Opne the Edit Theme Metadata modal.
- Update "Version" field.
- Open style.css in your active theme and check the `Version:` header data.
