### PR TITLE
Fix "troobleshooting" typo in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -96,7 +96,7 @@ If you run into an issue, you should check the [Support forum](https://wordpress
 
 If you have a bug to report, please submit it to the [GitHub repository](https://github.com/WordPress/create-block-theme/issues) as an issue. Please search prior to creating a new bug to confirm its not a duplicate.
 
-== General Troobleshooting ==
+== General Troubleshooting ==
 
 If you are having problems, please try the following:
 


### PR DESCRIPTION
I was looking through the readme and noticed a typo, thought I'd give a quick fix here.

I tried looking around to make sure "troobleshooting" wasn't a reference or meme or something intentional, but couldn't find anything 😅 