### PR TITLE
Automatically enqueue style.css when creating a blank theme

### DIFF
--- a/assets/boilerplate/functions.php
+++ b/assets/boilerplate/functions.php
@@ -1,39 +1,55 @@
 <?php
-/**
- * Enqueue the theme's main stylesheet.
- *
- * This function checks if the `style.css` file exists in the theme directory
- * before attempting to enqueue it. It ensures that missing files do not
- * generate PHP warnings and also applies the theme version for cache busting.
- *
- * Usage: Hooked into 'wp_enqueue_scripts'.
- *
- * @since 1.0.0
- *
- * @see https://developer.wordpress.org/reference/functions/wp_enqueue_style/
- * @see https://developer.wordpress.org/reference/functions/get_stylesheet_directory/
- * @see https://developer.wordpress.org/reference/functions/get_stylesheet_uri/
- * @see https://developer.wordpress.org/reference/functions/wp_get_theme/
- *
- * @return void
- */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
-add_action(
-	'wp_enqueue_scripts',
-	function() {
-		$stylesheet_path = get_stylesheet_directory() . '/style.css';
-
-		if ( file_exists( $stylesheet_path ) ) {
-
-			wp_enqueue_style(
-				'theme-style',
-				get_stylesheet_uri(),
-				array(),
-				wp_get_theme()->get( 'Version' )
-			);
-
-		} else {
-			error_log( 'Stylesheet not found: ' . $stylesheet_path );
-		}
+if ( ! function_exists( 'theme_enqueue_style' ) ) {
+	/**
+	 * Enqueue the theme's main stylesheet on the frontend.
+	 *
+	 * This function checks if the `style.css` file exists in the theme directory
+	 * before attempting to enqueue it. It ensures that missing files do not
+	 * generate PHP warnings and also applies the theme version for cache busting.
+	 *
+	 * Usage: Hooked into 'wp_enqueue_scripts'.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @see https://developer.wordpress.org/reference/functions/wp_enqueue_style/
+	 * @see https://developer.wordpress.org/reference/functions/get_stylesheet_directory_uri/
+	 * @see https://developer.wordpress.org/reference/functions/wp_get_theme/
+	 *
+	 * @return void
+	 */
+	function theme_enqueue_style() {
+		wp_enqueue_style(
+			'theme-style',
+			get_template_directory_uri() . '/style.css',
+			array(),
+			wp_get_theme()->get( 'Version' )
+		);
 	}
-);
+	add_action( 'wp_enqueue_scripts', 'theme_enqueue_style' );
+}
+
+if ( ! function_exists( 'theme_enqueue_editor_style' ) ) {
+	/**
+	 * Enqueue the theme's main stylesheet in the block editor.
+	 *
+	 * This function enqueues the `style.css` file in the block editor to ensure
+	 * that the editor styles match the frontend styles. It uses the
+	 * `add_editor_style` function which is specifically designed for this purpose.
+	 *
+	 * Usage: Hooked into 'after_setup_theme'.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @see https://developer.wordpress.org/reference/functions/add_editor_style/
+	 *
+	 * @return void
+	 */
+	function theme_enqueue_editor_style() {
+		add_editor_style( 'style.css' );
+	}
+	add_action( 'after_setup_theme', 'theme_enqueue_editor_style' );
+}

--- a/assets/boilerplate/functions.php
+++ b/assets/boilerplate/functions.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Enqueue the theme's main stylesheet.
+ *
+ * This function checks if the `style.css` file exists in the theme directory
+ * before attempting to enqueue it. It ensures that missing files do not
+ * generate PHP warnings and also applies the theme version for cache busting.
+ *
+ * Usage: Hooked into 'wp_enqueue_scripts'.
+ *
+ * @since 1.0.0
+ *
+ * @see https://developer.wordpress.org/reference/functions/wp_enqueue_style/
+ * @see https://developer.wordpress.org/reference/functions/get_stylesheet_directory/
+ * @see https://developer.wordpress.org/reference/functions/get_stylesheet_uri/
+ * @see https://developer.wordpress.org/reference/functions/wp_get_theme/
+ *
+ * @return void
+ */
+
+add_action(
+	'wp_enqueue_scripts',
+	function() {
+		$stylesheet_path = get_stylesheet_directory() . '/style.css';
+
+		if ( file_exists( $stylesheet_path ) ) {
+
+			wp_enqueue_style(
+				'theme-style',
+				get_stylesheet_uri(),
+				array(),
+				wp_get_theme()->get( 'Version' )
+			);
+
+		} else {
+			error_log( 'Stylesheet not found: ' . $stylesheet_path );
+		}
+	}
+);

--- a/includes/create-theme/theme-create.php
+++ b/includes/create-theme/theme-create.php
@@ -124,6 +124,13 @@ class CBT_Theme_Create {
 			}
 		}
 
+		// Ensure functions.php is present to enqueue style.css
+		$functions_src  = $source . DIRECTORY_SEPARATOR . 'functions.php';
+		$functions_dest = $blank_theme_path . DIRECTORY_SEPARATOR . 'functions.php';
+		if ( file_exists( $functions_src ) ) {
+			copy( $functions_src, $functions_dest );
+		}
+
 		// Overwrite default screenshot if one is provided.
 		if ( static::is_valid_screenshot( $screenshot ) ) {
 			file_put_contents(


### PR DESCRIPTION
### What?
Automatically enqueue **style.css** when creating a blank theme with the Create Block Theme (CBT) plugin.

### Why?
Currently, when a blank theme is created, an empty **style.css** file is added, but adding CSS to it does not take effect until a **functions.php** file is added to enqueue the stylesheet. This creates confusion for users who want to work directly in the editor or prefer using **style.css** instead of the Additional CSS area. Automatically enqueuing **style.css** ensures that the stylesheet works out-of-the-box for those who want to use it.

**Fixes / Reference**
Fixes [#334](https://github.com/WordPress/create-block-theme/issues/334)

### How to test:

1. Install and activate the updated Create Block Theme plugin.
2. In the WP Admin, go to Appearance → Create Block Theme → Create Blank Theme.
3. Confirm that a new blank theme is generated.
4. Open the generated theme folder and check:
     - A functions.php file exists.
     - It contains enqueue code for style.css.
5. Add some simple CSS to **style.css**, for example:
```
body {
  background: pink;
}

```
6. Activate the new blank theme.
7. Visit the site’s frontend — the background should reflect your CSS changes (confirming that **style.css** is enqueued).
8. Optional: Inspect the source in the browser dev tools → check that **style.css** is being loaded.