### PR TITLE
Don't enable sidebar UI in classic theme

### DIFF
--- a/includes/class-create-block-theme-editor-tools.php
+++ b/includes/class-create-block-theme-editor-tools.php
@@ -16,7 +16,7 @@ class CBT_Editor_Tools {
 	function create_block_theme_sidebar_enqueue() {
 		global $pagenow;
 
-		if ( 'site-editor.php' !== $pagenow ) {
+		if ( 'site-editor.php' !== $pagenow || ! wp_is_block_theme() ) {
 			return;
 		}
 


### PR DESCRIPTION
In WordPress 6.6, Patterns was added as a submenu in the Appearance menu for classic themes:

![image](https://github.com/user-attachments/assets/28bc6265-051a-42af-a141-2126b5ae6446)

This means that classic themes have access to some screens in the site editor.

I noticed that when I opened the Pattern Editor in a classic theme, the Plugins sidebar is available:

![image](https://github.com/user-attachments/assets/95da41d4-fa2b-4d8e-874b-c3acf6a0f3ba)

This plugin is for block themes and should not be used in classic themes.