### PR TITLE
Persist font settings when cloning a theme

### DIFF
--- a/includes/create-theme/theme-create.php
+++ b/includes/create-theme/theme-create.php
@@ -25,6 +25,9 @@ class CBT_Theme_Create {
 
 		wp_mkdir_p( $new_theme_path );
 
+		// Persist font settings for cloned theme.
+		CBT_Theme_Fonts::persist_font_settings();
+
 		// Copy theme files.
 		$template_options = array(
 			'localizeText'   => false,


### PR DESCRIPTION
This PR should apply the "Save Fonts" save option when cloning a theme via Create Theme -> Clone Theme. This means that any font settings and files are copied over to the new cloned theme, including updating the file asset paths.

Fixes https://github.com/WordPress/create-block-theme/issues/677.

To test:

1. Install and activate some custom fonts using the Font Library.
2. Go to the CBT menu, Create Theme -> Clone Theme.
3. Name your theme.
4. Check the theme.json of the newly cloned theme: ensure that the `fontFace.src` paths are relative to the cloned theme. i.e. the paths start with `file:.` and not an absolute URL. 