### PR TITLE
Add screenshot to valid theme properties during sanitization

### DIFF
--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -490,6 +490,7 @@ class CBT_Theme_API {
 		$sanitized_theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] ?? '' );
 		$sanitized_theme['subfolder']           = sanitize_text_field( $theme['subfolder'] ?? '' );
 		$sanitized_theme['version']             = sanitize_text_field( $theme['version'] ?? '' );
+		$sanitized_theme['screenshot']          = sanitize_text_field( $theme['screenshot'] ?? '' );
 		$sanitized_theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] ?? '' );
 		$sanitized_theme['template']            = '';
 		$sanitized_theme['slug']                = sanitize_title( $theme['name'] );


### PR DESCRIPTION
When we starting sanitizing the updating of metadata the screenshot editing functionality stopped working.

This adds it back.

To test:

Modify the screenshot using CBT.
Click Update

Note that the screenshot is updated.