### PR TITLE
Localize Details block summary text

### DIFF
--- a/includes/create-theme/theme-locale.php
+++ b/includes/create-theme/theme-locale.php
@@ -123,6 +123,8 @@ class CBT_Theme_Locale {
 			case 'core/cover':
 			case 'core/media-text':
 				return array( '/(alt=")(.*?)(")/' );
+			case 'core/details':
+				return array( '/(<summary[^>]*>)(.*?)(<\/summary>)/' );
 			default:
 				return null;
 		}
@@ -168,6 +170,7 @@ class CBT_Theme_Locale {
 				case 'core/image':
 				case 'core/cover':
 				case 'core/media-text':
+				case 'core/details':
 					$replace_content_callback = function ( $content, $pattern ) {
 						if ( empty( $content ) ) {
 							return;


### PR DESCRIPTION
Part of #776

## Testing Instructions

- Insert a Details block into one of the templates and enter summary text.
- Save the template.
- From the CBT sidebar, click the Save button.
- Verify that the localization function is applied to the Summary text.

### Before

```jsx
<?php
/**
 * Title: home
 * Slug: twentytwentyfive/home
 * Inserter: no
 */
?>
<!-- wp:details -->
<details class="wp-block-details"><summary>Details Summary</summary><!-- wp:paragraph {"placeholder":"Type / to add a hidden block"} -->
<p><?php esc_html_e('Details Content', 'twentytwentyfive');?></p>
<!-- /wp:paragraph --></details>
<!-- /wp:details -->
```

### After

```html
<?php
/**
 * Title: home
 * Slug: twentytwentyfive/home
 * Inserter: no
 */
?>
<!-- wp:details -->
<details class="wp-block-details"><summary><?php esc_html_e('Details Summary', 'twentytwentyfive');?></summary><!-- wp:paragraph {"placeholder":"Type / to add a hidden block"} -->
<p><?php esc_html_e('Details Content', 'twentytwentyfive');?></p>
<!-- /wp:paragraph --></details>
<!-- /wp:details -->
```