### PR TITLE
Add theme reset section

### DIFF
--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -144,6 +144,18 @@ class CBT_Theme_API {
 				},
 			),
 		);
+		register_rest_route(
+			'create-block-theme/v1',
+			'/reset-theme',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'rest_reset_theme' ),
+				// 'permission_callback' => function () {
+				// 	return current_user_can( 'edit_theme_options' );
+				// },
+				'permission_callback' => '__return_true',
+			),
+		);
 	}
 
 	function rest_get_theme_data( $request ) {
@@ -371,6 +383,7 @@ class CBT_Theme_API {
 				}
 			}
 			CBT_Theme_Templates::clear_user_templates_customizations();
+			CBT_Theme_Templates::clear_user_template_parts_customizations();
 		}
 
 		if ( isset( $options['saveStyle'] ) && true === $options['saveStyle'] ) {
@@ -406,6 +419,32 @@ class CBT_Theme_API {
 				'status'  => 'SUCCESS',
 				'message' => __( 'Font Families retrieved.', 'create-block-theme' ),
 				'data'    => $font_families,
+			)
+		);
+	}
+
+	/**
+	 * Reset the theme to the default state.
+	 */
+	function rest_reset_theme( $request ) {
+		$options = $request->get_params();
+
+		if ( isset( $options['resetStyles'] ) && true === $options['resetStyles'] ) {
+			CBT_Theme_Styles::clear_user_styles_customizations();
+		}
+
+		if ( isset( $options['resetTemplates'] ) && true === $options['resetTemplates'] ) {
+			CBT_Theme_Templates::clear_user_templates_customizations();
+		}
+
+		if ( isset( $options['resetTemplateParts'] ) && true === $options['resetTemplateParts'] ) {
+			CBT_Theme_Templates::clear_user_template_parts_customizations();
+		}
+
+		return rest_ensure_response(
+			array(
+				'status'  => 'SUCCESS',
+				'message' => __( 'Theme Reset.', 'create-block-theme' ),
 			)
 		);
 	}

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -150,10 +150,9 @@ class CBT_Theme_API {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'rest_reset_theme' ),
-				// 'permission_callback' => function () {
-				// 	return current_user_can( 'edit_theme_options' );
-				// },
-				'permission_callback' => '__return_true',
+				'permission_callback' => function () {
+					return current_user_can( 'edit_theme_options' );
+				},
 			),
 		);
 	}

--- a/includes/create-theme/theme-templates.php
+++ b/includes/create-theme/theme-templates.php
@@ -106,17 +106,22 @@ class CBT_Theme_Templates {
 	 * This will remove all user templates from the database.
 	 */
 	public static function clear_user_templates_customizations() {
-		//remove all user templates (they have been saved in the theme)
-		$templates      = get_block_templates();
-		$template_parts = get_block_templates( array(), 'wp_template_part' );
-		foreach ( $template_parts as $template ) {
+		$templates = get_block_templates();
+		foreach ( $templates as $template ) {
 			if ( 'custom' !== $template->source ) {
 				continue;
 			}
 			wp_delete_post( $template->wp_id, true );
 		}
+	}
 
-		foreach ( $templates as $template ) {
+	/**
+	 * Clear all user template-parts customizations.
+	 * This will remove all user template-parts from the database.
+	 */
+	public static function clear_user_template_parts_customizations() {
+		$template_parts = get_block_templates( array(), 'wp_template_part' );
+		foreach ( $template_parts as $template ) {
 			if ( 'custom' !== $template->source ) {
 				continue;
 			}

--- a/src/editor-sidebar/reset-theme.js
+++ b/src/editor-sidebar/reset-theme.js
@@ -6,12 +6,15 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalConfirmDialog as ConfirmDialog,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 	PanelBody,
 	Button,
 	CheckboxControl,
 } from '@wordpress/components';
 import { trash } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
@@ -38,6 +41,7 @@ function ResetTheme() {
 
 	const { set: setPreferences } = useDispatch( preferencesStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
+	const [ isConfirmDialogOpen, setIsConfirmDialogOpen ] = useState( false );
 
 	const handleTogglePreference = ( key ) => {
 		setPreferences( PREFERENCE_SCOPE, PREFERENCE_KEY, {
@@ -46,9 +50,14 @@ function ResetTheme() {
 		} );
 	};
 
+	const toggleConfirmDialog = () => {
+		setIsConfirmDialogOpen( ! isConfirmDialogOpen );
+	};
+
 	const handleResetTheme = async () => {
 		try {
 			await resetTheme( preferences );
+			toggleConfirmDialog();
 			// eslint-disable-next-line no-alert
 			window.alert(
 				__(
@@ -68,62 +77,83 @@ function ResetTheme() {
 	};
 
 	return (
-		<PanelBody>
-			<ScreenHeader title={ __( 'Reset Theme', 'create-block-theme' ) } />
-			<VStack>
-				<CheckboxControl
-					label={ __( 'Reset theme styles', 'create-block-theme' ) }
-					help={ __(
-						'Reset customizations to theme styles and settings.',
-						'create-block-theme'
-					) }
-					checked={ preferences.resetStyles }
-					onChange={ () => handleTogglePreference( 'resetStyles' ) }
+		<>
+			<ConfirmDialog
+				isOpen={ isConfirmDialogOpen }
+				confirmButtonText={ __( 'Reset', 'create-block-theme' ) }
+				onCancel={ toggleConfirmDialog }
+				onConfirm={ handleResetTheme }
+				size="medium"
+			>
+				{ __(
+					'Are you sure you want to reset the theme? This action cannot be undone.',
+					'create-block-theme'
+				) }
+			</ConfirmDialog>
+			<PanelBody>
+				<ScreenHeader
+					title={ __( 'Reset Theme', 'create-block-theme' ) }
 				/>
+				<VStack>
+					<CheckboxControl
+						label={ __(
+							'Reset theme styles',
+							'create-block-theme'
+						) }
+						help={ __(
+							'Reset customizations to theme styles and settings.',
+							'create-block-theme'
+						) }
+						checked={ preferences.resetStyles }
+						onChange={ () =>
+							handleTogglePreference( 'resetStyles' )
+						}
+					/>
 
-				<CheckboxControl
-					label={ __(
-						'Reset theme templates',
-						'create-block-theme'
-					) }
-					help={ __(
-						'Reset customizations to theme templates.',
-						'create-block-theme'
-					) }
-					checked={ preferences.resetTemplates }
-					onChange={ () =>
-						handleTogglePreference( 'resetTemplates' )
-					}
-				/>
+					<CheckboxControl
+						label={ __(
+							'Reset theme templates',
+							'create-block-theme'
+						) }
+						help={ __(
+							'Reset customizations to theme templates.',
+							'create-block-theme'
+						) }
+						checked={ preferences.resetTemplates }
+						onChange={ () =>
+							handleTogglePreference( 'resetTemplates' )
+						}
+					/>
 
-				<CheckboxControl
-					label={ __(
-						'Reset theme template-parts',
-						'create-block-theme'
-					) }
-					help={ __(
-						'Reset customizations to theme template-parts.',
-						'create-block-theme'
-					) }
-					checked={ preferences.resetTemplateParts }
-					onChange={ () =>
-						handleTogglePreference( 'resetTemplateParts' )
-					}
-				/>
+					<CheckboxControl
+						label={ __(
+							'Reset theme template-parts',
+							'create-block-theme'
+						) }
+						help={ __(
+							'Reset customizations to theme template-parts.',
+							'create-block-theme'
+						) }
+						checked={ preferences.resetTemplateParts }
+						onChange={ () =>
+							handleTogglePreference( 'resetTemplateParts' )
+						}
+					/>
 
-				<Button
-					text={ __( 'Reset theme', 'create-block-theme' ) }
-					variant="primary"
-					icon={ trash }
-					disabled={
-						! preferences.resetStyles &&
-						! preferences.resetTemplates &&
-						! preferences.resetTemplateParts
-					}
-					onClick={ handleResetTheme }
-				/>
-			</VStack>
-		</PanelBody>
+					<Button
+						text={ __( 'Reset theme', 'create-block-theme' ) }
+						variant="primary"
+						icon={ trash }
+						disabled={
+							! preferences.resetStyles &&
+							! preferences.resetTemplates &&
+							! preferences.resetTemplateParts
+						}
+						onClick={ toggleConfirmDialog }
+					/>
+				</VStack>
+			</PanelBody>
+		</>
 	);
 }
 

--- a/src/editor-sidebar/reset-theme.js
+++ b/src/editor-sidebar/reset-theme.js
@@ -61,7 +61,7 @@ function ResetTheme() {
 			// eslint-disable-next-line no-alert
 			window.alert(
 				__(
-					'Theme reseted successfully. The editor will now reload.',
+					'Theme reset successfully. The editor will now reload.',
 					'create-block-theme'
 				)
 			);
@@ -69,7 +69,7 @@ function ResetTheme() {
 		} catch ( error ) {
 			createErrorNotice(
 				__(
-					'An error occurred while resetting theme.',
+					'An error occurred while resetting the theme.',
 					'create-block-theme'
 				)
 			);
@@ -141,7 +141,7 @@ function ResetTheme() {
 					/>
 
 					<Button
-						text={ __( 'Reset theme', 'create-block-theme' ) }
+						text={ __( 'Reset Theme', 'create-block-theme' ) }
 						variant="primary"
 						icon={ trash }
 						disabled={

--- a/src/editor-sidebar/reset-theme.js
+++ b/src/editor-sidebar/reset-theme.js
@@ -1,0 +1,130 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+	PanelBody,
+	Button,
+	CheckboxControl,
+} from '@wordpress/components';
+import { trash } from '@wordpress/icons';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import ScreenHeader from './screen-header';
+import { resetTheme } from '../resolvers';
+
+const PREFERENCE_SCOPE = 'create-block-theme';
+const PREFERENCE_KEY = 'reset-theme';
+
+function ResetTheme() {
+	const preferences = useSelect( ( select ) => {
+		const _preference = select( preferencesStore ).get(
+			PREFERENCE_SCOPE,
+			PREFERENCE_KEY
+		);
+		return {
+			resetStyles: _preference?.resetStyles ?? true,
+			resetTemplates: _preference?.resetTemplates ?? true,
+			resetTemplateParts: _preference?.resetTemplateParts ?? true,
+		};
+	}, [] );
+
+	const { set: setPreferences } = useDispatch( preferencesStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	const handleTogglePreference = ( key ) => {
+		setPreferences( PREFERENCE_SCOPE, PREFERENCE_KEY, {
+			...preferences,
+			[ key ]: ! preferences[ key ],
+		} );
+	};
+
+	const handleResetTheme = async () => {
+		try {
+			await resetTheme( preferences );
+			// eslint-disable-next-line no-alert
+			window.alert(
+				__(
+					'Theme reseted successfully. The editor will now reload.',
+					'create-block-theme'
+				)
+			);
+			window.location.reload();
+		} catch ( error ) {
+			createErrorNotice(
+				__(
+					'An error occurred while resetting theme.',
+					'create-block-theme'
+				)
+			);
+		}
+	};
+
+	return (
+		<PanelBody>
+			<ScreenHeader title={ __( 'Reset Theme', 'create-block-theme' ) } />
+			<VStack>
+				<CheckboxControl
+					label={ __( 'Reset theme styles', 'create-block-theme' ) }
+					help={ __(
+						'Reset customizations to theme styles and settings.',
+						'create-block-theme'
+					) }
+					checked={ preferences.resetStyles }
+					onChange={ () => handleTogglePreference( 'resetStyles' ) }
+				/>
+
+				<CheckboxControl
+					label={ __(
+						'Reset theme templates',
+						'create-block-theme'
+					) }
+					help={ __(
+						'Reset customizations to theme templates.',
+						'create-block-theme'
+					) }
+					checked={ preferences.resetTemplates }
+					onChange={ () =>
+						handleTogglePreference( 'resetTemplates' )
+					}
+				/>
+
+				<CheckboxControl
+					label={ __(
+						'Reset theme template-parts',
+						'create-block-theme'
+					) }
+					help={ __(
+						'Reset customizations to theme template-parts.',
+						'create-block-theme'
+					) }
+					checked={ preferences.resetTemplateParts }
+					onChange={ () =>
+						handleTogglePreference( 'resetTemplateParts' )
+					}
+				/>
+
+				<Button
+					text={ __( 'Reset theme', 'create-block-theme' ) }
+					variant="primary"
+					icon={ trash }
+					disabled={
+						! preferences.resetStyles &&
+						! preferences.resetTemplates &&
+						! preferences.resetTemplateParts
+					}
+					onClick={ handleResetTheme }
+				/>
+			</VStack>
+		</PanelBody>
+	);
+}
+
+export default ResetTheme;

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -39,6 +39,7 @@ import {
 	addCard,
 	blockMeta,
 	help,
+	trash,
 } from '@wordpress/icons';
 
 /**
@@ -52,8 +53,9 @@ import { ThemeMetadataEditorModal } from './editor-sidebar/metadata-editor-modal
 import ScreenHeader from './editor-sidebar/screen-header';
 import { downloadExportedTheme } from './resolvers';
 import downloadFile from './utils/download-file';
-import './plugin-styles.scss';
 import AboutPlugin from './editor-sidebar/about';
+import ResetTheme from './editor-sidebar/reset-theme';
+import './plugin-styles.scss';
 
 const CreateBlockThemePlugin = () => {
 	const [ isEditorOpen, setIsEditorOpen ] = useState( false );
@@ -190,6 +192,21 @@ const CreateBlockThemePlugin = () => {
 
 								<Divider />
 
+								<NavigatorButton path="/reset" icon={ trash }>
+									<Spacer />
+									<HStack>
+										<FlexItem>
+											{ __(
+												'Reset Theme',
+												'create-block-theme'
+											) }
+										</FlexItem>
+										<Icon icon={ chevronRight } />
+									</HStack>
+								</NavigatorButton>
+
+								<Divider />
+
 								<NavigatorButton
 									path="/about"
 									icon={ help }
@@ -298,6 +315,10 @@ const CreateBlockThemePlugin = () => {
 
 					<NavigatorScreen path="/about">
 						<AboutPlugin />
+					</NavigatorScreen>
+
+					<NavigatorScreen path="/reset">
+						<ResetTheme />
 					</NavigatorScreen>
 				</NavigatorProvider>
 			</PluginSidebar>

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -144,3 +144,23 @@ export async function getFontFamilies() {
 	} );
 	return response.data;
 }
+
+export async function resetTheme( preferences ) {
+	return apiFetch( {
+		path: '/create-block-theme/v1/reset-theme',
+		method: 'PATCH',
+		data: preferences,
+		headers: {
+			'Content-Type': 'application/json',
+		},
+	} ).then( ( response ) => {
+		if ( 'SUCCESS' !== response?.status ) {
+			throw new Error(
+				`Failed to reset theme: ${
+					response?.message || response?.status
+				}`
+			);
+		}
+		return response;
+	} );
+}


### PR DESCRIPTION
## What?
Add theme reset section

## Why?
Closes: https://github.com/WordPress/create-block-theme/issues/686 https://github.com/WordPress/create-block-theme/issues/494

## Screencast
[Screencast from 09-07-24 16:37:50.webm](https://github.com/WordPress/create-block-theme/assets/1310626/1a8c48ad-2c99-44df-a8bc-5fa791766522)


## Testing instructions:
1. make changes to theme templates using the site editor.
2. make changes to theme template parts using the site editor.
3. make changes to theme global styles using the site editor.
4. save the changes in the editor.
5. use the CBT reset functionality and check that the theme customization was erased.