### PR TITLE
Try: Add synced patterns to theme on save

### DIFF
--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -395,8 +395,11 @@ class CBT_Theme_API {
 		}
 
 		if ( isset( $options['savePatterns'] ) && true === $options['savePatterns'] ) {
-			CBT_Theme_Patterns::add_patterns_to_theme( $options );
-			// clear pattern customisations?
+			$response = CBT_Theme_Patterns::add_patterns_to_theme( $options );
+
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
 		}
 
 		wp_get_theme()->cache_delete();

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -383,7 +383,7 @@ class CBT_Theme_API {
 		}
 
 		if ( isset( $options['savePatterns'] ) && true === $options['savePatterns'] ) {
-			CBT_Theme_Patterns::add_patterns_to_theme();
+			CBT_Theme_Patterns::add_patterns_to_theme( $options );
 			// clear pattern customisations?
 		}
 

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -382,6 +382,11 @@ class CBT_Theme_API {
 			CBT_Theme_Styles::clear_user_styles_customizations();
 		}
 
+		if ( isset( $options['savePatterns'] ) && true === $options['savePatterns'] ) {
+			CBT_Theme_Patterns::add_patterns_to_theme();
+			// clear pattern customisations?
+		}
+
 		wp_cache_flush();
 
 		return new WP_REST_Response(

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -24,13 +24,13 @@ class CBT_Theme_Patterns {
 	public static function pattern_from_wp_block( $pattern_post ) {
 		$pattern          = new stdClass();
 		$pattern->id      = $pattern_post->ID;
+		$pattern->title   = $pattern_post->post_title;
 		$pattern->name    = sanitize_title_with_dashes( $pattern_post->post_title );
-		$theme_slug       = wp_get_theme()->get( 'TextDomain' );
-		$pattern->slug    = $theme_slug . '/' . $pattern->name;
+		$pattern->slug    = wp_get_theme()->get( 'TextDomain' ) . '/' . $pattern->name;
 		$pattern->content = (
 		'<?php
 /**
- * Title: ' . $pattern_post->post_title . '
+ * Title: ' . $pattern->title . '
  * Slug: ' . $pattern->slug . '
  * Categories: hidden
  * Inserter: no

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -29,7 +29,8 @@ class CBT_Theme_Patterns {
 		$pattern->slug         = wp_get_theme()->get( 'TextDomain' ) . '/' . $pattern->name;
 		$pattern_category_list = get_the_terms( $pattern->id, 'wp_pattern_category' );
 		$pattern->categories   = ! empty( $pattern_category_list ) ? join( ', ', wp_list_pluck( $pattern_category_list, 'name' ) ) : '';
-		$pattern->content      = (
+		// $pattern->sync_status  = get_post_meta( $pattern->id, 'wp_pattern_sync_status', true );
+		$pattern->content = (
 		'<?php
 /**
  * Title: ' . $pattern->title . '

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -144,6 +144,12 @@ class CBT_Theme_Patterns {
 				);
 
 				self::replace_local_pattern_references( $pattern );
+
+				// If it's a synced pattern then remove it from the database.
+				// This is to ensure that these patterns are loaded from the theme.
+				if ( 'unsynced' !== $pattern->sync_status ) {
+					wp_delete_post( $pattern->id, true );
+				}
 			}
 		}
 	}

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -28,7 +28,7 @@ class CBT_Theme_Patterns {
 		$pattern->name         = sanitize_title_with_dashes( $pattern_post->post_title );
 		$pattern->slug         = wp_get_theme()->get( 'TextDomain' ) . '/' . $pattern->name;
 		$pattern_category_list = get_the_terms( $pattern->id, 'wp_pattern_category' );
-		$pattern->categories   = join( ', ', wp_list_pluck( $pattern_category_list, 'name' ) );
+		$pattern->categories   = ! empty( $pattern_category_list ) ? join( ', ', wp_list_pluck( $pattern_category_list, 'name' ) ) : '';
 		$pattern->content      = (
 		'<?php
 /**

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -144,7 +144,7 @@ class CBT_Theme_Patterns {
 					// Check pattern name doesn't already exist before creating the file.
 					$existing_patterns = glob( $patterns_dir . DIRECTORY_SEPARATOR . '*.php' );
 					foreach ( $existing_patterns as $existing_pattern ) {
-						if ( strpos( $existing_pattern, 'pattern-' . $pattern->name . '.php' ) !== false ) {
+						if ( strpos( $existing_pattern, $pattern->name . '.php' ) !== false ) {
 							$pattern_exists = true;
 						}
 					}
@@ -164,9 +164,9 @@ class CBT_Theme_Patterns {
 					}
 
 					// Create the pattern file.
-					$pattern_file = $patterns_dir . 'pattern-' . $pattern->name . '.php';
+					$pattern_file = $patterns_dir . $pattern->name . '.php';
 					file_put_contents(
-						$patterns_dir . DIRECTORY_SEPARATOR . 'pattern-' . $pattern->name . '.php',
+						$patterns_dir . DIRECTORY_SEPARATOR . $pattern->name . '.php',
 						$pattern->content
 					);
 

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -25,12 +25,12 @@ class CBT_Theme_Patterns {
 		$pattern          = new stdClass();
 		$pattern->name    = sanitize_title_with_dashes( $pattern_post->post_title );
 		$theme_slug       = wp_get_theme()->get( 'TextDomain' );
-		$pattern->slug    = $theme_slug . '/' . $pattern_name;
+		$pattern->slug    = $theme_slug . '/' . $pattern->name;
 		$pattern->content = (
 		'<?php
 /**
  * Title: ' . $pattern_post->post_title . '
- * Slug: ' . $pattern_slug . '
+ * Slug: ' . $pattern->slug . '
  * Categories: hidden
  * Inserter: no
  */

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -22,17 +22,19 @@ class CBT_Theme_Patterns {
 	}
 
 	public static function pattern_from_wp_block( $pattern_post ) {
-		$pattern          = new stdClass();
-		$pattern->id      = $pattern_post->ID;
-		$pattern->title   = $pattern_post->post_title;
-		$pattern->name    = sanitize_title_with_dashes( $pattern_post->post_title );
-		$pattern->slug    = wp_get_theme()->get( 'TextDomain' ) . '/' . $pattern->name;
-		$pattern->content = (
+		$pattern               = new stdClass();
+		$pattern->id           = $pattern_post->ID;
+		$pattern->title        = $pattern_post->post_title;
+		$pattern->name         = sanitize_title_with_dashes( $pattern_post->post_title );
+		$pattern->slug         = wp_get_theme()->get( 'TextDomain' ) . '/' . $pattern->name;
+		$pattern_category_list = get_the_terms( $pattern->id, 'wp_pattern_category' );
+		$pattern->categories   = join( ', ', wp_list_pluck( $pattern_category_list, 'name' ) );
+		$pattern->content      = (
 		'<?php
 /**
  * Title: ' . $pattern->title . '
  * Slug: ' . $pattern->slug . '
- * Categories: hidden
+ * Categories: ' . $pattern->categories . '
  * Inserter: no
  */
 ?>

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -85,6 +85,11 @@ class CBT_Theme_Patterns {
 
 		if ( array_key_exists( 'localizeImages', $options ) && $options['localizeImages'] ) {
 			$pattern = CBT_Theme_Media::make_template_images_local( $pattern );
+
+			// Write the media assets if there are any
+			if ( $pattern->media ) {
+				CBT_Theme_Media::add_media_to_local( $pattern->media );
+			}
 		}
 
 		return $pattern;
@@ -122,7 +127,6 @@ class CBT_Theme_Patterns {
 		}
 
 		// TODO:
-		// Copy media to the theme filesystem and replace media URLs.
 		// Replace any references to the custom patterns with the new theme patterns.
 	}
 }

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -30,18 +30,17 @@ class CBT_Theme_Patterns {
 		$pattern->slug         = wp_get_theme()->get( 'TextDomain' ) . '/' . $pattern->name;
 		$pattern_category_list = get_the_terms( $pattern->id, 'wp_pattern_category' );
 		$pattern->categories   = ! empty( $pattern_category_list ) ? join( ', ', wp_list_pluck( $pattern_category_list, 'name' ) ) : '';
-		// $pattern->sync_status  = get_post_meta( $pattern->id, 'wp_pattern_sync_status', true );
-		$pattern->content = (
-		'<?php
-/**
- * Title: ' . $pattern->title . '
- * Slug: ' . $pattern->slug . '
- * Categories: ' . $pattern->categories . '
- * Inserter: no
- */
-?>
-' . $pattern_post->post_content
-		);
+		$pattern->sync_status  = get_post_meta( $pattern->id, 'wp_pattern_sync_status', true );
+		$pattern->content      = <<<PHP
+		<?php
+		/**
+		 * Title: {$pattern->title}
+		 * Slug: {$pattern->slug}
+		 * Categories: {$pattern->categories}
+		 */
+		?>
+		{$pattern_post->post_content}
+		PHP;
 
 		return $pattern;
 	}

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -4,17 +4,18 @@ class CBT_Theme_Patterns {
 	public static function pattern_from_template( $template, $new_slug = null ) {
 		$theme_slug      = $new_slug ? $new_slug : wp_get_theme()->get( 'TextDomain' );
 		$pattern_slug    = $theme_slug . '/' . $template->slug;
-		$pattern_content = (
-		'<?php
-/**
- * Title: ' . $template->slug . '
- * Slug: ' . $pattern_slug . '
- * Categories: hidden
- * Inserter: no
- */
-?>
-' . $template->content
-		);
+		$pattern_content = <<<PHP
+		<?php
+		/**
+		 * Title: {$template->slug}
+		 * Slug: {$pattern_slug}
+		 * Categories: hidden
+		 * Inserter: no
+		 */
+		?>
+		{$template->content}
+		PHP;
+
 		return array(
 			'slug'    => $pattern_slug,
 			'content' => $pattern_content,

--- a/includes/create-theme/theme-templates.php
+++ b/includes/create-theme/theme-templates.php
@@ -10,12 +10,13 @@ class CBT_Theme_Templates {
 	 * based on the given export_type.
 	 *
 	 * @param string $export_type The type of export to perform. 'all', 'current', or 'user'.
+	 * @param array $templates_to_export List of specific templates to export.
 	 * @return object An object containing the templates and parts that should be exported.
 	 */
-	public static function get_theme_templates( $export_type ) {
+	public static function get_theme_templates( $export_type, $templates_to_export = null ) {
 
-		$templates          = get_block_templates();
-		$template_parts     = get_block_templates( array(), 'wp_template_part' );
+		$templates          = get_block_templates( array( 'slug__in' => $templates_to_export ) );
+		$template_parts     = get_block_templates( array( 'slug__in' => $templates_to_export ), 'wp_template_part' );
 		$exported_templates = array();
 		$exported_parts     = array();
 
@@ -195,10 +196,12 @@ class CBT_Theme_Templates {
 	 * @param string $export_type The type of export to perform. 'all', 'current', or 'user'.
 	 * @param string $path The path to the theme folder. If null it is assumed to be the current theme.
 	 * @param string $slug The slug of the theme. If null it is assumed to be the current theme.
+	 * @param array $options An array of options to use when exporting the templates.
+	 * @param array $templates_to_export List of specific templates to export. If null it will be fetched.
 	 */
-	public static function add_templates_to_local( $export_type, $path = null, $slug = null, $options = null ) {
+	public static function add_templates_to_local( $export_type, $path = null, $slug = null, $options = null, $templates_to_export = null ) {
 
-		$theme_templates  = self::get_theme_templates( $export_type );
+		$theme_templates  = self::get_theme_templates( $export_type, $templates_to_export );
 		$template_folders = get_block_theme_folders();
 
 		$base_dir          = $path ? $path : get_stylesheet_directory();

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -139,7 +139,7 @@ export const SaveThemePanel = () => {
 				<CheckboxControl
 					label={ __( 'Save Synced Patterns', 'create-block-theme' ) }
 					help={ __(
-						'Save synced patterns created in the Editor, listed under "My patterns", to the theme. Note that this will delete synced patterns from the Editor and move them to the theme.',
+						'Any synced patterns created in the Editor will be moved to the theme. Note that this will delete all synced patterns from the Editor and any references in templates will be made relative to the theme.',
 						'create-block-theme'
 					) }
 					checked={ preference.savePatterns }

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -137,9 +137,9 @@ export const SaveThemePanel = () => {
 					}
 				/>
 				<CheckboxControl
-					label={ __( 'Save My Patterns', 'create-block-theme' ) }
+					label={ __( 'Save Synced Patterns', 'create-block-theme' ) }
 					help={ __(
-						'Save custom patterns created in the Editor, listed under "My patterns", to the theme.',
+						'Save synced patterns created in the Editor, listed under "My patterns", to the theme. Note that this will delete synced patterns from the Editor and move them to the theme.',
 						'create-block-theme'
 					) }
 					checked={ preference.savePatterns }

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -69,7 +69,21 @@ export const SaveThemePanel = () => {
 						'create-block-theme'
 					)
 				);
-				window.location.reload();
+
+				const searchParams = new URLSearchParams(
+					window?.location?.search
+				);
+				// If user is editing a pattern, redirect back to the patterns page.
+				if (
+					searchParams.get( 'postType' ) === 'wp_block' &&
+					searchParams.get( 'postId' )
+				) {
+					window.location =
+						'/wp-admin/site-editor.php?postType=wp_block';
+				} else {
+					// If user is not editing a pattern, reload the editor.
+					window.location.reload();
+				}
 			} )
 			.catch( ( error ) => {
 				const errorMessage =

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -32,9 +32,9 @@ export const SaveThemePanel = () => {
 		return {
 			saveStyle: _preference?.saveStyle ?? true,
 			saveTemplates: _preference?.saveTemplates ?? true,
-			savePatterns: _preference?.savePatterns ?? true,
 			processOnlySavedTemplates:
 				_preference?.processOnlySavedTemplates ?? true,
+			savePatterns: _preference?.savePatterns ?? true,
 			saveFonts: _preference?.saveFonts ?? true,
 			removeNavRefs: _preference?.removeNavRefs ?? false,
 			localizeText: _preference?.localizeText ?? false,
@@ -119,15 +119,6 @@ export const SaveThemePanel = () => {
 					onChange={ () => handleTogglePreference( 'saveTemplates' ) }
 				/>
 				<CheckboxControl
-					label={ __( 'Save My Patterns', 'create-block-theme' ) }
-					help={ __(
-						'Save custom patterns created in the Editor, listed under "My patterns", to the theme.',
-						'create-block-theme'
-					) }
-					checked={ preference.savePatterns }
-					onChange={ () => handleTogglePreference( 'savePatterns' ) }
-				/>
-				<CheckboxControl
 					label={ __(
 						'Process Only Modified Templates',
 						'create-block-theme'
@@ -146,14 +137,27 @@ export const SaveThemePanel = () => {
 					}
 				/>
 				<CheckboxControl
+					label={ __( 'Save My Patterns', 'create-block-theme' ) }
+					help={ __(
+						'Save custom patterns created in the Editor, listed under "My patterns", to the theme.',
+						'create-block-theme'
+					) }
+					checked={ preference.savePatterns }
+					onChange={ () => handleTogglePreference( 'savePatterns' ) }
+				/>
+				<CheckboxControl
 					label={ __( 'Localize Text', 'create-block-theme' ) }
 					help={ __(
 						'Any text in a template will be copied to a pattern and localized.',
 						'create-block-theme'
 					) }
-					disabled={ ! preference.saveTemplates }
+					disabled={
+						! preference.saveTemplates && ! preference.savePatterns
+					}
 					checked={
-						preference.saveTemplates && preference.localizeText
+						( preference.saveTemplates ||
+							preference.savePatterns ) &&
+						preference.localizeText
 					}
 					onChange={ () => handleTogglePreference( 'localizeText' ) }
 				/>
@@ -163,9 +167,13 @@ export const SaveThemePanel = () => {
 						'Any images in a template will be copied to a local /assets folder and referenced from there via a pattern.',
 						'create-block-theme'
 					) }
-					disabled={ ! preference.saveTemplates }
+					disabled={
+						! preference.saveTemplates && ! preference.savePatterns
+					}
 					checked={
-						preference.saveTemplates && preference.localizeImages
+						( preference.saveTemplates ||
+							preference.savePatterns ) &&
+						preference.localizeImages
 					}
 					onChange={ () =>
 						handleTogglePreference( 'localizeImages' )
@@ -180,9 +188,13 @@ export const SaveThemePanel = () => {
 						'Remove Navigation Refs from the theme returning your navigation to the default state.',
 						'create-block-theme'
 					) }
-					disabled={ ! preference.saveTemplates }
+					disabled={
+						! preference.saveTemplates && ! preference.savePatterns
+					}
 					checked={
-						preference.saveTemplates && preference.removeNavRefs
+						( preference.saveTemplates ||
+							preference.savePatterns ) &&
+						preference.removeNavRefs
 					}
 					onChange={ () => handleTogglePreference( 'removeNavRefs' ) }
 				/>

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -148,7 +148,7 @@ export const SaveThemePanel = () => {
 				<CheckboxControl
 					label={ __( 'Localize Text', 'create-block-theme' ) }
 					help={ __(
-						'Any text in a template will be copied to a pattern and localized.',
+						'Any text in a template or pattern will be localized in a pattern.',
 						'create-block-theme'
 					) }
 					disabled={
@@ -164,7 +164,7 @@ export const SaveThemePanel = () => {
 				<CheckboxControl
 					label={ __( 'Localize Images', 'create-block-theme' ) }
 					help={ __(
-						'Any images in a template will be copied to a local /assets folder and referenced from there via a pattern.',
+						'Any images in a template or pattern will be copied to a local /assets folder and referenced from there via a pattern.',
 						'create-block-theme'
 					) }
 					disabled={

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -73,8 +73,9 @@ export const SaveThemePanel = () => {
 				const searchParams = new URLSearchParams(
 					window?.location?.search
 				);
-				// If user is editing a pattern, redirect back to the patterns page.
+				// If user is editing a pattern and savePatterns is true, redirect back to the patterns page.
 				if (
+					preference.savePatterns &&
 					searchParams.get( 'postType' ) === 'wp_block' &&
 					searchParams.get( 'postId' )
 				) {

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -32,6 +32,7 @@ export const SaveThemePanel = () => {
 		return {
 			saveStyle: _preference?.saveStyle ?? true,
 			saveTemplates: _preference?.saveTemplates ?? true,
+			savePatterns: _preference?.savePatterns ?? true,
 			processOnlySavedTemplates:
 				_preference?.processOnlySavedTemplates ?? true,
 			saveFonts: _preference?.saveFonts ?? true,
@@ -116,6 +117,15 @@ export const SaveThemePanel = () => {
 					) }
 					checked={ preference.saveTemplates }
 					onChange={ () => handleTogglePreference( 'saveTemplates' ) }
+				/>
+				<CheckboxControl
+					label={ __( 'Save My Patterns', 'create-block-theme' ) }
+					help={ __(
+						'Save custom patterns created in the Editor, listed under "My patterns", to the theme.',
+						'create-block-theme'
+					) }
+					checked={ preference.savePatterns }
+					onChange={ () => handleTogglePreference( 'savePatterns' ) }
 				/>
 				<CheckboxControl
 					label={ __(


### PR DESCRIPTION
This PR explores the most minimal way we can introduce some pattern management into the plugin by allowing custom patterns to be saved to the theme filesystem on save, allowing them to be exported with the theme.

Part of https://github.com/WordPress/create-block-theme/issues/287.

<img width="288" alt="image" src="https://github.com/WordPress/create-block-theme/assets/1645628/557380f9-d141-4542-bb18-915d836d4aa7">

## Testing Instructions
1. Create a new synced pattern in the Editor (also try adding categories)
2. Go to the Editor, and in the Create Block Theme menu, save the theme changes with the "Save My Patterns" option checked