### PR TITLE
Update escaping function

### DIFF
--- a/includes/create-theme/theme-locale.php
+++ b/includes/create-theme/theme-locale.php
@@ -17,12 +17,16 @@ class CBT_Theme_Locale {
 		}
 
 		// Check if the text is already escaped.
-		if ( str_starts_with( $string, '<?php echo' ) ) {
+		if (
+			str_starts_with( $string, '<?php echo' ) ||
+			str_starts_with( $string, '<?php esc_html_e' ) ||
+			str_starts_with( $string, '<?php esc_html' )
+		) {
 			return $string;
 		}
 
 		$string = addcslashes( $string, "'" );
-		return "<?php echo __('" . $string . "', '" . wp_get_theme()->get( 'TextDomain' ) . "');?>";
+		return "<?php esc_html_e('" . $string . "', '" . wp_get_theme()->get( 'TextDomain' ) . "');?>";
 	}
 
 	/**

--- a/includes/create-theme/theme-locale.php
+++ b/includes/create-theme/theme-locale.php
@@ -17,11 +17,7 @@ class CBT_Theme_Locale {
 		}
 
 		// Check if the text is already escaped.
-		if (
-			str_starts_with( $string, '<?php echo' ) ||
-			str_starts_with( $string, '<?php esc_html_e' ) ||
-			str_starts_with( $string, '<?php esc_html' )
-		) {
+		if ( str_starts_with( $string, '<?php' ) ) {
 			return $string;
 		}
 

--- a/tests/CbtThemeLocale/escapeString.php
+++ b/tests/CbtThemeLocale/escapeString.php
@@ -13,29 +13,29 @@ class CBT_Theme_Locale_EscapeString extends CBT_Theme_Locale_UnitTestCase {
 	public function test_escape_string() {
 		$string         = 'This is a test text.';
 		$escaped_string = CBT_Theme_Locale::escape_string( $string );
-		$this->assertEquals( "<?php echo __('This is a test text.', 'test-locale-theme');?>", $escaped_string );
+		$this->assertEquals( "<?php esc_html_e('This is a test text.', 'test-locale-theme');?>", $escaped_string );
 	}
 
 	public function test_escape_string_with_single_quote() {
 		$string         = "This is a test text with a single quote '";
 		$escaped_string = CBT_Theme_Locale::escape_string( $string );
-		$this->assertEquals( "<?php echo __('This is a test text with a single quote \\'', 'test-locale-theme');?>", $escaped_string );
+		$this->assertEquals( "<?php esc_html_e('This is a test text with a single quote \\'', 'test-locale-theme');?>", $escaped_string );
 	}
 
 	public function test_escape_string_with_double_quote() {
 		$string         = 'This is a test text with a double quote "';
 		$escaped_string = CBT_Theme_Locale::escape_string( $string );
-		$this->assertEquals( "<?php echo __('This is a test text with a double quote \"', 'test-locale-theme');?>", $escaped_string );
+		$this->assertEquals( "<?php esc_html_e('This is a test text with a double quote \"', 'test-locale-theme');?>", $escaped_string );
 	}
 
 	public function test_escape_string_with_html() {
 		$string         = '<p>This is a test text with HTML.</p>';
 		$escaped_string = CBT_Theme_Locale::escape_string( $string );
-		$this->assertEquals( "<?php echo __('<p>This is a test text with HTML.</p>', 'test-locale-theme');?>", $escaped_string );
+		$this->assertEquals( "<?php esc_html_e('<p>This is a test text with HTML.</p>', 'test-locale-theme');?>", $escaped_string );
 	}
 
 	public function test_escape_string_with_already_escaped_string() {
-		$string         = "<?php echo __('This is a test text.', 'test-locale-theme');?>";
+		$string         = "<?php esc_html_e('This is a test text.', 'test-locale-theme');?>";
 		$escaped_string = CBT_Theme_Locale::escape_string( $string );
 		$this->assertEquals( $string, $escaped_string );
 	}

--- a/tests/CbtThemeLocale/escapeTextContentOfBlocks.php
+++ b/tests/CbtThemeLocale/escapeTextContentOfBlocks.php
@@ -30,7 +30,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
 
 			'paragraph'                  => array(
 				'block_markup'    => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center">This is a test text.</p><!-- /wp:paragraph -->',
-				'expected_markup' => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><?php echo __(\'This is a test text.\', \'test-locale-theme\');?></p><!-- /wp:paragraph -->',
+				'expected_markup' => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><?php esc_html_e(\'This is a test text.\', \'test-locale-theme\');?></p><!-- /wp:paragraph -->',
 			),
 
 			'paragraph on nested groups' => array(
@@ -46,7 +46,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
 					'<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"","wideSize":""}} -->
                     <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"constrained","contentSize":"565px"}} -->
                     <div class="wp-block-group"><!-- wp:paragraph {"align":"center"} -->
-                    <p class="has-text-align-center"><?php echo __(\'This is a test text.\', \'test-locale-theme\');?></p>
+                    <p class="has-text-align-center"><?php esc_html_e(\'This is a test text.\', \'test-locale-theme\');?></p>
                     <!-- /wp:paragraph --></div>
                     <!-- /wp:group --></div>
                     <!-- /wp:group -->',
@@ -59,7 +59,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:heading -->',
 				'expected_markup' =>
 					'<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
-                    <h1 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo __(\'A passion for creating spaces\', \'test-locale-theme\');?></h1>
+                    <h1 class="wp-block-heading has-text-align-center is-style-asterisk"><?php esc_html_e(\'A passion for creating spaces\', \'test-locale-theme\');?></h1>
                     <!-- /wp:heading -->',
 			),
 
@@ -70,7 +70,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:heading -->',
 				'expected_markup' =>
 					'<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
-                    <h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo __(\'A passion for creating spaces\', \'test-locale-theme\');?></h2>
+                    <h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php esc_html_e(\'A passion for creating spaces\', \'test-locale-theme\');?></h2>
                     <!-- /wp:heading -->',
 			),
 
@@ -90,13 +90,13 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
 				'expected_markup' =>
 					'<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
                     <ul style="line-height:1.75" class="is-style-checkmark-list"><!-- wp:list-item -->
-                    <li><?php echo __(\'Collaborate with fellow architects.\', \'test-locale-theme\');?></li>
+                    <li><?php esc_html_e(\'Collaborate with fellow architects.\', \'test-locale-theme\');?></li>
                     <!-- /wp:list-item -->
                     <!-- wp:list-item -->
-                    <li><?php echo __(\'Showcase your projects.\', \'test-locale-theme\');?></li>
+                    <li><?php esc_html_e(\'Showcase your projects.\', \'test-locale-theme\');?></li>
                     <!-- /wp:list-item -->
                     <!-- wp:list-item -->
-                    <li><?php echo __(\'Experience the world of architecture.\', \'test-locale-theme\');?></li>
+                    <li><?php esc_html_e(\'Experience the world of architecture.\', \'test-locale-theme\');?></li>
                     <!-- /wp:list-item --></ul>
                     <!-- /wp:list -->',
 			),
@@ -108,7 +108,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:verse -->',
 				'expected_markup' =>
 					'<!-- wp:verse {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
-                    <pre class="wp-block-verse"><?php echo __(\'Ya somos el olvido que seremos.<br>El polvo elemental que nos ignora<br>y que fue el rojo Adán y que es ahora<br>todos los hombres, y que no veremos.\', \'test-locale-theme\');?></pre>
+                    <pre class="wp-block-verse"><?php esc_html_e(\'Ya somos el olvido que seremos.<br>El polvo elemental que nos ignora<br>y que fue el rojo Adán y que es ahora<br>todos los hombres, y que no veremos.\', \'test-locale-theme\');?></pre>
                     <!-- /wp:verse -->',
 			),
 
@@ -119,7 +119,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:button -->',
 				'expected_markup' =>
 					'<!-- wp:button -->
-                    <div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo __(\'Sign up\', \'test-locale-theme\');?></a></div>
+                    <div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php esc_html_e(\'Sign up\', \'test-locale-theme\');?></a></div>
                     <!-- /wp:button -->',
 			),
 
@@ -130,7 +130,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:image -->',
 				'expected_markup' =>
 					'<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
-                    <figure class="wp-block-image size-large is-style-rounded"><img src="http://localhost/wp1/wp-content/themes/twentytwentyfour/assets/images/windows.webp" alt="<?php echo __(\'Windows of a building in Nuremberg, Germany\', \'test-locale-theme\');?>"/></figure>
+                    <figure class="wp-block-image size-large is-style-rounded"><img src="http://localhost/wp1/wp-content/themes/twentytwentyfour/assets/images/windows.webp" alt="<?php esc_html_e(\'Windows of a building in Nuremberg, Germany\', \'test-locale-theme\');?>"/></figure>
                     <!-- /wp:image -->',
 			),
 
@@ -143,8 +143,8 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:cover -->',
 				'expected_markup' =>
 					'<!-- wp:cover {"url":"http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg","id":39,"alt":"Alternative text for cover image","dimRatio":50,"customOverlayColor":"#1d2b2f","layout":{"type":"constrained"}} -->
-                    <div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#1d2b2f"></span><img class="wp-block-cover__image-background wp-image-39" alt="<?php echo __(\'Alternative text for cover image\', \'test-locale-theme\');?>" src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
-                    <p class="has-text-align-center has-large-font-size"><?php echo __(\'This is a cover caption\', \'test-locale-theme\');?></p>
+                    <div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#1d2b2f"></span><img class="wp-block-cover__image-background wp-image-39" alt="<?php esc_html_e(\'Alternative text for cover image\', \'test-locale-theme\');?>" src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+                    <p class="has-text-align-center has-large-font-size"><?php esc_html_e(\'This is a cover caption\', \'test-locale-theme\');?></p>
                     <!-- /wp:paragraph --></div></div>
                     <!-- /wp:cover -->',
 			),
@@ -158,8 +158,8 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:media-text -->',
 				'expected_markup' =>
 					'<!-- wp:media-text {"mediaId":39,"mediaLink":"http://localhost/wp1/image/","mediaType":"image"} -->
-                    <div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" alt="<?php echo __(\'This is alt text\', \'test-locale-theme\');?>" class="wp-image-39 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…"} -->
-                    <p><?php echo __(\'Media text content test.\', \'test-locale-theme\');?></p>
+                    <div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="http://localhost/wp1/wp-content/uploads/2024/05/image.jpeg" alt="<?php esc_html_e(\'This is alt text\', \'test-locale-theme\');?>" class="wp-image-39 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…"} -->
+                    <p><?php esc_html_e(\'Media text content test.\', \'test-locale-theme\');?></p>
                     <!-- /wp:paragraph --></div></div>
                     <!-- /wp:media-text -->',
 			),
@@ -171,7 +171,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:pullquote -->',
 				'expected_markup' =>
 					'<!-- wp:pullquote -->
-                    <figure class="wp-block-pullquote"><blockquote><p><?php echo __(\'Yo me equivoqué y pagué, pero la pelota no se mancha.\', \'test-locale-theme\');?></p><cite><?php echo __(\'Diego Armando Maradona\', \'test-locale-theme\');?></cite></blockquote></figure>
+                    <figure class="wp-block-pullquote"><blockquote><p><?php esc_html_e(\'Yo me equivoqué y pagué, pero la pelota no se mancha.\', \'test-locale-theme\');?></p><cite><?php esc_html_e(\'Diego Armando Maradona\', \'test-locale-theme\');?></cite></blockquote></figure>
                     <!-- /wp:pullquote -->',
 			),
 
@@ -182,7 +182,7 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:table -->',
 				'expected_markup' =>
 					'<!-- wp:table -->
-                    <figure class="wp-block-table"><table><tbody><tr><td><?php echo __(\'Team\', \'test-locale-theme\');?></td><td><?php echo __(\'Points\', \'test-locale-theme\');?></td></tr><tr><td><?php echo __(\'Boca\', \'test-locale-theme\');?></td><td><?php echo __(\'74\', \'test-locale-theme\');?></td></tr><tr><td><?php echo __(\'River\', \'test-locale-theme\');?></td><td><?php echo __(\'2\', \'test-locale-theme\');?></td></tr></tbody></table><figcaption class="wp-element-caption"><?php echo __(\'Score table\', \'test-locale-theme\');?></figcaption></figure>
+                    <figure class="wp-block-table"><table><tbody><tr><td><?php esc_html_e(\'Team\', \'test-locale-theme\');?></td><td><?php esc_html_e(\'Points\', \'test-locale-theme\');?></td></tr><tr><td><?php esc_html_e(\'Boca\', \'test-locale-theme\');?></td><td><?php esc_html_e(\'74\', \'test-locale-theme\');?></td></tr><tr><td><?php esc_html_e(\'River\', \'test-locale-theme\');?></td><td><?php esc_html_e(\'2\', \'test-locale-theme\');?></td></tr></tbody></table><figcaption class="wp-element-caption"><?php esc_html_e(\'Score table\', \'test-locale-theme\');?></figcaption></figure>
                     <!-- /wp:table -->',
 			),
 

--- a/tests/test-theme-templates.php
+++ b/tests/test-theme-templates.php
@@ -12,7 +12,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 		$template          = new stdClass();
 		$template->content = '<!-- wp:paragraph --><p>This is text to localize</p><!-- /wp:paragraph -->';
 		$new_template      = CBT_Theme_Templates::escape_text_in_template( $template );
-		$this->assertStringContainsString( "<p><?php echo __('This is text to localize', '');?></p>", $new_template->content );
+		$this->assertStringContainsString( "<p><?php esc_html_e('This is text to localize', '');?></p>", $new_template->content );
 		$this->assertStringNotContainsString( '<p>This is text to localize</p>', $new_template->content );
 	}
 
@@ -136,7 +136,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 		$escaped_template  = CBT_Theme_Templates::escape_text_in_template( $template );
 
 		/* That looks like a mess, but what it should look like for REAL is <?php echo esc_attr_e( '"This" is a \'test\'', '' ); ?> */
-		$this->assertStringContainsString( '<?php echo __(\'"This" is a \\\'test\\\'\', \'\');?>', $escaped_template->content );
+		$this->assertStringContainsString( '<?php esc_html_e(\'"This" is a \\\'test\\\'\', \'\');?>', $escaped_template->content );
 	}
 
 	public function test_properly_encode_lessthan_and_greaterthan() {
@@ -146,7 +146,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 		<!-- /wp:heading -->';
 		$escaped_template  = CBT_Theme_Templates::escape_text_in_template( $template );
 
-		$this->assertStringContainsString( '<?php echo __(\'&lt;This> is a &lt;test&gt;\', \'\');?>', $escaped_template->content );
+		$this->assertStringContainsString( '<?php esc_html_e(\'&lt;This> is a &lt;test&gt;\', \'\');?>', $escaped_template->content );
 	}
 
 	public function test_properly_encode_html_markup() {
@@ -156,7 +156,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 			<!-- /wp:paragraph -->';
 		$escaped_template  = CBT_Theme_Templates::escape_text_in_template( $template );
 
-		$this->assertStringContainsString( '<?php echo __(\'<strong>Bold</strong> text has feelings &lt;&gt; TOO\', \'\');?>', $escaped_template->content );
+		$this->assertStringContainsString( '<?php esc_html_e(\'<strong>Bold</strong> text has feelings &lt;&gt; TOO\', \'\');?>', $escaped_template->content );
 	}
 
 	public function test_localize_alt_text_from_image() {
@@ -167,7 +167,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 			<!-- /wp:image -->
 		';
 		$new_template      = CBT_Theme_Templates::escape_text_in_template( $template );
-		$this->assertStringContainsString( 'alt="<?php echo __(\'This is alt text\', \'\');?>"', $new_template->content );
+		$this->assertStringContainsString( 'alt="<?php esc_html_e(\'This is alt text\', \'\');?>"', $new_template->content );
 	}
 
 	public function test_localize_alt_text_from_cover() {
@@ -187,7 +187,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 		';
 		$new_template      = CBT_Theme_Templates::escape_text_in_template( $template );
 		// Check the markup attribute
-		$this->assertStringContainsString( 'alt="<?php echo __(\'This is alt text\', \'\');?>"', $new_template->content );
+		$this->assertStringContainsString( 'alt="<?php esc_html_e(\'This is alt text\', \'\');?>"', $new_template->content );
 	}
 
 	public function test_localize_quote() {
@@ -201,8 +201,8 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 			</blockquote>
 		<!-- /wp:quote -->';
 		$new_template      = CBT_Theme_Templates::escape_text_in_template( $template );
-		$this->assertStringContainsString( "<?php echo __('This is my Quote', '');?>", $new_template->content );
-		$this->assertStringContainsString( "<?php echo __('Citation too', '');?>", $new_template->content );
+		$this->assertStringContainsString( "<?php esc_html_e('This is my Quote', '');?>", $new_template->content );
+		$this->assertStringContainsString( "<?php esc_html_e('Citation too', '');?>", $new_template->content );
 	}
 
 	public function test_localize_pullquote() {
@@ -216,8 +216,8 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 			</figure>
 		<!-- /wp:pullquote -->';
 		$new_template      = CBT_Theme_Templates::escape_text_in_template( $template );
-		$this->assertStringContainsString( "<?php echo __('This is my Quote', '');?>", $new_template->content );
-		$this->assertStringContainsString( "<?php echo __('Citation too', '');?>", $new_template->content );
+		$this->assertStringContainsString( "<?php esc_html_e('This is my Quote', '');?>", $new_template->content );
+		$this->assertStringContainsString( "<?php esc_html_e('Citation too', '');?>", $new_template->content );
 	}
 
 	public function test_localize_list() {
@@ -234,7 +234,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 			</ul>
 		<!-- /wp:list -->';
 		$new_template      = CBT_Theme_Templates::escape_text_in_template( $template );
-		$this->assertStringContainsString( "<li><?php echo __('Item One', '');?></li>", $new_template->content );
+		$this->assertStringContainsString( "<li><?php esc_html_e('Item One', '');?></li>", $new_template->content );
 	}
 
 	public function test_localize_verse() {
@@ -243,7 +243,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 			<pre class="wp-block-verse">Here is some <strong>verse</strong> to localize</pre>
 		<!-- /wp:verse -->';
 		$new_template      = CBT_Theme_Templates::escape_text_in_template( $template );
-		$this->assertStringContainsString( "<?php echo __('Here is some <strong>verse</strong> to localize', '');?>", $new_template->content );
+		$this->assertStringContainsString( "<?php esc_html_e('Here is some <strong>verse</strong> to localize', '');?>", $new_template->content );
 	}
 
 	public function test_localize_table() {
@@ -274,10 +274,10 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 			</figure>
 		<!-- /wp:table -->';
 		$new_template      = CBT_Theme_Templates::escape_text_in_template( $template );
-		$this->assertStringContainsString( "<td><?php echo __('Apples', '');?></td>", $new_template->content );
-		$this->assertStringContainsString( "<?php echo __('Header One', '');?>", $new_template->content );
-		$this->assertStringContainsString( "<?php echo __('Footer One', '');?>", $new_template->content );
-		$this->assertStringContainsString( "<?php echo __('This is my caption', '');?>", $new_template->content );
+		$this->assertStringContainsString( "<td><?php esc_html_e('Apples', '');?></td>", $new_template->content );
+		$this->assertStringContainsString( "<?php esc_html_e('Header One', '');?>", $new_template->content );
+		$this->assertStringContainsString( "<?php esc_html_e('Footer One', '');?>", $new_template->content );
+		$this->assertStringContainsString( "<?php esc_html_e('This is my caption', '');?>", $new_template->content );
 	}
 
 	public function test_localize_media_text() {
@@ -295,8 +295,8 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 		</div>
 		<!-- /wp:media-text -->';
 		$new_template      = CBT_Theme_Templates::escape_text_in_template( $template );
-		$this->assertStringContainsString( "<?php echo __('Content to Localize', '');?>", $new_template->content );
-		$this->assertStringContainsString( "<?php echo __('Alt Text Is Here', '');?>", $new_template->content );
+		$this->assertStringContainsString( "<?php esc_html_e('Content to Localize', '');?>", $new_template->content );
+		$this->assertStringContainsString( "<?php esc_html_e('Alt Text Is Here', '');?>", $new_template->content );
 	}
 
 	public function test_localize_cover_block_children() {
@@ -314,7 +314,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 		';
 		$new_template      = CBT_Theme_Templates::escape_text_in_template( $template );
 
-		$this->assertStringContainsString( '<p><?php echo __(\'This is text to localize\', \'\');?></p>', $new_template->content );
+		$this->assertStringContainsString( '<p><?php esc_html_e(\'This is text to localize\', \'\');?></p>', $new_template->content );
 	}
 
 	public function test_localize_nested_cover_block_children() {


### PR DESCRIPTION
## What?
Replace a simple translate function call with an escaping and translating function when escaping is missing.

## Why?
Fixes: https://github.com/WordPress/create-block-theme/issues/590
