### PR TITLE
Check if theme fonts present before removing

### DIFF
--- a/includes/create-theme/theme-fonts.php
+++ b/includes/create-theme/theme-fonts.php
@@ -221,7 +221,7 @@ class CBT_Theme_Fonts {
 		$font_families_to_not_remove = $user_settings['typography']['fontFamilies']['theme'];
 
 		$theme_font_families = isset( $theme_json['settings']['typography']['fontFamilies'] ) ? $theme_json['settings']['typography']['fontFamilies'] : null;
-		$did_remove_assets   = static::remove_deactivated_font_assets( $font_families_to_not_remove, $theme_font_families );
+		static::remove_deactivated_font_assets( $font_families_to_not_remove, $theme_font_families );
 
 		if ( null !== $theme_font_families ) {
 			$theme_json['settings']['typography']['fontFamilies'] = array_values(

--- a/includes/create-theme/theme-fonts.php
+++ b/includes/create-theme/theme-fonts.php
@@ -164,6 +164,12 @@ class CBT_Theme_Fonts {
 
 	}
 
+	/**
+	 * Remove font face assets from the theme that are not in the user configuration.
+	 *
+	 * @param array $font_families_to_not_remove
+	 * @param array $theme_font_families
+	 */
 	private static function remove_deactivated_font_assets( $font_families_to_not_remove, $theme_font_families ) {
 		/* Bail if there are no theme font families, which can happen
 		 * if the theme.json file, missing, or if the theme is a child theme, in
@@ -173,7 +179,7 @@ class CBT_Theme_Fonts {
 			return;
 		}
 
-		// Remove font assets from theme
+		// Remove font face assets from the theme that are not in the user configuration.
 		$theme_font_asset_location = get_stylesheet_directory() . '/assets/fonts/';
 		$font_families_to_remove   = array_values(
 			array_filter(
@@ -207,6 +213,8 @@ class CBT_Theme_Fonts {
 	 * Remove any deactivated fonts from the theme configuration.
 	 * This includes removing the font face assets from the theme,
 	 * but does not remove the font face assets from the user configuration.
+	 *
+	 * This is because the user may have deactivated a font, but still want to use it in the future.
 	 */
 	public static function remove_deactivated_fonts_from_theme() {
 
@@ -223,6 +231,7 @@ class CBT_Theme_Fonts {
 		$theme_font_families = isset( $theme_json['settings']['typography']['fontFamilies'] ) ? $theme_json['settings']['typography']['fontFamilies'] : null;
 		static::remove_deactivated_font_assets( $font_families_to_not_remove, $theme_font_families );
 
+		// If there are font families in the theme, remove the deactivated ones
 		if ( null !== $theme_font_families ) {
 			$theme_json['settings']['typography']['fontFamilies'] = array_values(
 				array_filter(
@@ -236,7 +245,7 @@ class CBT_Theme_Fonts {
 
 		CBT_Theme_JSON_Resolver::write_theme_file_contents( $theme_json );
 
-		// Remove user preferences for theme font activation
+		// Remove deactivated fonts from user settings
 		unset( $user_settings['typography']['fontFamilies']['theme'] );
 		if ( empty( $user_settings['typography']['fontFamilies'] ) ) {
 			unset( $user_settings['typography']['fontFamilies'] );
@@ -247,5 +256,4 @@ class CBT_Theme_Fonts {
 
 		CBT_Theme_JSON_Resolver::write_user_settings( $user_settings );
 	}
-
 }

--- a/includes/create-theme/theme-fonts.php
+++ b/includes/create-theme/theme-fonts.php
@@ -164,11 +164,11 @@ class CBT_Theme_Fonts {
 
 	}
 
-	private function remove_deactivated_font_assets( $font_families_to_not_remove, $theme_font_families ) {
+	private static function remove_deactivated_font_assets( $font_families_to_not_remove, $theme_font_families ) {
 		/* Bail if there are no theme font families, which can happen
 		 * if the theme.json file, missing, or if the theme is a child theme, in
 		 * which case the font families are inherited from the parent theme.
-		 */
+			*/
 		if ( null !== $theme_font_families ) {
 			return;
 		}

--- a/includes/create-theme/theme-fonts.php
+++ b/includes/create-theme/theme-fonts.php
@@ -164,28 +164,26 @@ class CBT_Theme_Fonts {
 
 	}
 
-	public static function remove_deactivated_fonts_from_theme() {
-
-		$user_settings = CBT_Theme_JSON_Resolver::get_user_data()->get_settings();
-		$theme_json    = CBT_Theme_JSON_Resolver::get_theme_file_contents();
-
-		// If there are no deactivated theme fonts, bounce out
-		if ( ! isset( $user_settings['typography']['fontFamilies']['theme'] ) ) {
+	private function remove_deactivated_font_assets( $font_families_to_not_remove, $theme_font_families ) {
+		/* Bail if there are no theme font families, which can happen
+		 * if the theme.json file, missing, or if the theme is a child theme, in
+		 * which case the font families are inherited from the parent theme.
+		 */
+		if ( null !== $theme_font_families ) {
 			return;
 		}
-
-		$font_families_to_not_remove = $user_settings['typography']['fontFamilies']['theme'];
 
 		// Remove font assets from theme
 		$theme_font_asset_location = get_stylesheet_directory() . '/assets/fonts/';
 		$font_families_to_remove   = array_values(
 			array_filter(
-				$theme_json['settings']['typography']['fontFamilies'],
+				$theme_font_families,
 				function( $theme_font_family ) use ( $font_families_to_not_remove ) {
 					return ! in_array( $theme_font_family['slug'], array_column( $font_families_to_not_remove, 'slug' ), true );
 				}
 			)
 		);
+
 		foreach ( $font_families_to_remove as $font_family ) {
 			if ( isset( $font_family['fontFace'] ) ) {
 				foreach ( $font_family['fontFace'] as $font_face ) {
@@ -203,16 +201,39 @@ class CBT_Theme_Fonts {
 				}
 			}
 		}
+	}
 
-		// Remove user fonts from theme
-		$theme_json['settings']['typography']['fontFamilies'] = array_values(
-			array_filter(
-				$theme_json['settings']['typography']['fontFamilies'],
-				function( $theme_font_family ) use ( $font_families_to_not_remove ) {
-					return in_array( $theme_font_family['slug'], array_column( $font_families_to_not_remove, 'slug' ), true );
-				}
-			)
-		);
+	/**
+	 * Remove any deactivated fonts from the theme configuration.
+	 * This includes removing the font face assets from the theme,
+	 * but does not remove the font face assets from the user configuration.
+	 */
+	public static function remove_deactivated_fonts_from_theme() {
+
+		$user_settings = CBT_Theme_JSON_Resolver::get_user_data()->get_settings();
+		$theme_json    = CBT_Theme_JSON_Resolver::get_theme_file_contents();
+
+		// If there are no deactivated theme fonts, bounce out
+		if ( ! isset( $user_settings['typography']['fontFamilies']['theme'] ) ) {
+			return;
+		}
+
+		$font_families_to_not_remove = $user_settings['typography']['fontFamilies']['theme'];
+
+		$theme_font_families = isset( $theme_json['settings']['typography']['fontFamilies'] ) ? $theme_json['settings']['typography']['fontFamilies'] : null;
+		$did_remove_assets   = static::remove_deactivated_font_assets( $font_families_to_not_remove, $theme_font_families );
+
+		if ( null !== $theme_font_families ) {
+			$theme_json['settings']['typography']['fontFamilies'] = array_values(
+				array_filter(
+					$theme_font_families,
+					function( $theme_font_family ) use ( $font_families_to_not_remove ) {
+						return in_array( $theme_font_family['slug'], array_column( $font_families_to_not_remove, 'slug' ), true );
+					}
+				)
+			);
+		}
+
 		CBT_Theme_JSON_Resolver::write_theme_file_contents( $theme_json );
 
 		// Remove user preferences for theme font activation

--- a/includes/create-theme/theme-fonts.php
+++ b/includes/create-theme/theme-fonts.php
@@ -169,7 +169,7 @@ class CBT_Theme_Fonts {
 		 * if the theme.json file, missing, or if the theme is a child theme, in
 		 * which case the font families are inherited from the parent theme.
 			*/
-		if ( null !== $theme_font_families ) {
+		if ( null === $theme_font_families ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/create-block-theme/issues/659

## What?
This PR implements a check to verify the presence of theme fonts before attempting to remove them. Additionally, it restructures the handling of deactivated font removal to ensure safety when theme fonts are not present.

## Why?
This PR addresses a critical error that occurs when saving changes to a theme after modifying font settings in a child theme, as detailed in GitHub issue #659. The issue resulted from an unhandled scenario where `array_filter()` was being called on a `null` value, leading to a fatal error.

## How?
The main changes include:
- Adding a check to ensure that theme font families are present before attempting their removal.
- Splitting the deactivation and asset removal process into separate functions for better clarity and error handling.
- Adjusting the logic to bail out early if theme font families are not defined, to prevent errors when `array_filter` operates on `null`.

## Testing Instructions
1. Create a child theme from TT4.
3. Click the "Save Changes to Theme" button.
4. Verify that no errors occur, and the changes are saved successfully.