### PR TITLE
GitHub Actions: Install Subversion

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,6 +78,9 @@ jobs:
             - name: Run JavaScript unit tests
               run: npm run test:unit
 
+            - name: Install Subversion
+              run: sudo apt-get update -y && sudo apt-get install -y subversion
+
             - name: Run PHP tests
               run: |
                   mysql -uroot -h127.0.0.1 -e 'SELECT version()' \


### PR DESCRIPTION
I noticed that Test Suite CI failed on trunk branch.

Example: https://github.com/WordPress/create-block-theme/actions/runs/14313190404/job/40113732278

Looking at the error log, this was caused by the latest GitHub Actions runner removing svn, which was causing similar issues in Gutenberg projects:

- https://github.com/WordPress/gutenberg/pull/68837
- https://github.com/WordPress/gutenberg/pull/69047

Explicitly installing Subversion solved the problem.