### PR TITLE
Bump minimum required WordPress version to 6.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Create Block Theme ===
 Contributors: wordpressdotorg, mikachan, onemaggie, pbking, scruffian, mmaattiiaass, jffng, madhudollu, egregor, vcanales, jeffikus, cwhitmore
 Tags: themes, theme, block-theme
-Requires at least: 6.5
+Requires at least: 6.6
 Tested up to: 6.6
 Stable tag: 2.3.0
 Requires PHP: 7.4

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -3,7 +3,7 @@
  */
 import { useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-site';
+import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/editor';
 import { __, _x } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';


### PR DESCRIPTION
Bump the minimum required WordPress version to 6.6.

There is a convention in the Gutenberg project to support one version older than the latest WordPress release. Regarding the Create Block Theme plugin, I don't think there is a clear backward compatibility policy yet, but if it's been a few weeks since the latest WP version was released, I think it's okay to bump up the minimum WordPress version.

Please let me know your thoughts.

In this PR, l also moved the following APIs from the `@wordpress/edit-site` package to the `@wordpress/editor` package to prevent browser warning errors:

- `PluginSidebar`
- `PluginSidebarMoreMenuItem`