### PR TITLE
Make external links translatable

### DIFF
--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -224,7 +224,10 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 					} }
 				>
 					<ExternalLink
-						href="https://make.wordpress.org/themes/handbook/review/required/theme-tags/"
+						href={ __(
+							'https://make.wordpress.org/themes/handbook/review/required/theme-tags/',
+							'create-block-theme'
+						) }
 						style={ { fontSize: '12px' } }
 					>
 						{ __( 'Read more.', 'create-block-theme' ) }
@@ -239,7 +242,12 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 								'create-block-theme'
 							) }
 							<br />
-							<ExternalLink href="https://make.wordpress.org/themes/handbook/review/required/#6-plugins">
+							<ExternalLink
+								href={ __(
+									'https://make.wordpress.org/themes/handbook/review/required/#6-plugins',
+									'create-block-theme'
+								) }
+							>
 								{ __( 'Read more.', 'create-block-theme' ) }
 							</ExternalLink>
 						</>
@@ -276,7 +284,12 @@ Plugin Description`,
 								'create-block-theme'
 							) }
 							<br />
-							<ExternalLink href="https://make.wordpress.org/themes/handbook/review/required/#1-licensing-copyright">
+							<ExternalLink
+								href={ __(
+									'https://make.wordpress.org/themes/handbook/review/required/#1-licensing-copyright',
+									'create-block-theme'
+								) }
+							>
 								{ __( 'Read more.', 'create-block-theme' ) }
 							</ExternalLink>
 						</>

--- a/src/landing-page/landing-page.js
+++ b/src/landing-page/landing-page.js
@@ -177,7 +177,12 @@ export default function LandingPage() {
 							),
 							{
 								ExternalLink: (
-									<ExternalLink href="https://wordpress.org/support/plugin/create-block-theme/" />
+									<ExternalLink
+										href={ __(
+											'https://wordpress.org/support/plugin/create-block-theme/',
+											'create-block-theme'
+										) }
+									/>
 								),
 							}
 						) }


### PR DESCRIPTION
This PR applies a translation function to some external links, since they may be locale-specific.

However, the following links remain unchanged:

---

https://github.com/WordPress/create-block-theme/blob/eabd38201d6a7cbb1631be4cf9eae820fe838028/src/landing-page/landing-page.js#L193
https://github.com/WordPress/create-block-theme/blob/eabd38201d6a7cbb1631be4cf9eae820fe838028/src/landing-page/landing-page.js#L206

GitHub URLs are the same regardless of locale.

---

https://github.com/WordPress/create-block-theme/blob/eabd38201d6a7cbb1631be4cf9eae820fe838028/assets/boilerplate/parts/footer.html#L6

Currently it is not possible to make strings in HTML templates translatable. See the following core ticket for more information: https://core.trac.wordpress.org/ticket/60298