### PR TITLE
Update wp-env configuration 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ build/
 
 # phpunit
 *.result.*
+
+dev-env/

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -6,7 +6,12 @@
 	"plugins": [ "." ],
 	"config": {
 		"WP_UPLOAD_MAX_FILESIZE": "128M",
-		"WP_MEMORY_LIMIT": "256M"
+		"WP_MEMORY_LIMIT": "256M",
+		"WP_ENVIRONMENT_TYPE": "development",
+		"WP_DEVELOPMENT_MODE": "all"
+	},
+	"mappings": {
+		"wp-content/themes": "./dev-env/themes"
 	},
 	"env": {
 		"development": {


### PR DESCRIPTION
Update wp-env configuration to use 'development mode' and to store themes in an accessible place for development.

with these environment variables set:
```
"WP_ENVIRONMENT_TYPE": "development",
"WP_DEVELOPMENT_MODE": "all"
```

Things like patterns are not cached and other improvements that make sure the WordPress environment provided by wp-env is the best to develop in.

Additionally the /themes folder is mapped to a local folder so that themes created and saved in the development environment can be easily observed.