### PR TITLE
Update blank themes theme json version

### DIFF
--- a/assets/boilerplate/theme.json
+++ b/assets/boilerplate/theme.json
@@ -30,5 +30,5 @@
 			"name": "footer"
 		}
 	],
-	"version": 2
+	"version": 3
 }


### PR DESCRIPTION
## What?
Update blank themes theme json version to 3

## Why?
Use the latest version in WordPress 6.6

https://github.com/WordPress/wordpress-develop/blob/5f8f3789d16e28923772f1675e371baaea3e71ec/src/wp-includes/class-wp-theme-json.php#L743