### PR TITLE
a11y: Improve color contrast for help button

### DIFF
--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -27,12 +27,8 @@ $modal-footer-height: 70px;
 
 	&__plugin-sidebar {
 		&__about-button {
-			color: $gray-600;
+			color: $gray-700;
 			margin-top: 3rem;
-		}
-
-		&__about-button svg {
-			fill: $gray-600;
 		}
 	}
 }


### PR DESCRIPTION
The text color for the help button is [$gray-600](https://github.com/WordPress/gutenberg/blob/4d1aa40f02c6a46e08b1496f74c66a059611b0a2/packages/base-styles/_colors.scss#L12), which meets accessibility requirements for large text, but not for normal text. For normal text, we should use a color at least darker than [$gray-700](https://github.com/WordPress/gutenberg/blob/4d1aa40f02c6a46e08b1496f74c66a059611b0a2/packages/base-styles/_colors.scss#L11).

Or, we could just leave it as the normal text color.

| Before ($gray-600, #949494) | After ($gray-700, #757575) |
|--------|--------|
| ![image](https://github.com/WordPress/create-block-theme/assets/54422211/7423293c-72de-473f-9b78-e71441f56b6c)| ![image](https://github.com/WordPress/create-block-theme/assets/54422211/8de55bca-3a80-4227-9d1b-eb57c9d63eb8)|
| ![image](https://github.com/WordPress/create-block-theme/assets/54422211/7eca5627-047b-4827-b013-c1f55444d5ad)| ![image](https://github.com/WordPress/create-block-theme/assets/54422211/da41e1db-5288-4b6f-8fa3-df1f3bbac29d)| 