### PR TITLE
Removed all of the code relating to 'folder management' of a theme.

### DIFF
--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -350,13 +350,6 @@ class CBT_Theme_API {
 			CBT_Theme_Utils::replace_screenshot( $theme['screenshot'] );
 		}
 
-		// Relocate the theme to a new folder
-		$response = CBT_Theme_Utils::relocate_theme( $theme['subfolder'] );
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
 		wp_cache_flush();
 
 		return new WP_REST_Response(
@@ -470,7 +463,6 @@ class CBT_Theme_API {
 		$sanitized_theme['author']              = sanitize_text_field( $theme['author'] ?? '' );
 		$sanitized_theme['author_uri']          = sanitize_text_field( $theme['author_uri'] ?? '' );
 		$sanitized_theme['tags_custom']         = sanitize_text_field( $theme['tags_custom'] ?? '' );
-		$sanitized_theme['subfolder']           = sanitize_text_field( $theme['subfolder'] ?? '' );
 		$sanitized_theme['version']             = sanitize_text_field( $theme['version'] ?? '' );
 		$sanitized_theme['screenshot']          = sanitize_text_field( $theme['screenshot'] ?? '' );
 		$sanitized_theme['requires_wp']         = sanitize_text_field( $theme['requires_wp'] ?? '' );

--- a/includes/create-theme/cbt-zip-archive.php
+++ b/includes/create-theme/cbt-zip-archive.php
@@ -5,7 +5,6 @@ if ( class_exists( 'ZipArchive' ) ) {
 	// This Class extends the ZipArchive class to add the theme slug as a base folder for all the files
 	class CBT_Zip_Archive extends ZipArchive {
 
-		private string $theme_slug;
 		private string $theme_folder;
 
 		function __construct( $theme_slug ) {

--- a/includes/create-theme/theme-create.php
+++ b/includes/create-theme/theme-create.php
@@ -15,10 +15,6 @@ class CBT_Theme_Create {
 		// Create theme directory.
 		$new_theme_path = get_theme_root() . DIRECTORY_SEPARATOR . $theme['slug'];
 
-		if ( $theme['subfolder'] ) {
-			$new_theme_path = get_theme_root() . DIRECTORY_SEPARATOR . $theme['subfolder'] . DIRECTORY_SEPARATOR . $theme['slug'];
-		}
-
 		if ( file_exists( $new_theme_path ) ) {
 			return new WP_Error( 'theme_already_exists', __( 'Theme already exists.', 'create-block-theme' ) );
 		}
@@ -40,21 +36,13 @@ class CBT_Theme_Create {
 		file_put_contents( path_join( $new_theme_path, 'readme.txt' ), CBT_Theme_Readme::create( $theme ) );
 		file_put_contents( path_join( $new_theme_path, 'style.css' ), CBT_Theme_Styles::update_style_css( file_get_contents( path_join( $new_theme_path, 'style.css' ) ), $theme ) );
 
-		if ( $theme['subfolder'] ) {
-			switch_theme( $theme['subfolder'] . '/' . $theme['slug'] );
-		} else {
-			switch_theme( $theme['slug'] );
-		}
+		switch_theme( $theme['slug'] );
 	}
 
 	public static function create_child_theme( $theme, $screenshot ) {
 
 		// Create theme directory.
 		$new_theme_path = get_theme_root() . DIRECTORY_SEPARATOR . $theme['slug'];
-
-		if ( $theme['subfolder'] ) {
-			$new_theme_path = get_theme_root() . DIRECTORY_SEPARATOR . $theme['subfolder'] . DIRECTORY_SEPARATOR . $theme['slug'];
-		}
 
 		if ( file_exists( $new_theme_path ) ) {
 			return new WP_Error( 'theme_already_exists', __( 'Theme already exists.', 'create-block-theme' ) );
@@ -91,18 +79,14 @@ class CBT_Theme_Create {
 			copy( $source, $new_theme_path . DIRECTORY_SEPARATOR . 'screenshot.png' );
 		}
 
-		if ( $theme['subfolder'] ) {
-			switch_theme( $theme['subfolder'] . '/' . $theme['slug'] );
-		} else {
-			switch_theme( $theme['slug'] );
-		}
+		switch_theme( $theme['slug'] );
 	}
 
 	public static function create_blank_theme( $theme, $screenshot ) {
 
 		// Create theme directory.
 		$source           = plugin_dir_path( __DIR__ ) . '../assets/boilerplate';
-		$blank_theme_path = get_theme_root() . DIRECTORY_SEPARATOR . $theme['subfolder'] . DIRECTORY_SEPARATOR . $theme['slug'];
+		$blank_theme_path = get_theme_root() . DIRECTORY_SEPARATOR . $theme['slug'];
 
 		if ( file_exists( $blank_theme_path ) ) {
 			return new WP_Error( 'theme_already_exists', __( 'Theme already exists.', 'create-block-theme' ) );
@@ -158,11 +142,7 @@ class CBT_Theme_Create {
 			file_put_contents( $theme_json_path, $theme_json_string );
 		}
 
-		if ( $theme['subfolder'] ) {
-			switch_theme( $theme['subfolder'] . '/' . $theme['slug'] );
-		} else {
-			switch_theme( $theme['slug'] );
-		}
+		switch_theme( $theme['slug'] );
 	}
 
 	private static function is_valid_screenshot( $file ) {

--- a/includes/create-theme/theme-utils.php
+++ b/includes/create-theme/theme-utils.php
@@ -91,52 +91,6 @@ class CBT_Theme_Utils {
 		}
 	}
 
-	/**
-	 * Relocate the theme to a new folder and activate the newly relocated theme.
-	 */
-	public static function relocate_theme( $new_theme_subfolder ) {
-
-		$current_theme_subfolder = '';
-		$theme_dir               = get_stylesheet();
-
-		$source      = get_theme_root() . DIRECTORY_SEPARATOR . $theme_dir;
-		$destination = get_theme_root() . DIRECTORY_SEPARATOR . $theme_dir;
-
-		if ( str_contains( get_stylesheet(), '/' ) ) {
-			$current_theme_subfolder = substr( get_stylesheet(), 0, strrpos( get_stylesheet(), '/' ) );
-			$theme_dir               = substr( get_stylesheet(), strrpos( get_stylesheet(), '/' ) + 1 );
-			$source                  = get_theme_root() . DIRECTORY_SEPARATOR . $current_theme_subfolder . DIRECTORY_SEPARATOR . $theme_dir;
-			$destination             = get_theme_root() . DIRECTORY_SEPARATOR . $theme_dir;
-		}
-
-		if ( $new_theme_subfolder ) {
-			$destination = get_theme_root() . DIRECTORY_SEPARATOR . $new_theme_subfolder . DIRECTORY_SEPARATOR . $theme_dir;
-			wp_mkdir_p( get_theme_root() . DIRECTORY_SEPARATOR . $new_theme_subfolder );
-		}
-
-		if ( $source === $destination ) {
-			return;
-		}
-
-		global $wp_filesystem;
-		if ( ! $wp_filesystem ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-			WP_Filesystem();
-		}
-
-		$success = move_dir( $source, $destination, false );
-
-		if ( ! $success ) {
-			return new \WP_Error( 'problem_moving', __( 'There was a problem moving the theme', 'create-block-theme' ) );
-		}
-
-		if ( $new_theme_subfolder ) {
-			switch_theme( $new_theme_subfolder . '/' . $theme_dir );
-		} else {
-			switch_theme( $theme_dir );
-		}
-	}
-
 	public static function is_valid_screenshot( $file ) {
 
 		$allowed_screenshot_types = array(

--- a/src/editor-sidebar/create-panel.js
+++ b/src/editor-sidebar/create-panel.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -36,14 +36,6 @@ const WP_MINIMUM_VERSIONS = generateWpVersions( WP_VERSION ); // eslint-disable-
 export const CreateThemePanel = ( { createType } ) => {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
-	const subfolder = useSelect( ( select ) => {
-		const stylesheet = select( 'core' ).getCurrentTheme().stylesheet;
-		if ( stylesheet.lastIndexOf( '/' ) > 1 ) {
-			return stylesheet.substring( 0, stylesheet.lastIndexOf( '/' ) );
-		}
-		return '';
-	}, [] );
-
 	const [ theme, setTheme ] = useState( {
 		name: '',
 		description: '',
@@ -52,7 +44,6 @@ export const CreateThemePanel = ( { createType } ) => {
 		author_uri: '',
 		tags_custom: '',
 		requires_wp: '',
-		subfolder,
 	} );
 
 	const cloneTheme = () => {

--- a/src/editor-sidebar/metadata-editor-modal.js
+++ b/src/editor-sidebar/metadata-editor-modal.js
@@ -56,7 +56,6 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 		recommended_plugins: '',
 		font_credits: '',
 		image_credits: '',
-		subfolder: '',
 	} );
 
 	const { createErrorNotice } = useDispatch( noticesStore );
@@ -78,13 +77,6 @@ export const ThemeMetadataEditorModal = ( { onRequestClose } ) => {
 			recommended_plugins: readmeData.recommended_plugins,
 			font_credits: readmeData.fonts,
 			image_credits: readmeData.images,
-			subfolder:
-				themeData.stylesheet.lastIndexOf( '/' ) > 1
-					? themeData.stylesheet.substring(
-							0,
-							themeData.stylesheet.lastIndexOf( '/' )
-					  )
-					: '',
 		} );
 	}, [] );
 
@@ -417,14 +409,6 @@ Image license`,
 						/>
 					</MediaUploadCheck>
 				</BaseControl>
-				<TextControl
-					__nextHasNoMarginBottom
-					label={ __( 'Theme Subfolder', 'create-block-theme' ) }
-					value={ theme.subfolder }
-					onChange={ ( value ) =>
-						setTheme( { ...theme, subfolder: value } )
-					}
-				/>
 			</VStack>
 			<Spacer />
 			<HStack

--- a/tests/test-theme-fonts.php
+++ b/tests/test-theme-fonts.php
@@ -393,7 +393,6 @@ class Test_Create_Block_Theme_Fonts extends WP_UnitTestCase {
 		$request->set_param( 'author', '' );
 		$request->set_param( 'author_uri', '' );
 		$request->set_param( 'tags_custom', '' );
-		$request->set_param( 'subfolder', '' );
 		$request->set_param( 'recommended_plugins', '' );
 
 		rest_do_request( $request );


### PR DESCRIPTION
Removes reference to it from the Metadata modal.

Does not leverage it when cloning a theme or creating a new theme.

Themes in folders continue to export as expected.  Themes cloned from themes in folders are cloned as expected, but the `/themes` folder is now targeted as the new theme's destination rather than whatever folder the origin theme was in.

Fixes #716 
Fixes #500