### PR TITLE
Add an about section in the editor

### DIFF
--- a/src/editor-sidebar/about.js
+++ b/src/editor-sidebar/about.js
@@ -7,6 +7,8 @@ import {
 	__experimentalVStack as VStack,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalText as Text,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalDivider as Divider,
 	PanelBody,
 	ExternalLink,
 } from '@wordpress/components';
@@ -37,7 +39,7 @@ function AboutPlugin() {
 					) }
 				</Text>
 
-				<hr />
+				<Divider />
 
 				<Text weight="bold">
 					{ __( 'Help', 'create-block-theme' ) }

--- a/src/editor-sidebar/about.js
+++ b/src/editor-sidebar/about.js
@@ -1,0 +1,86 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text,
+	PanelBody,
+	ExternalLink,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import ScreenHeader from './screen-header';
+
+function AboutPlugin() {
+	return (
+		<PanelBody>
+			<ScreenHeader
+				title={ __( 'About the plugin', 'create-block-theme' ) }
+			/>
+			<VStack>
+				<Text>
+					{ __(
+						'Create Block Theme is a tool to help you make Block Themes using the WordPress Editor. It does this by adding tools to the Editor to help you create and manage your theme.',
+						'create-block-theme'
+					) }
+				</Text>
+
+				<Text>
+					{ __(
+						"Themes created with Create Block Theme don't require Create Block Theme to be installed on the site where the theme is used.",
+						'create-block-theme'
+					) }
+				</Text>
+
+				<hr />
+
+				<Text weight="bold">
+					{ __( 'Help', 'create-block-theme' ) }
+				</Text>
+
+				<Text>
+					<>
+						{ __( 'Have a question?', 'create-block-theme' ) }
+						<br />
+						<ExternalLink href="https://wordpress.org/support/plugin/create-block-theme/">
+							{ __( 'Ask in the forums.', 'create-block-theme' ) }
+						</ExternalLink>
+					</>
+				</Text>
+
+				<Text>
+					<>
+						{ __( 'Found a bug?', 'create-block-theme' ) }
+						<br />
+						<ExternalLink href="https://github.com/WordPress/create-block-theme/issues">
+							{ __(
+								'Report it on GitHub.',
+								'create-block-theme'
+							) }
+						</ExternalLink>
+					</>
+				</Text>
+
+				<Text>
+					<>
+						{ __( 'Want to contribute?', 'create-block-theme' ) }
+						<br />
+						<ExternalLink href="https://github.com/WordPress/create-block-theme">
+							{ __(
+								'Check out the project on GitHub.',
+								'create-block-theme'
+							) }
+						</ExternalLink>
+					</>
+				</Text>
+			</VStack>
+		</PanelBody>
+	);
+}
+
+export default AboutPlugin;

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -36,6 +36,7 @@ import {
 	chevronRight,
 	addCard,
 	blockMeta,
+	help,
 } from '@wordpress/icons';
 
 /**
@@ -50,6 +51,7 @@ import ScreenHeader from './editor-sidebar/screen-header';
 import { downloadExportedTheme } from './resolvers';
 import downloadFile from './utils/download-file';
 import './plugin-styles.scss';
+import AboutPlugin from './editor-sidebar/about';
 
 const CreateBlockThemePlugin = () => {
 	const [ isEditorOpen, setIsEditorOpen ] = useState( false );
@@ -183,6 +185,26 @@ const CreateBlockThemePlugin = () => {
 										<Icon icon={ chevronRight } />
 									</HStack>
 								</NavigatorButton>
+
+								<hr></hr>
+
+								<NavigatorButton
+									path="/about"
+									icon={ help }
+									className={
+										'create-block-theme__plugin-sidebar__about-button'
+									}
+								>
+									<Spacer />
+									<HStack>
+										<FlexItem>
+											{ __(
+												'Help',
+												'create-block-theme'
+											) }
+										</FlexItem>
+									</HStack>
+								</NavigatorButton>
 							</VStack>
 						</PanelBody>
 					</NavigatorScreen>
@@ -270,6 +292,10 @@ const CreateBlockThemePlugin = () => {
 
 					<NavigatorScreen path="/save">
 						<SaveThemePanel />
+					</NavigatorScreen>
+
+					<NavigatorScreen path="/about">
+						<AboutPlugin />
 					</NavigatorScreen>
 				</NavigatorProvider>
 			</PluginSidebar>

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -22,6 +22,8 @@ import {
 	__experimentalHStack as HStack,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalText as Text,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalDivider as Divider,
 	Button,
 	Icon,
 	FlexItem,
@@ -157,7 +159,7 @@ const CreateBlockThemePlugin = () => {
 								>
 									{ __( 'Export Zip', 'create-block-theme' ) }
 								</Button>
-								<hr></hr>
+								<Divider />
 								<NavigatorButton
 									path="/create/blank"
 									icon={ addCard }
@@ -186,7 +188,7 @@ const CreateBlockThemePlugin = () => {
 									</HStack>
 								</NavigatorButton>
 
-								<hr></hr>
+								<Divider />
 
 								<NavigatorButton
 									path="/about"
@@ -224,7 +226,7 @@ const CreateBlockThemePlugin = () => {
 										'create-block-theme'
 									) }
 								</Text>
-								<hr></hr>
+								<Divider />
 								<NavigatorButton
 									path="/clone/create"
 									icon={ copy }
@@ -249,7 +251,7 @@ const CreateBlockThemePlugin = () => {
 										'create-block-theme'
 									) }
 								</Text>
-								<hr></hr>
+								<Divider />
 								<NavigatorButton
 									path="/clone/create"
 									icon={ copy }

--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -1,3 +1,5 @@
+@import "~@wordpress/base-styles/colors";
+
 $plugin-prefix: "create-block-theme";
 $modal-footer-height: 70px;
 
@@ -25,12 +27,12 @@ $modal-footer-height: 70px;
 
 	&__plugin-sidebar {
 		&__about-button {
-			color: #949494;
+			color: $gray-600;
 			margin-top: 3rem;
 		}
 
 		&__about-button svg {
-			fill: #949494;
+			fill: $gray-600;
 		}
 	}
 }

--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -22,4 +22,15 @@ $modal-footer-height: 70px;
 			object-fit: cover;
 		}
 	}
+
+	&__plugin-sidebar {
+		&__about-button {
+			color: #949494;
+			margin-top: 3rem;
+		}
+
+		&__about-button svg {
+			fill: #949494;
+		}
+	}
 }


### PR DESCRIPTION
## What?
Add an 'About' section in the editor following the example from the admin page that will be deprecated in the next versions.

## Why?
- To provide some help to new users of the plugin.
- The admin page could be deprecated in the next versions.

## Screencast:
[Screencast from 03-06-24 13:33:21.webm](https://github.com/WordPress/create-block-theme/assets/1310626/a41467a4-908f-4b68-94a7-d66e62321532)
