### PR TITLE
Delete only theme-related caches when saving changes

### DIFF
--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -382,7 +382,7 @@ class CBT_Theme_API {
 			CBT_Theme_Styles::clear_user_styles_customizations();
 		}
 
-		wp_cache_flush();
+		wp_get_theme()->cache_delete();
 
 		return new WP_REST_Response(
 			array(


### PR DESCRIPTION
Related to #655, #654

This PR changes how the cache is deleted when you save changes to a theme:

- Delete the **database** cache as well as the **object** cache
- Delete only the theme cache, not all caches

## Delete the database cache as well as the object cache

As I understand it, the [wp_cache_flush() function](https://developer.wordpress.org/reference/functions/wp_cache_flush/) deletes _only_ the object cache. On the other hand, the pattern uses the database cache via the Transient API ([Source](https://github.com/WordPress/WordPress/blob/bccb3e46e13e54e02fe9654eae0c21de9e736846/wp-includes/class-wp-theme.php#L2000-L2032)).

Therefore, I think that `wp_cache_flush()` cannot completely solve the problem reported in #655.

In my testing in the local wp-env environment, the content did not appear in the editor canvas after saving a modified template unless I deleted the database cache or changed the value of the `DEVELOPMENT_MODE` constant to `theme`.

## Delete only the theme cache, not all caches

`wp_cache_flush()` function deletes all object caches. Therefore, it may have unintended negative effects on sites that are trying to improve performance by using object caches.

WP_Theme (wp_get_theme())->cache_delete() method properly deletes the object cache for the theme and the database cache for the pattern ([Source](https://github.com/WordPress/WordPress/blob/bccb3e46e13e54e02fe9654eae0c21de9e736846/wp-includes/class-wp-theme.php#L834-L850)).

## Testing Instructions

First of all, I would be grateful if you could confirm whether the problem reported in #655 still occurs in the wp-env environment and test whether this PR solves the problem.

If this PR is useful, we may evaluate the effectiveness of the `wp_cache_flush()` function used in other places individually and replace it with a different cache deletion method similar to this PR.

The video below shows that the issue reported in #655 still occurs in the wp-env environment.

https://github.com/WordPress/create-block-theme/assets/54422211/5d915787-0e40-4196-b7ab-62a56515c652

