### PR TITLE
Handle font credits in the backend

### DIFF
--- a/admin/class-create-theme.php
+++ b/admin/class-create-theme.php
@@ -135,6 +135,7 @@ class CBT_WP_Admin {
 		$theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
 		$theme['image_credits']       = sanitize_textarea_field( $theme['image_credits'] );
 		$theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
+		$theme['font_credits']        = sanitize_textarea_field( $theme['font_credits'] );
 		$theme['slug']                = $theme_slug;
 		$theme['template']            = wp_get_theme()->get( 'Template' );
 		$theme['text_domain']         = $theme_slug;
@@ -197,6 +198,7 @@ class CBT_WP_Admin {
 		$theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
 		$theme['image_credits']       = sanitize_textarea_field( $theme['image_credits'] );
 		$theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
+		$theme['font_credits']        = sanitize_textarea_field( $theme['font_credits'] );
 		$theme['slug']                = $theme_slug;
 		$theme['template']            = '';
 		$theme['text_domain']         = $theme_slug;
@@ -267,6 +269,7 @@ class CBT_WP_Admin {
 		$theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
 		$theme['image_credits']       = sanitize_textarea_field( $theme['image_credits'] );
 		$theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
+		$theme['font_credits']        = sanitize_textarea_field( $theme['font_credits'] );
 		$theme['is_child_theme']      = true;
 		$theme['text_domain']         = $child_theme_slug;
 		$theme['template']            = $parent_theme_slug;
@@ -345,6 +348,7 @@ class CBT_WP_Admin {
 		$theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] );
 		$theme['image_credits']       = sanitize_textarea_field( $theme['image_credits'] );
 		$theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] );
+		$theme['font_credits']        = sanitize_textarea_field( $theme['font_credits'] );
 		$theme['template']            = '';
 		$theme['slug']                = $theme_slug;
 		$theme['text_domain']         = $theme_slug;

--- a/admin/create-theme/theme-readme.php
+++ b/admin/create-theme/theme-readme.php
@@ -55,6 +55,7 @@ class CBT_Theme_Readme {
 		$license_uri          = $theme['license_uri'] ?? 'http://www.gnu.org/licenses/gpl-2.0.html';
 		$image_credits        = $theme['image_credits'] ?? '';
 		$recommended_plugins  = $theme['recommended_plugins'] ?? '';
+		$font_credits         = $theme['font_credits'] ?? '';
 		$is_child_theme       = $theme['is_child_theme'] ?? false;
 
 		// Generates the copyright section text.
@@ -86,6 +87,9 @@ License URI: {$license_uri}
 
 		// Adds the recommended plugins section
 		$readme_content = self::add_or_update_section( 'Recommended Plugins', $recommended_plugins, $readme_content );
+
+		// Adds the font credits section
+		$readme_content = self::add_or_update_section( 'Fonts', $font_credits, $readme_content );
 
 		// Adds the Copyright section
 		$readme_content = self::add_or_update_section( 'Copyright', $copyright_section_content, $readme_content );
@@ -193,6 +197,7 @@ GNU General Public License for more details.
 	 *   @type string $author The theme author.
 	 *   @type string $image_credits The image credits.
 	 *   @type string $recommended_plugins The recommended plugins.
+	 *   @type string $font_credits The font credits.
 	 * }
 	 * @param string $readme_content readme.txt content.
 	 * @return string
@@ -204,6 +209,7 @@ GNU General Public License for more details.
 		$wp_version          = $theme['wp_version'] ?? CBT_Theme_Utils::get_current_wordpress_version();
 		$image_credits       = $theme['image_credits'] ?? '';
 		$recommended_plugins = $theme['recommended_plugins'] ?? '';
+		$font_credits        = $theme['font_credits'] ?? '';
 
 		// Update description.
 		$readme_content = self::add_or_update_section( 'Description', $description, $readme_content );
@@ -216,6 +222,9 @@ GNU General Public License for more details.
 
 		// Update recommended plugins section.
 		$readme_content = self::add_or_update_section( 'Recommended Plugins', $recommended_plugins, $readme_content );
+
+		// Update font credits section.
+		$readme_content = self::add_or_update_section( 'Fonts', $font_credits, $readme_content );
 
 		// Update image credits section.
 		$readme_content = self::add_or_update_section( 'Images', $image_credits, $readme_content );

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -492,6 +492,7 @@ class CBT_Theme_API {
 		$sanitized_theme['version']             = sanitize_text_field( $theme['version'] ?? '' );
 		$sanitized_theme['screenshot']          = sanitize_text_field( $theme['screenshot'] ?? '' );
 		$sanitized_theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] ?? '' );
+		$sanitized_theme['font_credits']        = sanitize_textarea_field( $theme['font_credits'] ?? '' );
 		$sanitized_theme['template']            = '';
 		$sanitized_theme['slug']                = sanitize_title( $theme['name'] );
 		$sanitized_theme['text_domain']         = $sanitized_theme['slug'];

--- a/tests/CbtThemeReadme/create.php
+++ b/tests/CbtThemeReadme/create.php
@@ -55,6 +55,12 @@ class CBT_ThemeReadme_Create extends CBT_Theme_Readme_UnitTestCase {
 				'The expected reference to the parent theme is missing.'
 			);
 		}
+
+		// Assertion specific to font credits.
+		if ( isset( $data['font_credits'] ) ) {
+			$expected_font_credits = '== Fonts ==' . $data['font_credits'];
+			$this->assertStringContainsString( $expected_font_credits, $readme_without_newlines, 'The expected font credits are missing.' );
+		}
 	}
 
 	public function data_test_create() {
@@ -73,6 +79,7 @@ class CBT_ThemeReadme_Create extends CBT_Theme_Readme_UnitTestCase {
 					'license_uri'          => 'https://www.gnu.org/licenses/gpl-2.0.html',
 					'image_credits'        => 'The images were taken from https://example.org and have a CC0 license.',
 					'recommended_plugins'  => 'The theme is best used with the following plugins: Plugin 1, Plugin 2, Plugin 3.',
+					'font_credits'         => 'Font credit example text',
 				),
 			),
 			'complete data for a child theme'  => array(
@@ -90,6 +97,7 @@ class CBT_ThemeReadme_Create extends CBT_Theme_Readme_UnitTestCase {
 					'image_credits'        => 'The images were taken from https://example.org and have a CC0 license.',
 					'recommended_plugins'  => 'The theme is best used with the following plugins: Plugin 1, Plugin 2, Plugin 3.',
 					'is_child_theme'       => true,
+					'font_credits'         => 'Font credit example text',
 				),
 			),
 			'complete data for a cloned theme' => array(
@@ -107,6 +115,23 @@ class CBT_ThemeReadme_Create extends CBT_Theme_Readme_UnitTestCase {
 					'image_credits'        => 'The images were taken from https://example.org and have a CC0 license.',
 					'recommended_plugins'  => 'The theme is best used with the following plugins: Plugin 1, Plugin 2, Plugin 3.',
 					'is_cloned_theme'      => true,
+					'font_credits'         => 'Font credit example text',
+				),
+			),
+			'missing font credits'             => array(
+				'data' => array(
+					'name'                 => 'My Theme',
+					'description'          => 'New theme description',
+					'uri'                  => 'https://example.com',
+					'author'               => 'New theme author',
+					'author_uri'           => 'https://example.com/author',
+					'copyright_year'       => '2077',
+					'wp_version'           => '12.12',
+					'required_php_version' => '10.0',
+					'license'              => 'GPLv2 or later',
+					'license_uri'          => 'https://www.gnu.org/licenses/gpl-2.0.html',
+					'image_credits'        => 'The images were taken from https://example.org and have a CC0 license.',
+					'recommended_plugins'  => 'The theme is best used with the following plugins: Plugin 1, Plugin 2, Plugin 3.',
 				),
 			),
 			// TODO: Add more test cases.

--- a/tests/CbtThemeReadme/update.php
+++ b/tests/CbtThemeReadme/update.php
@@ -30,11 +30,27 @@ class CBT_ThemeReadme_Update extends CBT_Theme_Readme_UnitTestCase {
 		$this->assertStringContainsString( $expected_wp_version, $readme_without_newlines, 'The expected WP version is missing.' );
 		$this->assertStringContainsString( $expected_image_credits, $readme_without_newlines, 'The expected image credits are missing.' );
 		$this->assertStringContainsString( $expected_recommended_plugins, $readme_without_newlines, 'The expected recommended plugins are missing.' );
+
+		// Assertion specific to font credits.
+		if ( isset( $data['font_credits'] ) ) {
+			$expected_font_credits = '== Fonts ==' . $data['font_credits'];
+			$this->assertStringContainsString( $expected_font_credits, $readme_without_newlines, 'The expected font credits are missing.' );
+		}
 	}
 
 	public function data_test_update() {
 		return array(
-			'complete data' => array(
+			'complete data'        => array(
+				'data' => array(
+					'description'         => 'New theme description',
+					'author'              => 'New theme author',
+					'wp_version'          => '12.12',
+					'image_credits'       => 'New image credits',
+					'recommended_plugins' => 'New recommended plugins',
+					'font_credits'        => 'Example font credits text',
+				),
+			),
+			'missing font credits' => array(
 				'data' => array(
 					'description'         => 'New theme description',
 					'author'              => 'New theme author',


### PR DESCRIPTION
## What?
- Makes possible to send font_credits param in the requests to be written in the readme in the readme.txt file.
- Add corresponging tests

## Why?
- The plugin should be able to handle the addition of the font credits in the readme.txt file.
- This is part of the effort to re-introduce the font license theme automation (https://github.com/WordPress/create-block-theme/issues/525).