### PR TITLE
Flush cache after saving/creating/exporting themes

### DIFF
--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -382,7 +382,6 @@ class CBT_Theme_API {
 		}
 
 		$zip->close();
-		wp_cache_flush();
 
 		wp_cache_flush();
 

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -203,6 +203,8 @@ class CBT_Theme_API {
 
 		$response = CBT_Theme_Create::clone_current_theme( $this->sanitize_theme_data( $request->get_params() ) );
 
+		wp_cache_flush();
+
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
@@ -224,6 +226,8 @@ class CBT_Theme_API {
 
 		$response = CBT_Theme_Create::create_child_theme( $theme, $screenshot );
 
+		wp_cache_flush();
+
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
@@ -239,6 +243,8 @@ class CBT_Theme_API {
 	function rest_create_variation( $request ) {
 
 		$response = CBT_Theme_JSON::add_theme_json_variation_to_local( 'variation', $this->sanitize_theme_data( $request->get_params() ) );
+
+		wp_cache_flush();
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -259,6 +265,8 @@ class CBT_Theme_API {
 		$screenshot = null;
 
 		$response = CBT_Theme_Create::create_blank_theme( $theme, $screenshot );
+
+		wp_cache_flush();
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -320,6 +328,8 @@ class CBT_Theme_API {
 
 		$zip->close();
 
+		wp_cache_flush();
+
 		header( 'Content-Type: application/zip' );
 		header( 'Content-Disposition: attachment; filename=' . $theme['slug'] . '.zip' );
 		header( 'Content-Length: ' . filesize( $filename ) );
@@ -372,6 +382,9 @@ class CBT_Theme_API {
 		}
 
 		$zip->close();
+		wp_cache_flush();
+
+		wp_cache_flush();
 
 		header( 'Content-Type: application/zip' );
 		header( 'Content-Disposition: attachment; filename=' . $theme['slug'] . '.zip' );
@@ -390,7 +403,7 @@ class CBT_Theme_API {
 				__( 'Unable to create a zip file. ZipArchive not available.', 'create-block-theme' ),
 			);
 		}
-
+		wp_cache_flush();
 		$theme_slug = wp_get_theme()->get( 'TextDomain' );
 
 		// Create ZIP file in the temporary directory.
@@ -400,6 +413,7 @@ class CBT_Theme_API {
 		$zip = CBT_Theme_Zip::copy_theme_to_zip( $zip, null, null );
 
 		if ( is_child_theme() ) {
+			wp_cache_flush();
 			$zip        = CBT_Theme_Zip::add_templates_to_zip( $zip, 'current', $theme_slug );
 			$theme_json = CBT_Theme_JSON_Resolver::export_theme_data( 'current' );
 		} else {
@@ -412,6 +426,8 @@ class CBT_Theme_API {
 		$zip = CBT_Theme_Zip::add_theme_json_to_zip( $zip, $theme_json );
 
 		$zip->close();
+
+		wp_cache_flush();
 
 		header( 'Content-Type: application/zip' );
 		header( 'Content-Disposition: attachment; filename=' . $theme_slug . '.zip' );
@@ -447,6 +463,8 @@ class CBT_Theme_API {
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
+
+		wp_cache_flush();
 
 		return new WP_REST_Response(
 			array(
@@ -488,6 +506,8 @@ class CBT_Theme_API {
 			}
 			CBT_Theme_Styles::clear_user_styles_customizations();
 		}
+
+		wp_cache_flush();
 
 		return new WP_REST_Response(
 			array(


### PR DESCRIPTION
## What?
This pull request includes changes to flush the cache after creating new themes. 

Fixes: https://github.com/WordPress/create-block-theme/issues/655

## Why?
When the cache is not flushed, in plataforms using the WordPress cache utils, it could result in the editor loading a blank page. 
This ensures that the cache is updated with the latest theme data.

## How?
By calling `wp_cache_flush();` after the creation of new themes and variations.

## How to test.
- Create a site in pressable.
-  Install and activate CBT plugin with this patch.
-  Make a change to a template text and save the changes in the editor.
- Save the changes to the theme using the CBT  sidebar 'Save theme changes' button.
- Check that the changes were saved successfully and loaded in the editor as expected.



