### PR TITLE
Remove "Categories: hidden" from default pattern header

### DIFF
--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -9,7 +9,6 @@ class CBT_Theme_Patterns {
 		/**
 		 * Title: {$template->slug}
 		 * Slug: {$pattern_slug}
-		 * Categories: hidden
 		 * Inserter: no
 		 */
 		?>

--- a/tests/test-theme-utils.php
+++ b/tests/test-theme-utils.php
@@ -9,7 +9,6 @@ class Test_Create_Block_Theme_Utils extends WP_UnitTestCase {
 /**
  * Title: index
  * Slug: old-slug/index
- * Categories: hidden
  * Inserter: no
  */
 ?>


### PR DESCRIPTION
This removes "Categories: hidden" from the `pattern_from_template` function, as the `hidden` category does not exist and “categories” is not a required property for registering blocks.

Props to @carolinan for mentioning this [here](https://wordpress.slack.com/archives/C015GUFFC00/p1725864890894449).