### PR TITLE
Fixed font utilities to work with font sources as an (optional) array.

### DIFF
--- a/includes/create-theme/theme-fonts.php
+++ b/includes/create-theme/theme-fonts.php
@@ -47,19 +47,25 @@ class CBT_Theme_Fonts {
 				continue;
 			}
 			foreach ( $font_family['fontFace'] as &$font_face ) {
-				$font_filename = basename( $font_face['src'] );
-				$font_dir      = wp_get_font_dir();
-				if ( str_contains( $font_face['src'], $font_dir['url'] ) ) {
-					// If the file is hosted on this server then copy it to the theme
-					copy( $font_dir['path'] . '/' . $font_filename, $theme_font_asset_location . '/' . $font_filename );
-				} else {
-					// otherwise download it from wherever it is hosted
-					$tmp_file = download_url( $font_face['src'] );
-					copy( $tmp_file, $theme_font_asset_location . $font_filename );
-					unlink( $tmp_file );
+				// src can be a string or an array
+				// if it is a string, cast it to an array
+				if ( ! is_array( $font_face['src'] ) ) {
+					$font_face['src'] = array( $font_face['src'] );
 				}
-
-				$font_face['src'] = 'file:./assets/fonts/' . $font_filename;
+				foreach ( $font_face['src'] as $font_src_index => &$font_src ) {
+					$font_filename = basename( $font_src );
+					$font_dir      = wp_get_font_dir();
+					if ( str_contains( $font_src, $font_dir['url'] ) ) {
+						// If the file is hosted on this server then copy it to the theme
+						copy( $font_dir['path'] . '/' . $font_filename, $theme_font_asset_location . '/' . $font_filename );
+					} else {
+						// otherwise download it from wherever it is hosted
+						$tmp_file = download_url( $font_src );
+						copy( $tmp_file, $theme_font_asset_location . $font_filename );
+						unlink( $tmp_file );
+					}
+					$font_face['src'][ $font_src_index ] = 'file:./assets/fonts/' . $font_filename;
+				}
 			}
 		}
 
@@ -114,9 +120,16 @@ class CBT_Theme_Fonts {
 		foreach ( $font_families_to_remove as $font_family ) {
 			if ( isset( $font_family['fontFace'] ) ) {
 				foreach ( $font_family['fontFace'] as $font_face ) {
-					$font_filename = basename( $font_face['src'] );
-					if ( file_exists( $theme_font_asset_location . $font_filename ) ) {
-						unlink( $theme_font_asset_location . $font_filename );
+					// src can be a string or an array
+					// if it is a string, cast it to an array
+					if ( ! is_array( $font_face['src'] ) ) {
+						$font_face['src'] = array( $font_face['src'] );
+					}
+					foreach ( $font_face['src'] as $font_src ) {
+						$font_filename = basename( $font_src );
+						if ( file_exists( $theme_font_asset_location . $font_filename ) ) {
+							unlink( $theme_font_asset_location . $font_filename );
+						}
 					}
 				}
 			}

--- a/tests/test-theme-fonts.php
+++ b/tests/test-theme-fonts.php
@@ -52,7 +52,7 @@ class Test_Create_Block_Theme_Fonts extends WP_UnitTestCase {
 		$this->assertEquals( 'open-sans', $theme_data_after['typography']['fontFamilies']['theme'][1]['slug'] );
 
 		// Ensure that the URL was changed to a local file and that it was copied to where it should be
-		$this->assertEquals( 'file:./assets/fonts/open-sans-normal-400.ttf', $theme_data_after['typography']['fontFamilies']['theme'][1]['fontFace'][0]['src'] );
+		$this->assertEquals( 'file:./assets/fonts/open-sans-normal-400.ttf', $theme_data_after['typography']['fontFamilies']['theme'][1]['fontFace'][0]['src'][0] );
 		$this->assertTrue( file_exists( get_stylesheet_directory() . '/assets/fonts/open-sans-normal-400.ttf' ) );
 
 		$this->uninstall_theme( $test_theme_slug );
@@ -103,10 +103,6 @@ class Test_Create_Block_Theme_Fonts extends WP_UnitTestCase {
 
 	private function save_theme() {
 		CBT_Theme_Fonts::persist_font_settings();
-		// CBT_Theme_Templates::add_templates_to_local( 'all' );
-		// CBT_Theme_JSON::add_theme_json_to_local( 'all' );
-		// CBT_Theme_Styles::clear_user_styles_customizations();
-		// CBT_Theme_Templates::clear_user_templates_customizations();
 	}
 
 	private function create_blank_theme() {
@@ -197,7 +193,10 @@ class Test_Create_Block_Theme_Fonts extends WP_UnitTestCase {
 					'fontFamily' => 'Open Sans',
 					'fontStyle'  => 'normal',
 					'fontWeight' => '400',
-					'src'        => 'file:./assets/fonts/open-sans-normal-400.ttf',
+					'src'        => array(
+						'file:./assets/fonts/open-sans-normal-400.ttf',
+						'file:./assets/fonts/open-sans-normal-400.ttf',
+					),
 				),
 			),
 		);


### PR DESCRIPTION
When saving theme.json the `src` of font faces CAN be an array.

This change always writes that value as an array and can now operate on theme.json configurations that use arrays OR strings.

Fixes #599 