### PR TITLE
Fix template texts localizing/escaping

### DIFF
--- a/admin/class-create-theme.php
+++ b/admin/class-create-theme.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once __DIR__ . '/resolver_additions.php';
+require_once __DIR__ . '/create-theme/theme-locale.php';
 require_once __DIR__ . '/create-theme/theme-tags.php';
 require_once __DIR__ . '/create-theme/theme-zip.php';
 require_once __DIR__ . '/create-theme/theme-media.php';

--- a/admin/create-theme/theme-locale.php
+++ b/admin/create-theme/theme-locale.php
@@ -29,9 +29,9 @@ class CBT_Theme_Locale {
 	 * Get a replacement pattern for escaping the text from the html content of a block.
 	 *
 	 * @param string $block_name The block name.
-	 * @return string|array|null The regex pattern to match the content that needs to be escaped.
+	 * @return array|null The regex patterns to match the content that needs to be escaped.
 	 *      Returns null if the block is not supported.
-	 *      Returns an array if the block has multiple html elements that need to be escaped.
+	 *      Returns an array of regex patterns if the block has html elements that need to be escaped.
 	 */
 	private static function get_text_replacement_patterns_for_html( $block_name ) {
 		switch ( $block_name ) {

--- a/admin/create-theme/theme-locale.php
+++ b/admin/create-theme/theme-locale.php
@@ -19,6 +19,47 @@ class CBT_Theme_Locale {
 		return "<?php echo __('" . $string . "', '" . wp_get_theme()->get( 'TextDomain' ) . "');?>";
 	}
 
+	/**
+	 * Get a replacement pattern for escaping the text from the html content of a block.
+	 *
+	 * @param string $block_name The block name.
+	 * @return string|array|null The regex pattern to match the content that needs to be escaped.
+	 *      Returns null if the block is not supported.
+	 *      Returns an array if the block has multiple html elements that need to be escaped.
+	 */
+	private static function get_text_replacement_patterns_for_html( $block_name ) {
+		switch ( $block_name ) {
+			case 'core/paragraph':
+				return array( '/(<p[^>]*>)(.*?)(<\/p>)/' );
+			case 'core/heading':
+				return array( '/(<h[^>]*>)(.*?)(<\/h[^>]*>)/' );
+			case 'core/list-item':
+				return array( '/(<li[^>]*>)(.*?)(<\/li>)/' );
+			case 'core/verse':
+				return array( '/(<pre[^>]*>)(.*?)(<\/pre>)/' );
+			case 'core/button':
+				return array( '/(<a[^>]*>)(.*?)(<\/a>)/' );
+			case 'core/image':
+			case 'core/cover':
+			case 'core/media-text':
+				return array( '/alt="(.*?)"/' );
+			case 'core/quote':
+			case 'core/pullquote':
+				return array(
+					'/(<p[^>]*>)(.*?)(<\/p>)/',
+					'/(<cite[^>]*>)(.*?)(<\/cite>)/',
+				);
+			case 'core/table':
+				return array(
+					'/(<td[^>]*>)(.*?)(<\/td>)/',
+					'/(<th[^>]*>)(.*?)(<\/th>)/',
+					'/(<figcaption[^>]*>)(.*?)(<\/figcaption>)/',
+				);
+			default:
+				return null;
+		}
+	}
+
 	/*
 	 * Localize text in text blocks.
 	 *
@@ -28,113 +69,41 @@ class CBT_Theme_Locale {
 	public static function escape_text_content_of_blocks( $blocks ) {
 		foreach ( $blocks as &$block ) {
 
+			// Recursively escape the inner blocks.
 			if ( ! empty( $block['innerBlocks'] ) ) {
-				// Recursively escape the inner blocks.
 				$block['innerBlocks'] = self::escape_text_content_of_blocks( $block['innerBlocks'] );
 			}
 
 			/*
 			 * Set the pattern based on the block type.
 			 * The pattern is used to match the content that needs to be escaped.
-			 * Pattern is a string for most blocks, but an array for blocks with multiple html elements that need to be escaped.
+			 * Patterns are defined in the get_text_replacement_patterns_for_html method.
 			 */
-			$pattern = '';
-			switch ( $block['blockName'] ) {
-				case 'core/paragraph':
-					$pattern = '/(<p[^>]*>)(.*?)(<\/p>)/';
-					break;
-				case 'core/heading':
-					$pattern = '/(<h[^>]*>)(.*?)(<\/h[^>]*>)/';
-					break;
-				case 'core/list-item':
-					$pattern = '/(<li[^>]*>)(.*?)(<\/li>)/';
-					break;
-				case 'core/verse':
-					$pattern = '/(<pre[^>]*>)(.*?)(<\/pre>)/';
-					break;
-				case 'core/button':
-					$pattern = '/(<a[^>]*>)(.*?)(<\/a>)/';
-					break;
-				case 'core/image':
-				case 'core/cover':
-				case 'core/media-text':
-					$pattern = '/alt="(.*?)"/';
-					break;
-				case 'core/quote':
-				case 'core/pullquote':
-					$pattern = array(
-						'/(<p[^>]*>)(.*?)(<\/p>)/',
-						'/(<cite[^>]*>)(.*?)(<\/cite>)/',
-					);
-					break;
-				case 'core/table':
-					$pattern = array(
-						'/(<td[^>]*>)(.*?)(<\/td>)/',
-						'/(<th[^>]*>)(.*?)(<\/th>)/',
-						'/(<figcaption[^>]*>)(.*?)(<\/figcaption>)/',
-					);
-					break;
+			$patterns = self::get_text_replacement_patterns_for_html( $block['blockName'] );
+
+			// If the block does not have any patterns leave the block as is and continue to the next block.
+			if ( ! $patterns ) {
+				continue;
 			}
 
 			// Replace the content with the new content based on the pattern.
 			switch ( $block['blockName'] ) {
-
 				case 'core/paragraph':
 				case 'core/heading':
 				case 'core/list-item':
 				case 'core/verse':
 				case 'core/button':
-					$replace_content_callback = function ( $content ) use ( $pattern ) {
-						if ( empty( $content ) ) {
-							return;
-						}
-						return preg_replace_callback(
-							$pattern,
-							function( $matches ) {
-								return $matches[1] . self::escape_string( $matches[2] ) . $matches[3];
-							},
-							$content
-						);
-					};
-					if ( ! empty( $block['innerContent'] ) ) {
-						$block['innerContent'] = is_array( $block['innerContent'] )
-							? array_map( $replace_content_callback, $block['innerContent'] )
-							: $replace_content_callback( $block['innerContent'] );
-					}
-					break;
-
-				case 'core/image':
-				case 'core/cover':
-				case 'core/media-text':
-					$replace_content_callback = function ( $content ) use ( $pattern ) {
-						if ( empty( $content ) ) {
-							return;
-						}
-						return preg_replace_callback(
-							$pattern,
-							function( $matches ) {
-								return 'alt="' . self::escape_string( $matches[1] ) . '"';
-							},
-							$content
-						);
-					};
-					if ( ! empty( $block['innerContent'] ) ) {
-						$block['innerContent'] = is_array( $block['innerContent'] )
-						? array_map( $replace_content_callback, $block['innerContent'] )
-						: $replace_content_callback( $block['innerContent'] );
-					}
-					break;
-
 				case 'core/quote':
 				case 'core/pullquote':
+				case 'core/table':
 					// Iterates the html patterns and replace the content with the escaped content.
-					foreach ( $pattern as $element_pattern ) {
-						$replace_content_callback = function ( $content ) use ( $element_pattern ) {
+					foreach ( $patterns as $pattern ) {
+						$replace_content_callback = function ( $content ) use ( $pattern ) {
 							if ( empty( $content ) ) {
 								return;
 							}
 							return preg_replace_callback(
-								$element_pattern,
+								$pattern,
 								function( $matches ) {
 									return $matches[1] . self::escape_string( $matches[2] ) . $matches[3];
 								},
@@ -149,23 +118,23 @@ class CBT_Theme_Locale {
 						}
 					}
 					break;
-
-				case 'core/table':
+				case 'core/image':
+				case 'core/cover':
+				case 'core/media-text':
 					// Iterates the html patterns and replace the content with the escaped content.
-					foreach ( $pattern as $element_pattern ) {
-						$replace_content_callback = function ( $content ) use ( $element_pattern ) {
+					foreach ( $patterns as $pattern ) {
+						$replace_content_callback = function ( $content ) use ( $pattern ) {
 							if ( empty( $content ) ) {
 								return;
 							}
 							return preg_replace_callback(
-								$element_pattern,
+								$pattern,
 								function( $matches ) {
-									return $matches[1] . self::escape_string( $matches[2] ) . $matches[3];
+									return 'alt="' . self::escape_string( $matches[1] ) . '"';
 								},
 								$content
 							);
 						};
-
 						if ( ! empty( $block['innerContent'] ) ) {
 							$block['innerContent'] = is_array( $block['innerContent'] )
 							? array_map( $replace_content_callback, $block['innerContent'] )
@@ -175,7 +144,6 @@ class CBT_Theme_Locale {
 					break;
 			}
 		}
-
 		return $blocks;
 	}
 }

--- a/admin/create-theme/theme-locale.php
+++ b/admin/create-theme/theme-locale.php
@@ -4,6 +4,12 @@
 */
 class CBT_Theme_Locale {
 
+	/**
+	 * Escape a string for localization.
+	 *
+	 * @param string $string The string to escape.
+	 * @return string The escaped string.
+	 */
 	public static function escape_string( $string ) {
 		// Avoid escaping if the text is not a string.
 		if ( ! is_string( $string ) ) {

--- a/admin/create-theme/theme-locale.php
+++ b/admin/create-theme/theme-locale.php
@@ -16,7 +16,7 @@ class CBT_Theme_Locale {
 		}
 
 		$string = addcslashes( $string, "'" );
-		return "<?php echo __( '" . $string . "', '" . wp_get_theme()->get( 'TextDomain' ) . "' ); ?>";
+		return "<?php echo __('" . $string . "', '" . wp_get_theme()->get( 'TextDomain' ) . "');?>";
 	}
 
 	/*
@@ -29,136 +29,150 @@ class CBT_Theme_Locale {
 		foreach ( $blocks as &$block ) {
 
 			if ( ! empty( $block['innerBlocks'] ) ) {
+				// Recursively escape the inner blocks.
 				$block['innerBlocks'] = self::escape_text_content_of_blocks( $block['innerBlocks'] );
-			} else {
-				/*
-				 * Set the pattern based on the block type.
-				 * The pattern is used to match the content that needs to be escaped.
-				 * Pattern is a string for most blocks, but an array for blocks with multiple html elements that need to be escaped.
-				 */
-				$pattern = '';
-				switch ( $block['blockName'] ) {
-					case 'core/paragraph':
-						$pattern = '/(<p[^>]*>)(.*?)(<\/p>)/';
-						break;
-					case 'core/heading':
-						$pattern = '/(<h[^>]*>)(.*?)(<\/h[^>]*>)/';
-						break;
-					case 'core/list-item':
-						$pattern = '/(<li[^>]*>)(.*?)(<\/li>)/';
-						break;
-					case 'core/verse':
-						$pattern = '/(<pre[^>]*>)(.*?)(<\/pre>)/';
-						break;
-					case 'core/button':
-						$pattern = '/(<a[^>]*>)(.*?)(<\/a>)/';
-						break;
-					case 'core/image':
-					case 'core/cover':
-					case 'core/media-text':
-						$pattern = '/alt="(.*?)"/';
-						break;
-					case 'core/quote':
-					case 'core/pullquote':
-						$pattern = array(
-							'/(<p[^>]*>)(.*?)(<\/p>)/',
-							'/(<cite[^>]*>)(.*?)(<\/cite>)/',
-						);
-						break;
-					case 'core/table':
-						$pattern = array(
-							'/(<td[^>]*>)(.*?)(<\/td>)/',
-							'/(<th[^>]*>)(.*?)(<\/th>)/',
-							'/(<figcaption[^>]*>)(.*?)(<\/figcaption>)/',
-						);
-						break;
-				}
+			}
 
-				// Replace the content with the new content based on the pattern.
-				switch ( $block['blockName'] ) {
+			/*
+			 * Set the pattern based on the block type.
+			 * The pattern is used to match the content that needs to be escaped.
+			 * Pattern is a string for most blocks, but an array for blocks with multiple html elements that need to be escaped.
+			 */
+			$pattern = '';
+			switch ( $block['blockName'] ) {
+				case 'core/paragraph':
+					$pattern = '/(<p[^>]*>)(.*?)(<\/p>)/';
+					break;
+				case 'core/heading':
+					$pattern = '/(<h[^>]*>)(.*?)(<\/h[^>]*>)/';
+					break;
+				case 'core/list-item':
+					$pattern = '/(<li[^>]*>)(.*?)(<\/li>)/';
+					break;
+				case 'core/verse':
+					$pattern = '/(<pre[^>]*>)(.*?)(<\/pre>)/';
+					break;
+				case 'core/button':
+					$pattern = '/(<a[^>]*>)(.*?)(<\/a>)/';
+					break;
+				case 'core/image':
+				case 'core/cover':
+				case 'core/media-text':
+					$pattern = '/alt="(.*?)"/';
+					break;
+				case 'core/quote':
+				case 'core/pullquote':
+					$pattern = array(
+						'/(<p[^>]*>)(.*?)(<\/p>)/',
+						'/(<cite[^>]*>)(.*?)(<\/cite>)/',
+					);
+					break;
+				case 'core/table':
+					$pattern = array(
+						'/(<td[^>]*>)(.*?)(<\/td>)/',
+						'/(<th[^>]*>)(.*?)(<\/th>)/',
+						'/(<figcaption[^>]*>)(.*?)(<\/figcaption>)/',
+					);
+					break;
+			}
 
-					case 'core/paragraph':
-					case 'core/heading':
-					case 'core/list-item':
-					case 'core/verse':
-					case 'core/button':
-						$replace_content_callback = function ( $content ) use ( $pattern ) {
+			// Replace the content with the new content based on the pattern.
+			switch ( $block['blockName'] ) {
+
+				case 'core/paragraph':
+				case 'core/heading':
+				case 'core/list-item':
+				case 'core/verse':
+				case 'core/button':
+					$replace_content_callback = function ( $content ) use ( $pattern ) {
+						if ( empty( $content ) ) {
+							return;
+						}
+						return preg_replace_callback(
+							$pattern,
+							function( $matches ) {
+								return $matches[1] . self::escape_string( $matches[2] ) . $matches[3];
+							},
+							$content
+						);
+					};
+					if ( ! empty( $block['innerContent'] ) ) {
+						$block['innerContent'] = is_array( $block['innerContent'] )
+							? array_map( $replace_content_callback, $block['innerContent'] )
+							: $replace_content_callback( $block['innerContent'] );
+					}
+					break;
+
+				case 'core/image':
+				case 'core/cover':
+				case 'core/media-text':
+					$replace_content_callback = function ( $content ) use ( $pattern ) {
+						if ( empty( $content ) ) {
+							return;
+						}
+						return preg_replace_callback(
+							$pattern,
+							function( $matches ) {
+								return 'alt="' . self::escape_string( $matches[1] ) . '"';
+							},
+							$content
+						);
+					};
+					if ( ! empty( $block['innerContent'] ) ) {
+						$block['innerContent'] = is_array( $block['innerContent'] )
+						? array_map( $replace_content_callback, $block['innerContent'] )
+						: $replace_content_callback( $block['innerContent'] );
+					}
+					break;
+
+				case 'core/quote':
+				case 'core/pullquote':
+					// Iterates the html patterns and replace the content with the escaped content.
+					foreach ( $pattern as $element_pattern ) {
+						$replace_content_callback = function ( $content ) use ( $element_pattern ) {
+							if ( empty( $content ) ) {
+								return;
+							}
 							return preg_replace_callback(
-								$pattern,
+								$element_pattern,
 								function( $matches ) {
 									return $matches[1] . self::escape_string( $matches[2] ) . $matches[3];
 								},
 								$content
 							);
 						};
+
 						if ( ! empty( $block['innerContent'] ) ) {
 							$block['innerContent'] = is_array( $block['innerContent'] )
-								? array_map( $replace_content_callback, $block['innerContent'] )
-								: $replace_content_callback( $block['innerContent'] );
+							? array_map( $replace_content_callback, $block['innerContent'] )
+							: $replace_content_callback( $block['innerContent'] );
 						}
-						break;
+					}
+					break;
 
-					case 'core/image':
-					case 'core/cover':
-					case 'core/media-text':
-						$replace_content_callback = function ( $content ) use ( $pattern ) {
+				case 'core/table':
+					// Iterates the html patterns and replace the content with the escaped content.
+					foreach ( $pattern as $element_pattern ) {
+						$replace_content_callback = function ( $content ) use ( $element_pattern ) {
+							if ( empty( $content ) ) {
+								return;
+							}
 							return preg_replace_callback(
-								$pattern,
+								$element_pattern,
 								function( $matches ) {
-									return 'alt="' . self::escape_string( $matches[1] ) . '"';
+									return $matches[1] . self::escape_string( $matches[2] ) . $matches[3];
 								},
 								$content
 							);
 						};
+
 						if ( ! empty( $block['innerContent'] ) ) {
 							$block['innerContent'] = is_array( $block['innerContent'] )
-								? array_map( $replace_content_callback, $block['innerContent'] )
-								: $replace_content_callback( $block['innerContent'] );
+							? array_map( $replace_content_callback, $block['innerContent'] )
+							: $replace_content_callback( $block['innerContent'] );
 						}
-						if ( ! empty( $block['attrs']['alt'] ) ) {
-							$block['attrs']['alt'] = self::escape_string( $block['attrs']['alt'] );
-						}
-						break;
-
-					case 'core/quote':
-					case 'core/pullquote':
-						// Iterates the html patterns and replace the content with the escaped content.
-						foreach ( $pattern as $element_pattern ) {
-							$replace_content_callback = function ( $content ) use ( $element_pattern ) {
-								return preg_replace_callback(
-									$element_pattern,
-									function( $matches ) {
-										return $matches[1] . self::escape_string( $matches[2] ) . $matches[3];
-									},
-									$content
-								);
-							};
-
-							if ( ! empty( $block['innerContent'] ) ) {
-								$block['innerContent'] = $replace_content_callback( $block['innerContent'] );
-							}
-						}
-						break;
-
-					case 'core/table':
-						// Iterates the html patterns and replace the content with the escaped content.
-						foreach ( $pattern as $element_pattern ) {
-							$replace_content_callback = function ( $content ) use ( $element_pattern ) {
-								return preg_replace_callback(
-									$element_pattern,
-									function( $matches ) {
-										return $matches[1] . self::escape_string( $matches[2] ) . $matches[3];
-									},
-									$content
-								);
-							};
-
-							if ( ! empty( $block['innerContent'] ) ) {
-								$block['innerContent'] = $replace_content_callback( $block['innerContent'] );
-							}
-						}
-						break;
-				}
+					}
+					break;
 			}
 		}
 

--- a/admin/create-theme/theme-locale.php
+++ b/admin/create-theme/theme-locale.php
@@ -1,0 +1,167 @@
+<?php
+/*
+* Locale related functionality
+*/
+class CBT_Theme_Locale {
+
+	public static function escape_string( $string ) {
+		// Avoid escaping if the text is not a string.
+		if ( ! is_string( $string ) ) {
+			return $string;
+		}
+
+		// Check if the text is already escaped.
+		if ( str_starts_with( $string, '<?php echo' ) ) {
+			return $string;
+		}
+
+		$string = addcslashes( $string, "'" );
+		return "<?php echo __( '" . $string . "', '" . wp_get_theme()->get( 'TextDomain' ) . "' ); ?>";
+	}
+
+	/*
+	 * Localize text in text blocks.
+	 *
+	 * @param array $blocks The blocks to localize.
+	 * @return array The localized blocks.
+	 */
+	public static function escape_text_content_of_blocks( $blocks ) {
+		foreach ( $blocks as &$block ) {
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$block['innerBlocks'] = self::escape_text_content_of_blocks( $block['innerBlocks'] );
+			} else {
+				/*
+				 * Set the pattern based on the block type.
+				 * The pattern is used to match the content that needs to be escaped.
+				 * Pattern is a string for most blocks, but an array for blocks with multiple html elements that need to be escaped.
+				 */
+				$pattern = '';
+				switch ( $block['blockName'] ) {
+					case 'core/paragraph':
+						$pattern = '/(<p[^>]*>)(.*?)(<\/p>)/';
+						break;
+					case 'core/heading':
+						$pattern = '/(<h[^>]*>)(.*?)(<\/h[^>]*>)/';
+						break;
+					case 'core/list-item':
+						$pattern = '/(<li[^>]*>)(.*?)(<\/li>)/';
+						break;
+					case 'core/verse':
+						$pattern = '/(<pre[^>]*>)(.*?)(<\/pre>)/';
+						break;
+					case 'core/button':
+						$pattern = '/(<a[^>]*>)(.*?)(<\/a>)/';
+						break;
+					case 'core/image':
+					case 'core/cover':
+					case 'core/media-text':
+						$pattern = '/alt="(.*?)"/';
+						break;
+					case 'core/quote':
+					case 'core/pullquote':
+						$pattern = array(
+							'/(<p[^>]*>)(.*?)(<\/p>)/',
+							'/(<cite[^>]*>)(.*?)(<\/cite>)/',
+						);
+						break;
+					case 'core/table':
+						$pattern = array(
+							'/(<td[^>]*>)(.*?)(<\/td>)/',
+							'/(<th[^>]*>)(.*?)(<\/th>)/',
+							'/(<figcaption[^>]*>)(.*?)(<\/figcaption>)/',
+						);
+						break;
+				}
+
+				// Replace the content with the new content based on the pattern.
+				switch ( $block['blockName'] ) {
+
+					case 'core/paragraph':
+					case 'core/heading':
+					case 'core/list-item':
+					case 'core/verse':
+					case 'core/button':
+						$replace_content_callback = function ( $content ) use ( $pattern ) {
+							return preg_replace_callback(
+								$pattern,
+								function( $matches ) {
+									return $matches[1] . self::escape_string( $matches[2] ) . $matches[3];
+								},
+								$content
+							);
+						};
+						if ( ! empty( $block['innerContent'] ) ) {
+							$block['innerContent'] = is_array( $block['innerContent'] )
+								? array_map( $replace_content_callback, $block['innerContent'] )
+								: $replace_content_callback( $block['innerContent'] );
+						}
+						break;
+
+					case 'core/image':
+					case 'core/cover':
+					case 'core/media-text':
+						$replace_content_callback = function ( $content ) use ( $pattern ) {
+							return preg_replace_callback(
+								$pattern,
+								function( $matches ) {
+									return 'alt="' . self::escape_string( $matches[1] ) . '"';
+								},
+								$content
+							);
+						};
+						if ( ! empty( $block['innerContent'] ) ) {
+							$block['innerContent'] = is_array( $block['innerContent'] )
+								? array_map( $replace_content_callback, $block['innerContent'] )
+								: $replace_content_callback( $block['innerContent'] );
+						}
+						if ( ! empty( $block['attrs']['alt'] ) ) {
+							$block['attrs']['alt'] = self::escape_string( $block['attrs']['alt'] );
+						}
+						break;
+
+					case 'core/quote':
+					case 'core/pullquote':
+						// Iterates the html patterns and replace the content with the escaped content.
+						foreach ( $pattern as $element_pattern ) {
+							$replace_content_callback = function ( $content ) use ( $element_pattern ) {
+								return preg_replace_callback(
+									$element_pattern,
+									function( $matches ) {
+										return $matches[1] . self::escape_string( $matches[2] ) . $matches[3];
+									},
+									$content
+								);
+							};
+
+							if ( ! empty( $block['innerContent'] ) ) {
+								$block['innerContent'] = $replace_content_callback( $block['innerContent'] );
+							}
+						}
+						break;
+
+					case 'core/table':
+						// Iterates the html patterns and replace the content with the escaped content.
+						foreach ( $pattern as $element_pattern ) {
+							$replace_content_callback = function ( $content ) use ( $element_pattern ) {
+								return preg_replace_callback(
+									$element_pattern,
+									function( $matches ) {
+										return $matches[1] . self::escape_string( $matches[2] ) . $matches[3];
+									},
+									$content
+								);
+							};
+
+							if ( ! empty( $block['innerContent'] ) ) {
+								$block['innerContent'] = $replace_content_callback( $block['innerContent'] );
+							}
+						}
+						break;
+				}
+			}
+		}
+
+		return $blocks;
+	}
+}

--- a/tests/CbtThemeLocale/base.php
+++ b/tests/CbtThemeLocale/base.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Base test case for Theme Locale tests.
+ *
+ * @package Create_Block_Theme
+ */
+abstract class CBT_Theme_Locale_UnitTestCase extends WP_UnitTestCase {
+
+	/**
+	 * Stores the original active theme slug in order to restore it in tear down.
+	 *
+	 * @var string|null
+	 */
+	private $orig_active_theme_slug;
+
+	/**
+	 * Stores the custom test theme directory.
+	 *
+	 * @var string|null;
+	 */
+	private $test_theme_dir;
+
+	/**
+	 * Sets up tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Store the original active theme.
+		$this->orig_active_theme_slug = get_option( 'stylesheet' );
+
+		// Create a test theme directory.
+		$this->test_theme_dir = DIR_TESTDATA . '/themes/';
+
+		// Register test theme directory.
+		register_theme_directory( $this->test_theme_dir );
+
+		// Switch to the test theme.
+		switch_theme( 'test-theme-locale' );
+	}
+
+	/**
+	 * Tears down tests.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		// Restore the original active theme.
+		switch_theme( $this->orig_active_theme_slug );
+	}
+}

--- a/tests/CbtThemeLocale/escapeString.php
+++ b/tests/CbtThemeLocale/escapeString.php
@@ -1,0 +1,36 @@
+<?php
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * Tests for the CBT_Theme_Locale::escape_string method.
+ *
+ * @package Create_Block_Theme
+ * @covers CBT_Theme_Locale::escape_string
+ * @group locale
+ */
+class CBT_Theme_Locale_EscapeString extends CBT_Theme_Locale_UnitTestCase {
+	public function test_escape_string() {
+		$string         = 'This is a test text.';
+		$escaped_string = CBT_Theme_Locale::escape_string( $string );
+		$this->assertEquals( "<?php echo __( 'This is a test text.', 'test-locale-theme' ); ?>", $escaped_string );
+	}
+
+	public function test_escape_string_with_html() {
+		$string         = '<p>This is a test text with HTML.</p>';
+		$escaped_string = CBT_Theme_Locale::escape_string( $string );
+		$this->assertEquals( "<?php echo __( '<p>This is a test text with HTML.</p>', 'test-locale-theme' ); ?>", $escaped_string );
+	}
+
+	public function test_escape_string_with_already_escaped_string() {
+		$string         = "<?php echo __( 'This is a test text.', 'test-locale-theme' ); ?>";
+		$escaped_string = CBT_Theme_Locale::escape_string( $string );
+		$this->assertEquals( $string, $escaped_string );
+	}
+
+	public function test_escape_string_with_non_string() {
+		$string         = null;
+		$escaped_string = CBT_Theme_Locale::escape_string( $string );
+		$this->assertEquals( $string, $escaped_string );
+	}
+}

--- a/tests/CbtThemeLocale/escapeString.php
+++ b/tests/CbtThemeLocale/escapeString.php
@@ -16,6 +16,18 @@ class CBT_Theme_Locale_EscapeString extends CBT_Theme_Locale_UnitTestCase {
 		$this->assertEquals( "<?php echo __( 'This is a test text.', 'test-locale-theme' ); ?>", $escaped_string );
 	}
 
+	public function test_escape_string_with_single_quote() {
+		$string         = "This is a test text with a single quote '";
+		$escaped_string = CBT_Theme_Locale::escape_string( $string );
+		$this->assertEquals( "<?php echo __( 'This is a test text with a single quote \\'', 'test-locale-theme' ); ?>", $escaped_string );
+	}
+
+	public function test_escape_string_with_double_quote() {
+		$string         = 'This is a test text with a double quote "';
+		$escaped_string = CBT_Theme_Locale::escape_string( $string );
+		$this->assertEquals( "<?php echo __( 'This is a test text with a double quote \"', 'test-locale-theme' ); ?>", $escaped_string );
+	}
+
 	public function test_escape_string_with_html() {
 		$string         = '<p>This is a test text with HTML.</p>';
 		$escaped_string = CBT_Theme_Locale::escape_string( $string );

--- a/tests/CbtThemeLocale/escapeString.php
+++ b/tests/CbtThemeLocale/escapeString.php
@@ -13,29 +13,29 @@ class CBT_Theme_Locale_EscapeString extends CBT_Theme_Locale_UnitTestCase {
 	public function test_escape_string() {
 		$string         = 'This is a test text.';
 		$escaped_string = CBT_Theme_Locale::escape_string( $string );
-		$this->assertEquals( "<?php echo __( 'This is a test text.', 'test-locale-theme' ); ?>", $escaped_string );
+		$this->assertEquals( "<?php echo __('This is a test text.', 'test-locale-theme');?>", $escaped_string );
 	}
 
 	public function test_escape_string_with_single_quote() {
 		$string         = "This is a test text with a single quote '";
 		$escaped_string = CBT_Theme_Locale::escape_string( $string );
-		$this->assertEquals( "<?php echo __( 'This is a test text with a single quote \\'', 'test-locale-theme' ); ?>", $escaped_string );
+		$this->assertEquals( "<?php echo __('This is a test text with a single quote \\'', 'test-locale-theme');?>", $escaped_string );
 	}
 
 	public function test_escape_string_with_double_quote() {
 		$string         = 'This is a test text with a double quote "';
 		$escaped_string = CBT_Theme_Locale::escape_string( $string );
-		$this->assertEquals( "<?php echo __( 'This is a test text with a double quote \"', 'test-locale-theme' ); ?>", $escaped_string );
+		$this->assertEquals( "<?php echo __('This is a test text with a double quote \"', 'test-locale-theme');?>", $escaped_string );
 	}
 
 	public function test_escape_string_with_html() {
 		$string         = '<p>This is a test text with HTML.</p>';
 		$escaped_string = CBT_Theme_Locale::escape_string( $string );
-		$this->assertEquals( "<?php echo __( '<p>This is a test text with HTML.</p>', 'test-locale-theme' ); ?>", $escaped_string );
+		$this->assertEquals( "<?php echo __('<p>This is a test text with HTML.</p>', 'test-locale-theme');?>", $escaped_string );
 	}
 
 	public function test_escape_string_with_already_escaped_string() {
-		$string         = "<?php echo __( 'This is a test text.', 'test-locale-theme' ); ?>";
+		$string         = "<?php echo __('This is a test text.', 'test-locale-theme');?>";
 		$escaped_string = CBT_Theme_Locale::escape_string( $string );
 		$this->assertEquals( $string, $escaped_string );
 	}

--- a/tests/CbtThemeLocale/escapeTextContentOfBlocks.php
+++ b/tests/CbtThemeLocale/escapeTextContentOfBlocks.php
@@ -1,0 +1,195 @@
+<?php
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * Tests for the CBT_Theme_Locale::escape_text_content_of_blocks method.
+ *
+ * @package Create_Block_Theme
+ * @covers CBT_Theme_Locale::escape_text_content_of_blocks
+ * @group locale
+ */
+class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTestCase {
+
+	/**
+	 * @dataProvider data_test_escape_text_content_of_blocks
+	 */
+	public function test_escape_text_content_of_blocks( $block_markup, $expected_markup ) {
+		// Parse the block markup.
+		$blocks = parse_blocks( $block_markup );
+		// Escape the text content of the blocks.
+		$escaped_blocks = CBT_Theme_Locale::escape_text_content_of_blocks( $blocks );
+		// Serialize the blocks to get the markup.
+		$escaped_markup = serialize_blocks( $escaped_blocks );
+
+		$this->assertEquals( $expected_markup, $escaped_markup, 'The markup result is not as the expected one.' );
+	}
+
+	public function data_test_escape_text_content_of_blocks() {
+		return array(
+
+			'paragraph'                  => array(
+				'block_markup'    => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center">This is a test text.</p><!-- /wp:paragraph -->',
+				'expected_markup' => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><?php echo __( \'This is a test text.\', \'test-locale-theme\' ); ?></p><!-- /wp:paragraph -->',
+			),
+
+			'paragraph on nested groups' => array(
+				'block_markup'    =>
+					'<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"","wideSize":""}} -->
+                    <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"constrained","contentSize":"565px"}} -->
+                    <div class="wp-block-group"><!-- wp:paragraph {"align":"center"} -->
+                    <p class="has-text-align-center">This is a test text.</p>
+                    <!-- /wp:paragraph --></div>
+                    <!-- /wp:group --></div>
+                    <!-- /wp:group -->',
+				'expected_markup' =>
+					'<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"","wideSize":""}} -->
+                    <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"constrained","contentSize":"565px"}} -->
+                    <div class="wp-block-group"><!-- wp:paragraph {"align":"center"} -->
+                    <p class="has-text-align-center"><?php echo __( \'This is a test text.\', \'test-locale-theme\' ); ?></p>
+                    <!-- /wp:paragraph --></div>
+                    <!-- /wp:group --></div>
+                    <!-- /wp:group -->',
+			),
+
+			'heading 1'                  => array(
+				'block_markup'    =>
+					'<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
+                    <h1 class="wp-block-heading has-text-align-center is-style-asterisk">A passion for creating spaces</h1>
+                    <!-- /wp:heading -->',
+				'expected_markup' =>
+					'<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
+                    <h1 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo __( \'A passion for creating spaces\', \'test-locale-theme\' ); ?></h1>
+                    <!-- /wp:heading -->',
+			),
+
+			'heading 2'                  => array(
+				'block_markup'    =>
+					'<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
+                    <h2 class="wp-block-heading has-text-align-center is-style-asterisk">A passion for creating spaces</h2>
+                    <!-- /wp:heading -->',
+				'expected_markup' =>
+					'<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
+                    <h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo __( \'A passion for creating spaces\', \'test-locale-theme\' ); ?></h2>
+                    <!-- /wp:heading -->',
+			),
+
+			'list item'                  => array(
+				'block_markup'    =>
+					'<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
+                    <ul style="line-height:1.75" class="is-style-checkmark-list"><!-- wp:list-item -->
+                    <li>Collaborate with fellow architects.</li>
+                    <!-- /wp:list-item -->
+                    <!-- wp:list-item -->
+                    <li>Showcase your projects.</li>
+                    <!-- /wp:list-item -->
+                    <!-- wp:list-item -->
+                    <li>Experience the world of architecture.</li>
+                    <!-- /wp:list-item --></ul>
+                    <!-- /wp:list -->',
+				'expected_markup' =>
+					'<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
+                    <ul style="line-height:1.75" class="is-style-checkmark-list"><!-- wp:list-item -->
+                    <li><?php echo __( \'Collaborate with fellow architects.\', \'test-locale-theme\' ); ?></li>
+                    <!-- /wp:list-item -->
+                    <!-- wp:list-item -->
+                    <li><?php echo __( \'Showcase your projects.\', \'test-locale-theme\' ); ?></li>
+                    <!-- /wp:list-item -->
+                    <!-- wp:list-item -->
+                    <li><?php echo __( \'Experience the world of architecture.\', \'test-locale-theme\' ); ?></li>
+                    <!-- /wp:list-item --></ul>
+                    <!-- /wp:list -->',
+			),
+
+			'verse'                      => array(
+				'block_markup'    =>
+					'<!-- wp:verse {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+                    <pre class="wp-block-verse">Ya somos el olvido que seremos.<br>El polvo elemental que nos ignora<br>y que fue el rojo Adán y que es ahora<br>todos los hombres, y que no veremos.</pre>
+                    <!-- /wp:verse -->',
+				'expected_markup' =>
+					'<!-- wp:verse {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+                    <pre class="wp-block-verse"><?php echo __( \'Ya somos el olvido que seremos.<br>El polvo elemental que nos ignora<br>y que fue el rojo Adán y que es ahora<br>todos los hombres, y que no veremos.\', \'test-locale-theme\' ); ?></pre>
+                    <!-- /wp:verse -->',
+			),
+
+			'button'                     => array(
+				'block_markup'    =>
+					'<!-- wp:button -->
+                    <div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Sign up</a></div>
+                    <!-- /wp:button -->',
+				'expected_markup' =>
+					'<!-- wp:button -->
+                    <div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo __( \'Sign up\', \'test-locale-theme\' ); ?></a></div>
+                    <!-- /wp:button -->',
+			),
+
+			'image'                      => array(
+				'block_markup'    =>
+					'<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
+                    <figure class="wp-block-image size-large is-style-rounded"><img src="http://localhost/wp1/wp-content/themes/twentytwentyfour/assets/images/windows.webp" alt="Windows of a building in Nuremberg, Germany"/></figure>
+                    <!-- /wp:image -->',
+				'expected_markup' =>
+					'<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
+                    <figure class="wp-block-image size-large is-style-rounded"><img src="http://localhost/wp1/wp-content/themes/twentytwentyfour/assets/images/windows.webp" alt="<?php echo __( \'Windows of a building in Nuremberg, Germany\', \'test-locale-theme\' ); ?>"/></figure>
+                    <!-- /wp:image -->',
+			),
+
+			'cover'                      => array(
+				'block_markup'    =>
+					'<!-- wp:cover {"url":"http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg","id":39,"dimRatio":50,"customOverlayColor":"#1d2b2f","layout":{"type":"constrained"}} -->
+                    <div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#1d2b2f"></span><img class="wp-block-cover__image-background wp-image-39" alt="" src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+                    <p class="has-text-align-center has-large-font-size">This is a cover caption</p>
+                    <!-- /wp:paragraph --></div></div>
+                    <!-- /wp:cover -->',
+				'expected_markup' =>
+					'<!-- wp:cover {"url":"http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg","id":39,"dimRatio":50,"customOverlayColor":"#1d2b2f","layout":{"type":"constrained"}} -->
+                    <div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#1d2b2f"></span><img class="wp-block-cover__image-background wp-image-39" alt="" src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+                    <p class="has-text-align-center has-large-font-size"><?php echo __( \'This is a cover caption\', \'test-locale-theme\' ); ?></p>
+                    <!-- /wp:paragraph --></div></div>
+                    <!-- /wp:cover -->',
+			),
+
+			'media-text'                 => array(
+				'block_markup'    =>
+					'<!-- wp:media-text {"mediaId":39,"mediaLink":"http://localhost/wp1/image/","mediaType":"image"} -->
+                    <div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" alt="" class="wp-image-39 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…"} -->
+                    <p>Media text content test.</p>
+                    <!-- /wp:paragraph --></div></div>
+                    <!-- /wp:media-text -->',
+				'expected_markup' =>
+					'<!-- wp:media-text {"mediaId":39,"mediaLink":"http://localhost/wp1/image/","mediaType":"image"} -->
+                    <div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" alt="" class="wp-image-39 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…"} -->
+                    <p><?php echo __( \'Media text content test.\', \'test-locale-theme\' ); ?></p>
+                    <!-- /wp:paragraph --></div></div>
+                    <!-- /wp:media-text -->',
+			),
+
+			'pullquote'                  => array(
+				'block_markup'    =>
+					'<!-- wp:pullquote -->
+                    <figure class="wp-block-pullquote"><blockquote><p>Yo me equivoqué y pagué, pero la pelota no se mancha.</p><cite>Diego Armando Maradona</cite></blockquote></figure>
+                    <!-- /wp:pullquote -->',
+				'expected_markup' =>
+					'<!-- wp:pullquote -->
+                    <figure class="wp-block-pullquote"><blockquote><p><?php echo __( \'Yo me equivoqué y pagué, pero la pelota no se mancha.\', \'test-locale-theme\' ); ?></p><cite><?php echo __( \'Diego Armando Maradona\', \'test-locale-theme\' ); ?></cite></blockquote></figure>
+                    <!-- /wp:pullquote -->',
+			),
+
+			'table'                      => array(
+				'block_markup'    =>
+					'<!-- wp:table -->
+                    <figure class="wp-block-table"><table><tbody><tr><td>Team</td><td>Points</td></tr><tr><td>Boca</td><td>74</td></tr><tr><td>River</td><td>2</td></tr></tbody></table><figcaption class="wp-element-caption">Score table</figcaption></figure>
+                    <!-- /wp:table -->',
+				'expected_markup' =>
+					'<!-- wp:table -->
+                    <figure class="wp-block-table"><table><tbody><tr><td><?php echo __( \'Team\', \'test-locale-theme\' ); ?></td><td><?php echo __( \'Points\', \'test-locale-theme\' ); ?></td></tr><tr><td><?php echo __( \'Boca\', \'test-locale-theme\' ); ?></td><td><?php echo __( \'74\', \'test-locale-theme\' ); ?></td></tr><tr><td><?php echo __( \'River\', \'test-locale-theme\' ); ?></td><td><?php echo __( \'2\', \'test-locale-theme\' ); ?></td></tr></tbody></table><figcaption class="wp-element-caption"><?php echo __( \'Score table\', \'test-locale-theme\' ); ?></figcaption></figure>
+                    <!-- /wp:table -->',
+			),
+
+		);
+	}
+}
+
+
+
+

--- a/tests/CbtThemeLocale/escapeTextContentOfBlocks.php
+++ b/tests/CbtThemeLocale/escapeTextContentOfBlocks.php
@@ -30,7 +30,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
 
 			'paragraph'                  => array(
 				'block_markup'    => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center">This is a test text.</p><!-- /wp:paragraph -->',
-				'expected_markup' => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><?php echo __( \'This is a test text.\', \'test-locale-theme\' ); ?></p><!-- /wp:paragraph -->',
+				'expected_markup' => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><?php echo __(\'This is a test text.\', \'test-locale-theme\');?></p><!-- /wp:paragraph -->',
 			),
 
 			'paragraph on nested groups' => array(
@@ -46,7 +46,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
 					'<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"","wideSize":""}} -->
                     <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"constrained","contentSize":"565px"}} -->
                     <div class="wp-block-group"><!-- wp:paragraph {"align":"center"} -->
-                    <p class="has-text-align-center"><?php echo __( \'This is a test text.\', \'test-locale-theme\' ); ?></p>
+                    <p class="has-text-align-center"><?php echo __(\'This is a test text.\', \'test-locale-theme\');?></p>
                     <!-- /wp:paragraph --></div>
                     <!-- /wp:group --></div>
                     <!-- /wp:group -->',
@@ -59,7 +59,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:heading -->',
 				'expected_markup' =>
 					'<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
-                    <h1 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo __( \'A passion for creating spaces\', \'test-locale-theme\' ); ?></h1>
+                    <h1 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo __(\'A passion for creating spaces\', \'test-locale-theme\');?></h1>
                     <!-- /wp:heading -->',
 			),
 
@@ -70,7 +70,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:heading -->',
 				'expected_markup' =>
 					'<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
-                    <h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo __( \'A passion for creating spaces\', \'test-locale-theme\' ); ?></h2>
+                    <h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo __(\'A passion for creating spaces\', \'test-locale-theme\');?></h2>
                     <!-- /wp:heading -->',
 			),
 
@@ -90,13 +90,13 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
 				'expected_markup' =>
 					'<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
                     <ul style="line-height:1.75" class="is-style-checkmark-list"><!-- wp:list-item -->
-                    <li><?php echo __( \'Collaborate with fellow architects.\', \'test-locale-theme\' ); ?></li>
+                    <li><?php echo __(\'Collaborate with fellow architects.\', \'test-locale-theme\');?></li>
                     <!-- /wp:list-item -->
                     <!-- wp:list-item -->
-                    <li><?php echo __( \'Showcase your projects.\', \'test-locale-theme\' ); ?></li>
+                    <li><?php echo __(\'Showcase your projects.\', \'test-locale-theme\');?></li>
                     <!-- /wp:list-item -->
                     <!-- wp:list-item -->
-                    <li><?php echo __( \'Experience the world of architecture.\', \'test-locale-theme\' ); ?></li>
+                    <li><?php echo __(\'Experience the world of architecture.\', \'test-locale-theme\');?></li>
                     <!-- /wp:list-item --></ul>
                     <!-- /wp:list -->',
 			),
@@ -108,7 +108,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:verse -->',
 				'expected_markup' =>
 					'<!-- wp:verse {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
-                    <pre class="wp-block-verse"><?php echo __( \'Ya somos el olvido que seremos.<br>El polvo elemental que nos ignora<br>y que fue el rojo Adán y que es ahora<br>todos los hombres, y que no veremos.\', \'test-locale-theme\' ); ?></pre>
+                    <pre class="wp-block-verse"><?php echo __(\'Ya somos el olvido que seremos.<br>El polvo elemental que nos ignora<br>y que fue el rojo Adán y que es ahora<br>todos los hombres, y que no veremos.\', \'test-locale-theme\');?></pre>
                     <!-- /wp:verse -->',
 			),
 
@@ -119,7 +119,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:button -->',
 				'expected_markup' =>
 					'<!-- wp:button -->
-                    <div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo __( \'Sign up\', \'test-locale-theme\' ); ?></a></div>
+                    <div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo __(\'Sign up\', \'test-locale-theme\');?></a></div>
                     <!-- /wp:button -->',
 			),
 
@@ -130,21 +130,21 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:image -->',
 				'expected_markup' =>
 					'<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
-                    <figure class="wp-block-image size-large is-style-rounded"><img src="http://localhost/wp1/wp-content/themes/twentytwentyfour/assets/images/windows.webp" alt="<?php echo __( \'Windows of a building in Nuremberg, Germany\', \'test-locale-theme\' ); ?>"/></figure>
+                    <figure class="wp-block-image size-large is-style-rounded"><img src="http://localhost/wp1/wp-content/themes/twentytwentyfour/assets/images/windows.webp" alt="<?php echo __(\'Windows of a building in Nuremberg, Germany\', \'test-locale-theme\');?>"/></figure>
                     <!-- /wp:image -->',
 			),
 
 			'cover'                      => array(
 				'block_markup'    =>
-					'<!-- wp:cover {"url":"http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg","id":39,"dimRatio":50,"customOverlayColor":"#1d2b2f","layout":{"type":"constrained"}} -->
-                    <div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#1d2b2f"></span><img class="wp-block-cover__image-background wp-image-39" alt="" src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+					'<!-- wp:cover {"url":"http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg","id":39,"alt":"Alternative text for cover image","dimRatio":50,"customOverlayColor":"#1d2b2f","layout":{"type":"constrained"}} -->
+                    <div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#1d2b2f"></span><img class="wp-block-cover__image-background wp-image-39" alt="Alternative text for cover image" src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
                     <p class="has-text-align-center has-large-font-size">This is a cover caption</p>
                     <!-- /wp:paragraph --></div></div>
                     <!-- /wp:cover -->',
 				'expected_markup' =>
-					'<!-- wp:cover {"url":"http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg","id":39,"dimRatio":50,"customOverlayColor":"#1d2b2f","layout":{"type":"constrained"}} -->
-                    <div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#1d2b2f"></span><img class="wp-block-cover__image-background wp-image-39" alt="" src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
-                    <p class="has-text-align-center has-large-font-size"><?php echo __( \'This is a cover caption\', \'test-locale-theme\' ); ?></p>
+					'<!-- wp:cover {"url":"http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg","id":39,"alt":"Alternative text for cover image","dimRatio":50,"customOverlayColor":"#1d2b2f","layout":{"type":"constrained"}} -->
+                    <div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#1d2b2f"></span><img class="wp-block-cover__image-background wp-image-39" alt="<?php echo __(\'Alternative text for cover image\', \'test-locale-theme\');?>" src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+                    <p class="has-text-align-center has-large-font-size"><?php echo __(\'This is a cover caption\', \'test-locale-theme\');?></p>
                     <!-- /wp:paragraph --></div></div>
                     <!-- /wp:cover -->',
 			),
@@ -152,14 +152,14 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
 			'media-text'                 => array(
 				'block_markup'    =>
 					'<!-- wp:media-text {"mediaId":39,"mediaLink":"http://localhost/wp1/image/","mediaType":"image"} -->
-                    <div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" alt="" class="wp-image-39 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…"} -->
+                    <div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" alt="This is alt text" class="wp-image-39 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…"} -->
                     <p>Media text content test.</p>
                     <!-- /wp:paragraph --></div></div>
                     <!-- /wp:media-text -->',
 				'expected_markup' =>
 					'<!-- wp:media-text {"mediaId":39,"mediaLink":"http://localhost/wp1/image/","mediaType":"image"} -->
-                    <div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" alt="" class="wp-image-39 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…"} -->
-                    <p><?php echo __( \'Media text content test.\', \'test-locale-theme\' ); ?></p>
+                    <div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" alt="<?php echo __(\'This is alt text\', \'test-locale-theme\');?>" class="wp-image-39 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…"} -->
+                    <p><?php echo __(\'Media text content test.\', \'test-locale-theme\');?></p>
                     <!-- /wp:paragraph --></div></div>
                     <!-- /wp:media-text -->',
 			),
@@ -171,7 +171,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:pullquote -->',
 				'expected_markup' =>
 					'<!-- wp:pullquote -->
-                    <figure class="wp-block-pullquote"><blockquote><p><?php echo __( \'Yo me equivoqué y pagué, pero la pelota no se mancha.\', \'test-locale-theme\' ); ?></p><cite><?php echo __( \'Diego Armando Maradona\', \'test-locale-theme\' ); ?></cite></blockquote></figure>
+                    <figure class="wp-block-pullquote"><blockquote><p><?php echo __(\'Yo me equivoqué y pagué, pero la pelota no se mancha.\', \'test-locale-theme\');?></p><cite><?php echo __(\'Diego Armando Maradona\', \'test-locale-theme\');?></cite></blockquote></figure>
                     <!-- /wp:pullquote -->',
 			),
 
@@ -182,7 +182,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:table -->',
 				'expected_markup' =>
 					'<!-- wp:table -->
-                    <figure class="wp-block-table"><table><tbody><tr><td><?php echo __( \'Team\', \'test-locale-theme\' ); ?></td><td><?php echo __( \'Points\', \'test-locale-theme\' ); ?></td></tr><tr><td><?php echo __( \'Boca\', \'test-locale-theme\' ); ?></td><td><?php echo __( \'74\', \'test-locale-theme\' ); ?></td></tr><tr><td><?php echo __( \'River\', \'test-locale-theme\' ); ?></td><td><?php echo __( \'2\', \'test-locale-theme\' ); ?></td></tr></tbody></table><figcaption class="wp-element-caption"><?php echo __( \'Score table\', \'test-locale-theme\' ); ?></figcaption></figure>
+                    <figure class="wp-block-table"><table><tbody><tr><td><?php echo __(\'Team\', \'test-locale-theme\');?></td><td><?php echo __(\'Points\', \'test-locale-theme\');?></td></tr><tr><td><?php echo __(\'Boca\', \'test-locale-theme\');?></td><td><?php echo __(\'74\', \'test-locale-theme\');?></td></tr><tr><td><?php echo __(\'River\', \'test-locale-theme\');?></td><td><?php echo __(\'2\', \'test-locale-theme\');?></td></tr></tbody></table><figcaption class="wp-element-caption"><?php echo __(\'Score table\', \'test-locale-theme\');?></figcaption></figure>
                     <!-- /wp:table -->',
 			),
 

--- a/tests/data/themes/test-theme-locale/style.css
+++ b/tests/data/themes/test-theme-locale/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Test Locale Theme
+Theme URI: https://example.org/themes/test-locale-theme
+Author: the WordPress team
+Author URI: https://wordpress.org
+Description: Test Locale Theme is a theme for testing the text localization/escaping capabilities of the Create Block Theme plugin.
+Requires at least: 6.4
+Tested up to: 6.4
+Requires PHP: 7.0
+Version: 1.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: test-locale-theme
+Tags: test, locale, theme
+*/

--- a/tests/data/themes/test-theme-locale/theme.json
+++ b/tests/data/themes/test-theme-locale/theme.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"styles": {},
+	"settings": {}
+}

--- a/tests/test-theme-templates.php
+++ b/tests/test-theme-templates.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @package Create_Block_Theme
+ * @group templates
  */
 class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 
@@ -187,8 +188,6 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 		$new_template      = CBT_Theme_Templates::escape_text_in_template( $template );
 		// Check the markup attribute
 		$this->assertStringContainsString( 'alt="<?php echo __(\'This is alt text\', \'\');?>"', $new_template->content );
-		// Check the block attribute
-		$this->assertStringContainsString( '"alt":"<?php echo __(\'This is alt text\', \'\');?>"', $new_template->content );
 	}
 
 	public function test_localize_quote() {


### PR DESCRIPTION
## What?
Fix template texts localizing/escaping.


Fixes: https://github.com/WordPress/create-block-theme/issues/632

## Why?
The current implementation consisting of:
1. Collect all the strings from the templates markup using regex.
2. Search and replace the strings collected.

This approach is flawed because it fails, for example, when there are substrings. The problem is explained in this comment: https://github.com/WordPress/create-block-theme/issues/632#issuecomment-2112602045

☣️ The severity of the problem is high because the resulting templates/patterns are broken because the plugin is producing invalid markup.

## How?
This PR improves the approach around escaping block strings for translation. It avoids the substring problem by just considering the HTML content block by block.
The new implementation consist of:
1. Parse the template markup with the core's function `parse_blocks().`
2. In the blocks that can contain text, use regex to update the HTML content of the block 'innetContent' property with the escaped text.
3.  Serialize the template blocks to markup again using core's `serialize_blocks()` function.

