### PR TITLE
Quality: Fix warning error when exporting theme

### DIFF
--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -442,6 +442,7 @@ class CBT_Theme_API {
 		header( 'Content-Length: ' . filesize( $filename ) );
 		flush();
 		echo readfile( $filename );
+		exit;
 	}
 
 	/**

--- a/src/utils/download-file.js
+++ b/src/utils/download-file.js
@@ -1,3 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { downloadBlob } from '@wordpress/blob';
+
 /*
  * Download a file from in a browser.
  *
@@ -9,25 +14,5 @@ export default async function downloadFile( response ) {
 	const filename = response.headers
 		.get( 'Content-Disposition' )
 		.split( 'filename=' )[ 1 ];
-
-	// Check if the browser supports navigator.msSaveBlob or navigator.saveBlob
-	if ( window.navigator.msSaveBlob || window.navigator.saveBlob ) {
-		const saveBlob =
-			window.navigator.msSaveBlob || window.navigator.saveBlob;
-		saveBlob.call( window.navigator, blob, filename );
-	} else {
-		// Fall back to creating an object URL and triggering a download using an anchor element
-		const url = URL.createObjectURL( blob );
-
-		const a = document.createElement( 'a' );
-		a.href = url;
-		a.download = filename;
-		document.body.appendChild( a );
-		a.click();
-		document.body.removeChild( a );
-
-		setTimeout( () => {
-			URL.revokeObjectURL( url );
-		}, 100 );
-	}
+	downloadBlob( filename, blob, 'application/zip' );
 }


### PR DESCRIPTION
I discovered this while investigating issue #612.


https://github.com/WordPress/create-block-theme/assets/54422211/8da13a84-c74f-4698-8222-01b824c75e83

I don't know the exact cause, but it seems that this problem can be solved by adding an `exit;` to the end of the callback function.

The `exit;` also exists in [the core export function](https://github.com/WordPress/wordpress-develop/blob/bca94a5fe45f9414f0d11a16372895a4817b1716/src/wp-includes/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php#L92).

### Testing Instructions

- Add `define( 'WP_DEBUG_LOG', true );` to the `wp-config.php`.
- Confirm that no PHP errors are logged when you export the theme.
