### PR TITLE
Move $schema  and version attributes to the start of the theme.json file

### DIFF
--- a/includes/create-theme/resolver_additions.php
+++ b/includes/create-theme/resolver_additions.php
@@ -88,7 +88,17 @@ function cbt_augment_resolver_with_utilities() {
 				}
 				$schema = 'https://schemas.wp.org/' . $theme_json_version . '/theme.json';
 			}
-			$data['$schema'] = $schema;
+			// Ensure $schema is the first property and version is second in the JSON output.
+			$ordered_data = array( '$schema' => $schema );
+
+			// Add version as the second property if it exists.
+			if ( isset( $data['version'] ) ) {
+				$ordered_data['version'] = $data['version'];
+				unset( $data['version'] );
+			}
+
+			// Merge the remaining data.
+			$data = array_merge( $ordered_data, $data );
 			return static::stringify( $data );
 		}
 


### PR DESCRIPTION
Move  and version attributes to the start of the theme.json file as this helps editing in IDEs. Fixes https://github.com/WordPress/create-block-theme/issues/779

## To test
1. Try exporting your theme and notice that $schema and version are at the top of theme.json
2. Try saving your theme and notice that $schema and version are at the top of theme.json