### PR TITLE
Added subfolder to initial theme state to eliminate render error

### DIFF
--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -48,6 +48,7 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 		author_uri: '',
 		tags_custom: '',
 		recommended_plugins: '',
+		subfolder: '',
 	} );
 
 	const { createErrorNotice } = useDispatch( noticesStore );


### PR DESCRIPTION
To test:

Load the Metadata Modal window with the browser console open.

Note that no errors are shown.  (There should be no other changes.)

<img width="912" alt="image" src="https://github.com/WordPress/create-block-theme/assets/146530/7ceb734f-ca16-4345-8421-0c14f9bd5838">
