### PR TITLE
Add figcaption escaping for image and video blocks

### DIFF
--- a/includes/create-theme/theme-locale.php
+++ b/includes/create-theme/theme-locale.php
@@ -101,10 +101,6 @@ class CBT_Theme_Locale {
 				return array( '/(<pre[^>]*>)(.*?)(<\/pre>)/' );
 			case 'core/button':
 				return array( '/(<a[^>]*>)(.*?)(<\/a>)/' );
-			case 'core/image':
-			case 'core/cover':
-			case 'core/media-text':
-				return array( '/alt="(.*?)"/' );
 			case 'core/quote':
 			case 'core/pullquote':
 				return array(
@@ -117,6 +113,16 @@ class CBT_Theme_Locale {
 					'/(<th[^>]*>)(.*?)(<\/th>)/',
 					'/(<figcaption[^>]*>)(.*?)(<\/figcaption>)/',
 				);
+			case 'core/video':
+				return array( '/(<figcaption[^>]*>)(.*?)(<\/figcaption>)/' );
+			case 'core/image':
+				return array(
+					'/(<figcaption[^>]*>)(.*?)(<\/figcaption>)/',
+					'/(alt=")(.*?)(")/',
+				);
+			case 'core/cover':
+			case 'core/media-text':
+				return array( '/(alt=")(.*?)(")/' );
 			default:
 				return null;
 		}
@@ -158,19 +164,7 @@ class CBT_Theme_Locale {
 				case 'core/quote':
 				case 'core/pullquote':
 				case 'core/table':
-					$replace_content_callback = function ( $content, $pattern ) {
-						if ( empty( $content ) ) {
-							return;
-						}
-						return preg_replace_callback(
-							$pattern,
-							function( $matches ) {
-								return $matches[1] . self::escape_text_content( $matches[2] ) . $matches[3];
-							},
-							$content
-						);
-					};
-					break;
+				case 'core/video':
 				case 'core/image':
 				case 'core/cover':
 				case 'core/media-text':
@@ -181,7 +175,11 @@ class CBT_Theme_Locale {
 						return preg_replace_callback(
 							$pattern,
 							function( $matches ) {
-								return 'alt="' . self::escape_attribute( $matches[1] ) . '"';
+								// If the pattern is for attribute like alt="".
+								if ( str_ends_with( $matches[1], '="' ) ) {
+									return $matches[1] . self::escape_attribute( $matches[2] ) . $matches[3];
+								}
+								return $matches[1] . self::escape_text_content( $matches[2] ) . $matches[3];
 							},
 							$content
 						);

--- a/tests/CbtThemeLocale/escapeTextContentOfBlocks.php
+++ b/tests/CbtThemeLocale/escapeTextContentOfBlocks.php
@@ -125,12 +125,12 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
 
 			'image'                      => array(
 				'block_markup'    =>
-					'<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
-                    <figure class="wp-block-image size-large is-style-rounded"><img src="http://localhost/wp1/wp-content/themes/twentytwentyfour/assets/images/windows.webp" alt="Windows of a building in Nuremberg, Germany"/></figure>
+					'<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+                    <figure class="wp-block-image size-large"><img src="http://example.org/image.webp" alt="image alt text" class="wp-image-151"/><figcaption class="wp-element-caption">Image caption</figcaption></figure>
                     <!-- /wp:image -->',
 				'expected_markup' =>
-					'<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
-                    <figure class="wp-block-image size-large is-style-rounded"><img src="http://localhost/wp1/wp-content/themes/twentytwentyfour/assets/images/windows.webp" alt="<?php esc_attr_e(\'Windows of a building in Nuremberg, Germany\', \'test-locale-theme\');?>"/></figure>
+					'<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+                    <figure class="wp-block-image size-large"><img src="http://example.org/image.webp" alt="<?php esc_attr_e(\'image alt text\', \'test-locale-theme\');?>" class="wp-image-151"/><figcaption class="wp-element-caption"><?php esc_html_e(\'Image caption\', \'test-locale-theme\');?></figcaption></figure>
                     <!-- /wp:image -->',
 			),
 
@@ -186,6 +186,15 @@ class CBT_Theme_Locale_EscapeTextContentOfBlocks extends CBT_Theme_Locale_UnitTe
                     <!-- /wp:table -->',
 			),
 
+			'video'                      => array(
+				'block_markup'    => '<!-- wp:video -->
+<figure class="wp-block-video"><video controls src="http://example.org/video.mp4"></video><figcaption class="wp-element-caption">Video caption test</figcaption></figure>
+<!-- /wp:video -->',
+				'expected_markup' =>
+					'<!-- wp:video -->
+<figure class="wp-block-video"><video controls src="http://example.org/video.mp4"></video><figcaption class="wp-element-caption"><?php esc_html_e(\'Video caption test\', \'test-locale-theme\');?></figcaption></figure>
+<!-- /wp:video -->',
+			),
 		);
 	}
 }


### PR DESCRIPTION
## What?
- Adds figcaption escaping for image and video blocks
- Updates the image block text locale test
- Adds video block text locale test

### Why?
Fixes: https://github.com/WordPress/create-block-theme/issues/735