### PR TITLE
Refactor theme fonts class for readability

### DIFF
--- a/includes/create-theme/theme-fonts.php
+++ b/includes/create-theme/theme-fonts.php
@@ -85,8 +85,7 @@ class CBT_Theme_Fonts {
 	}
 
 	public static function copy_activated_fonts_to_theme() {
-		$user_settings         = CBT_Theme_JSON_Resolver::get_user_data()->get_settings();
-		$font_families_to_copy = $user_settings['typography']['fontFamilies']['custom'] ?? null;
+		$font_families_to_copy = self::get_user_activated_fonts();
 
 		if ( is_null( $font_families_to_copy ) ) {
 			return;

--- a/includes/create-theme/theme-fonts.php
+++ b/includes/create-theme/theme-fonts.php
@@ -129,6 +129,7 @@ class CBT_Theme_Fonts {
 			$font_families_to_copy
 		);
 
+		$user_settings = CBT_Theme_JSON_Resolver::get_user_data()->get_settings();
 		unset( $user_settings['typography']['fontFamilies']['custom'] );
 		if ( empty( $user_settings['typography']['fontFamilies'] ) ) {
 			unset( $user_settings['typography']['fontFamilies'] );

--- a/includes/create-theme/theme-fonts.php
+++ b/includes/create-theme/theme-fonts.php
@@ -107,9 +107,7 @@ class CBT_Theme_Fonts {
 			foreach ( $font_family['fontFace'] as &$font_face ) {
 				// src can be a string or an array
 				// if it is a string, cast it to an array
-				if ( ! is_array( $font_face['src'] ) ) {
-					$font_face['src'] = array( $font_face['src'] );
-				}
+				$font_face['src'] = (array) $font_face['src'];
 				foreach ( $font_face['src'] as $font_src_index => &$font_src ) {
 					$font_filename = basename( $font_src );
 					$font_dir      = wp_get_font_dir();

--- a/tests/test-theme-fonts.php
+++ b/tests/test-theme-fonts.php
@@ -129,7 +129,8 @@ class Test_Create_Block_Theme_Fonts extends WP_UnitTestCase {
 
 		// ensure that the font was added to the theme settings and removed in user settings and therefore missing in merged settings
 		$this->assertCount( 2, $theme_data_before['typography']['fontFamilies']['theme'] );
-		$this->assertequals( 'open-sans', $theme_data_before['typography']['fontFamilies']['theme'][0]['slug'] );
+		$this->assertEquals( 'open-sans', $theme_data_before['typography']['fontFamilies']['theme'][0]['slug'] );
+		$this->assertEquals( 'deactivated-font', $theme_data_before['typography']['fontFamilies']['theme'][1]['slug'] );
 		$this->assertCount( 1, $user_data_before['typography']['fontFamilies']['theme'] );
 		$this->assertCount( 1, $merged_data_before['typography']['fontFamilies']['theme'] );
 

--- a/tests/test-theme-fonts.php
+++ b/tests/test-theme-fonts.php
@@ -22,7 +22,6 @@ class Test_Create_Block_Theme_Fonts extends WP_UnitTestCase {
 		);
 	}
 
-
 	public function test_copy_activated_fonts_to_theme() {
 
 		wp_set_current_user( self::$admin_id );
@@ -214,6 +213,117 @@ class Test_Create_Block_Theme_Fonts extends WP_UnitTestCase {
 
 	}
 
+	public function test_non_array_font_src() {
+		wp_set_current_user( self::$admin_id );
+
+		$test_theme_slug = $this->create_blank_theme();
+
+		// Create a theme with a non-array font src
+		$theme_json = CBT_Theme_JSON_Resolver::get_theme_file_contents();
+		$theme_json['settings']['typography']['fontFamilies'] = array(
+			array(
+				'slug'       => 'single-src-font',
+				'name'       => 'Single Src Font',
+				'fontFamily' => 'Single Src Font',
+				'fontFace'   => array(
+					array(
+						'fontFamily' => 'Single Src Font',
+						'fontStyle'  => 'normal',
+						'fontWeight' => '400',
+						'src'        => 'file:./assets/fonts/single-src-font.ttf',
+					),
+				),
+			),
+		);
+		CBT_Theme_JSON_Resolver::write_theme_file_contents( $theme_json );
+
+		// Attempt to get all fonts
+		$fonts = CBT_Theme_Fonts::get_all_fonts();
+
+		// Verify that the src is correctly handled
+		$this->assertCount( 1, $fonts );
+		$this->assertEquals( 'single-src-font', $fonts[0]['slug'] );
+		$this->assertEquals( get_stylesheet_directory_uri() . '/assets/fonts/single-src-font.ttf', $fonts[0]['fontFace'][0]['src'] );
+
+		$this->uninstall_theme( $test_theme_slug );
+	}
+
+	public function test_array_font_src() {
+		wp_set_current_user( self::$admin_id );
+
+		$test_theme_slug = $this->create_blank_theme();
+
+		// Create a theme with an array font src
+		$theme_json = CBT_Theme_JSON_Resolver::get_theme_file_contents();
+		$theme_json['settings']['typography']['fontFamilies'] = array(
+			array(
+				'slug'       => 'array-src-font',
+				'name'       => 'Array Src Font',
+				'fontFamily' => 'Array Src Font',
+				'fontFace'   => array(
+					array(
+						'fontFamily' => 'Array Src Font',
+						'fontStyle'  => 'normal',
+						'fontWeight' => '400',
+						'src'        => array(
+							'file:./assets/fonts/array-src-font.ttf',
+							'file:./assets/fonts/array-src-font-bold.ttf',
+						),
+					),
+				),
+			),
+		);
+		CBT_Theme_JSON_Resolver::write_theme_file_contents( $theme_json );
+
+		// Attempt to get all fonts
+		$fonts = CBT_Theme_Fonts::get_all_fonts();
+
+		// Verify that the src is correctly handled
+		$this->assertCount( 1, $fonts );
+		$this->assertEquals( 'array-src-font', $fonts[0]['slug'] );
+		$this->assertIsArray( $fonts[0]['fontFace'][0]['src'] );
+		$this->assertCount( 2, $fonts[0]['fontFace'][0]['src'] );
+		$this->assertEquals( get_stylesheet_directory_uri() . '/assets/fonts/array-src-font.ttf', $fonts[0]['fontFace'][0]['src'][0] );
+		$this->assertEquals( get_stylesheet_directory_uri() . '/assets/fonts/array-src-font-bold.ttf', $fonts[0]['fontFace'][0]['src'][1] );
+
+		$this->uninstall_theme( $test_theme_slug );
+	}
+
+	public function test_absolute_url_handling() {
+		wp_set_current_user( self::$admin_id );
+
+		$test_theme_slug = $this->create_blank_theme();
+
+		// Create a theme with an absolute URL
+		$theme_json = CBT_Theme_JSON_Resolver::get_theme_file_contents();
+		$theme_json['settings']['typography']['fontFamilies'] = array(
+			array(
+				'slug'       => 'absolute-url-font',
+				'name'       => 'Absolute URL Font',
+				'fontFamily' => 'Absolute URL Font',
+				'fontFace'   => array(
+					array(
+						'fontFamily' => 'Absolute URL Font',
+						'fontStyle'  => 'normal',
+						'fontWeight' => '400',
+						'src'        => 'http://example.com/fonts/absolute-url-font.ttf',
+					),
+				),
+			),
+		);
+		CBT_Theme_JSON_Resolver::write_theme_file_contents( $theme_json );
+
+		// Attempt to get all fonts
+		$fonts = CBT_Theme_Fonts::get_all_fonts();
+
+		// Verify that the absolute URL remains unchanged
+		$this->assertCount( 1, $fonts );
+		$this->assertEquals( 'absolute-url-font', $fonts[0]['slug'] );
+		$this->assertEquals( 'http://example.com/fonts/absolute-url-font.ttf', $fonts[0]['fontFace'][0]['src'] );
+
+		$this->uninstall_theme( $test_theme_slug );
+	}
+
 	private function save_theme() {
 		CBT_Theme_Fonts::persist_font_settings();
 	}
@@ -324,5 +434,5 @@ class Test_Create_Block_Theme_Fonts extends WP_UnitTestCase {
 		CBT_Theme_JSON_Resolver::write_user_settings( $settings );
 	}
 
-
 }
+


### PR DESCRIPTION
## What?
This Pull Request refactors the them fonts class to improve code readability and maintainability. The main focus is on cleaning up the code.

I felt inclined to do this because when debugging for https://github.com/WordPress/create-block-theme/pull/660, I found some parts of the code hard to follow.

## Why?
This PR addresses the need to make the code more readable and maintainable by:
1. Adding documentation and comments.
2. Simplifying functions and improving their readability.

## How?
### Key Changes:
1. **Class documentation added**: Added descriptions and the purpose of the `CBT_Theme_Fonts` class.

2. **Function improvements**:
   - *Inline Descriptions/Justifications*:
     - Refactored `make_theme_font_src_absolute()` to use `array_map` for cleaner array handling.
     - Replaced double newlines and improved spacing for better readability.
   - Changed `foreach` to `array_map`: This reduces the complexity and makes the handling of arrays cleaner.

3. **Code clean-up**:
   - Removed some redundant comments in favor of "self documenting" practices.
   - Used shorthand assignment (`?? null`) for checking array keys.
   - Introduced variables for commonly used expressions.

4. **Function calls**:
   - Replaced `CBT_Theme_Fonts::` with `self::` for static method calls within the class, enhancing readability and context awareness.

5. **Added test cases** for parts of the code that could break on further refactors.
