### PR TITLE
wp-env: remove mappings field

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -10,9 +10,6 @@
 		"WP_ENVIRONMENT_TYPE": "development",
 		"WP_DEVELOPMENT_MODE": "all"
 	},
-	"mappings": {
-		"wp-content/themes": "./dev-env/themes"
-	},
 	"env": {
 		"development": {
 			"phpmyadminPort": 9000


### PR DESCRIPTION
In #764, the local `dev-env/themes` directory is now mapped to the `wp-content/themes` directory to make it easier to create or check changes to themes.

This may be convenient, but in the initial setup, there are no themes, which causes the following problems:

- The frontend is blank.
- You'll get a warning that the TT5 theme is broken.

https://github.com/user-attachments/assets/584c9e8d-090f-42d4-86f5-c5a762680f5b

The `mappings` field should be excluded from the default settings. Contributors who really need the mapping can do so by creating a `.wp-env.override.json` file like this:

```json
{
	"mappings": {
		"wp-content/themes": "./dev-env/themes"
	}
}
```