### PR TITLE
Fix the jslint warning from useSelect usage

### DIFF
--- a/src/editor-sidebar/create-panel.js
+++ b/src/editor-sidebar/create-panel.js
@@ -32,6 +32,14 @@ import ScreenHeader from './screen-header';
 export const CreateThemePanel = ( { createType } ) => {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
+	const subfolder = useSelect( ( select ) => {
+		const stylesheet = select( 'core' ).getCurrentTheme().stylesheet;
+		if ( stylesheet.lastIndexOf( '/' ) > 1 ) {
+			return stylesheet.substring( 0, stylesheet.lastIndexOf( '/' ) );
+		}
+		return '';
+	}, [] );
+
 	const [ theme, setTheme ] = useState( {
 		name: '',
 		description: '',
@@ -39,22 +47,8 @@ export const CreateThemePanel = ( { createType } ) => {
 		author: '',
 		author_uri: '',
 		tags_custom: '',
-		subfolder: '',
+		subfolder,
 	} );
-
-	useSelect( ( select ) => {
-		const themeData = select( 'core' ).getCurrentTheme();
-		setTheme( {
-			...theme,
-			subfolder:
-				themeData.stylesheet.lastIndexOf( '/' ) > 1
-					? themeData.stylesheet.substring(
-							0,
-							themeData.stylesheet.lastIndexOf( '/' )
-					  )
-					: '',
-		} );
-	}, [] );
 
 	const cloneTheme = () => {
 		if ( createType === 'createClone' ) {


### PR DESCRIPTION
Fix the jslint warning (or infinate loop error when fixed) from useSelect usage.

Pulled the subfolder value (once) and set it in the initial call to `useState` rather than using that state in the `useSelect` when fetching the current theme's subfolder.

Fixes jslint warning and everything works as expected.

(To test, create a new theme using the Editor interface.  It should be created in the same subfolder as the currently activated theme)