### PR TITLE
Update wp-admin landing url for blueprint

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
-	"landingPage": "/wp-admin/themes.php?page=create-block-theme",
+	"landingPage": "/wp-admin/themes.php?page=create-block-theme-landing",
 	"features": {
 		"networking": true
 	},


### PR DESCRIPTION
## What?
Update wp-admin landing url for Wordpress playground blueprint.

## Why?
The old URL loaded at startup by playground is outdated.

Props to @pbking.

Co-authored-by: Jason Crist <146530+pbking@users.noreply.github.com>