### PR TITLE
Add image credits edit capabilities to the edit theme modal

### DIFF
--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -557,6 +557,7 @@ class CBT_Theme_API {
 		$sanitized_theme['screenshot']          = sanitize_text_field( $theme['screenshot'] ?? '' );
 		$sanitized_theme['recommended_plugins'] = sanitize_textarea_field( $theme['recommended_plugins'] ?? '' );
 		$sanitized_theme['font_credits']        = sanitize_textarea_field( $theme['font_credits'] ?? '' );
+		$sanitized_theme['image_credits']       = sanitize_textarea_field( $theme['image_credits'] ?? '' );
 		$sanitized_theme['template']            = '';
 		$sanitized_theme['slug']                = sanitize_title( $theme['name'] );
 		$sanitized_theme['text_domain']         = $sanitized_theme['slug'];

--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -50,6 +50,7 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 		tags_custom: '',
 		recommended_plugins: '',
 		font_credits: '',
+		image_credits: '',
 		subfolder: '',
 	} );
 
@@ -70,6 +71,7 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 			screenshot: themeData.screenshot,
 			recommended_plugins: readmeData.recommended_plugins,
 			font_credits: readmeData.fonts,
+			image_credits: readmeData.images,
 			subfolder:
 				themeData.stylesheet.lastIndexOf( '/' ) > 1
 					? themeData.stylesheet.substring(
@@ -288,6 +290,33 @@ ${ __( 'Source', 'create-block-theme' ) }` }
 					value={ theme.font_credits }
 					onChange={ ( value ) =>
 						setTheme( { ...theme, font_credits: value } )
+					}
+				/>
+
+				<TextareaControl
+					label={ __( 'Image Credits', 'create-block-theme' ) }
+					help={
+						<>
+							{ __(
+								'Credits for the images bundled with the theme.',
+								'create-block-theme'
+							) }
+							<br />
+							<ExternalLink href="hhttps://make.wordpress.org/themes/handbook/review/required/#1-licensing-copyright">
+								{ __( 'Read more.', 'create-block-theme' ) }
+							</ExternalLink>
+						</>
+					}
+					// eslint-disable-next-line @wordpress/i18n-no-collapsible-whitespace
+					placeholder={ __(
+						`Image filename
+Image source URL
+Image license`,
+						'create-block-theme'
+					) }
+					value={ theme.image_credits }
+					onChange={ ( value ) =>
+						setTheme( { ...theme, image_credits: value } )
 					}
 				/>
 

--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -302,7 +302,12 @@ ${ __( 'Source', 'create-block-theme' ) }` }
 								'create-block-theme'
 							) }
 							<br />
-							<ExternalLink href="hhttps://make.wordpress.org/themes/handbook/review/required/#1-licensing-copyright">
+							<ExternalLink
+								href={ __(
+									'https://make.wordpress.org/themes/handbook/review/required/#1-licensing-copyright',
+									'create-block-theme'
+								) }
+							>
 								{ __( 'Read more.', 'create-block-theme' ) }
 							</ExternalLink>
 						</>

--- a/tests/CbtThemeReadme/create.php
+++ b/tests/CbtThemeReadme/create.php
@@ -29,13 +29,15 @@ class CBT_ThemeReadme_Create extends CBT_Theme_Readme_UnitTestCase {
 		$expected_php_version         = 'Requires PHP: ' . $data['required_php_version'];
 		$expected_license             = 'License: ' . $data['license'];
 		$expected_license_uri         = 'License URI: ' . $data['license_uri'];
-		$expected_image_credits       = '== Images ==' . $data['image_credits'];
+		$expected_font_credits        = '== Fonts ==' .
+			( isset( $data['font_credits'] ) ? $data['font_credits'] : '' );
+		$expected_image_credits       = '== Images ==' .
+			( isset( $data['image_credits'] ) ? $data['image_credits'] : '' );
 		$expected_recommended_plugins = '== Recommended Plugins ==' . $data['recommended_plugins'];
 
 		$this->assertStringContainsString( $expected_name, $readme_without_newlines, 'The expected name is missing.' );
 		$this->assertStringContainsString( $expected_author, $readme_without_newlines, 'The expected author is missing.' );
 		$this->assertStringContainsString( $expected_wp_version, $readme_without_newlines, 'The expected WP version is missing.' );
-		$this->assertStringContainsString( $expected_image_credits, $readme_without_newlines, 'The expected image credits are missing.' );
 		$this->assertStringContainsString( $expected_recommended_plugins, $readme_without_newlines, 'The expected recommended plugins are missing.' );
 
 		// Assetion specific to child themes.
@@ -58,8 +60,17 @@ class CBT_ThemeReadme_Create extends CBT_Theme_Readme_UnitTestCase {
 
 		// Assertion specific to font credits.
 		if ( isset( $data['font_credits'] ) ) {
-			$expected_font_credits = '== Fonts ==' . $data['font_credits'];
 			$this->assertStringContainsString( $expected_font_credits, $readme_without_newlines, 'The expected font credits are missing.' );
+		} else {
+			$this->assertStringNotContainsString( $expected_font_credits, $readme_without_newlines, 'The font credits title should not be present if font credits were not defined.' );
+		}
+
+		// Assertion specific to imagee credits.
+		if ( isset( $data['image_credits'] ) ) {
+			$this->assertStringContainsString( $expected_image_credits, $readme_without_newlines, 'The expected image credits are missing.' );
+		} else {
+			$this->assertStringNotContainsString( $expected_image_credits, $readme_without_newlines, 'The image credits title should not be present if image_credits were not defined.' );
+
 		}
 	}
 
@@ -130,8 +141,24 @@ class CBT_ThemeReadme_Create extends CBT_Theme_Readme_UnitTestCase {
 					'required_php_version' => '10.0',
 					'license'              => 'GPLv2 or later',
 					'license_uri'          => 'https://www.gnu.org/licenses/gpl-2.0.html',
-					'image_credits'        => 'The images were taken from https://example.org and have a CC0 license.',
 					'recommended_plugins'  => 'The theme is best used with the following plugins: Plugin 1, Plugin 2, Plugin 3.',
+					'image_credits'        => 'The images were taken from https://example.org and have a CC0 license.',
+				),
+			),
+			'missing image credits'            => array(
+				'data' => array(
+					'name'                 => 'My Theme',
+					'description'          => 'New theme description',
+					'uri'                  => 'https://example.com',
+					'author'               => 'New theme author',
+					'author_uri'           => 'https://example.com/author',
+					'copyright_year'       => '2077',
+					'wp_version'           => '12.12',
+					'required_php_version' => '10.0',
+					'license'              => 'GPLv2 or later',
+					'license_uri'          => 'https://www.gnu.org/licenses/gpl-2.0.html',
+					'recommended_plugins'  => 'The theme is best used with the following plugins: Plugin 1, Plugin 2, Plugin 3.',
+					'font_credits'         => 'Font credit example text',
 				),
 			),
 			// TODO: Add more test cases.


### PR DESCRIPTION
## What?
Add image credits edit capabilities to the edit theme modal.
Fixes: https://github.com/WordPress/create-block-theme/issues/615

## Why?
To enable theme creators to edit image credits using the UI.

## Screencast
[Screencast from 31-05-24 15:13:35.webm](https://github.com/WordPress/create-block-theme/assets/1310626/7d35dc3b-09d8-4b99-b5ef-d403df9e465c)
