### PR TITLE
Save all patterns

### DIFF
--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -30,14 +30,7 @@ class CBT_Theme_Patterns {
 		$pattern_category_list = get_the_terms( $pattern->id, 'wp_pattern_category' );
 		$pattern->categories   = ! empty( $pattern_category_list ) ? join( ', ', wp_list_pluck( $pattern_category_list, 'name' ) ) : '';
 		$pattern->sync_status  = get_post_meta( $pattern->id, 'wp_pattern_sync_status', true );
-		// Store the raw content separately for processing
-		$pattern->content = $pattern_post->post_content;
-
-		return $pattern;
-	}
-
-	public static function wrap_pattern_in_php_file( $pattern ) {
-		$pattern_content  = <<<PHP
+		$pattern->content      = <<<PHP
 		<?php
 		/**
 		 * Title: {$pattern->title}
@@ -45,9 +38,9 @@ class CBT_Theme_Patterns {
 		 * Categories: {$pattern->categories}
 		 */
 		?>
-		{$pattern->content}
+		{$pattern_post->post_content}
 		PHP;
-		$pattern->content = $pattern_content;
+
 		return $pattern;
 	}
 
@@ -138,9 +131,6 @@ class CBT_Theme_Patterns {
 				CBT_Theme_Media::add_media_to_local( $pattern->media );
 			}
 		}
-
-		// Wrap the pattern content in the PHP file structure with metadata header
-		$pattern = self::wrap_pattern_in_php_file( $pattern );
 
 		return $pattern;
 	}

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -29,7 +29,6 @@ class CBT_Theme_Patterns {
 		$pattern->slug         = wp_get_theme()->get( 'TextDomain' ) . '/' . $pattern->name;
 		$pattern_category_list = get_the_terms( $pattern->id, 'wp_pattern_category' );
 		$pattern->categories   = ! empty( $pattern_category_list ) ? join( ', ', wp_list_pluck( $pattern_category_list, 'name' ) ) : '';
-		$pattern->sync_status  = get_post_meta( $pattern->id, 'wp_pattern_sync_status', true );
 		$pattern->content      = <<<PHP
 		<?php
 		/**

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -30,7 +30,14 @@ class CBT_Theme_Patterns {
 		$pattern_category_list = get_the_terms( $pattern->id, 'wp_pattern_category' );
 		$pattern->categories   = ! empty( $pattern_category_list ) ? join( ', ', wp_list_pluck( $pattern_category_list, 'name' ) ) : '';
 		$pattern->sync_status  = get_post_meta( $pattern->id, 'wp_pattern_sync_status', true );
-		$pattern->content      = <<<PHP
+		// Store the raw content separately for processing
+		$pattern->content = $pattern_post->post_content;
+
+		return $pattern;
+	}
+
+	public static function wrap_pattern_in_php_file( $pattern ) {
+		$pattern_content  = <<<PHP
 		<?php
 		/**
 		 * Title: {$pattern->title}
@@ -38,9 +45,9 @@ class CBT_Theme_Patterns {
 		 * Categories: {$pattern->categories}
 		 */
 		?>
-		{$pattern_post->post_content}
+		{$pattern->content}
 		PHP;
-
+		$pattern->content = $pattern_content;
 		return $pattern;
 	}
 
@@ -71,7 +78,7 @@ class CBT_Theme_Patterns {
 		return '<!-- wp:pattern ' . $attributes_json . ' /-->';
 	}
 
-	public static function replace_local_pattern_references( $pattern ) {
+	public static function replace_local_pattern_references( $pattern, $options = null ) {
 		// Find any references to pattern in templates
 		$templates_to_update = array();
 		$args                = array(
@@ -89,7 +96,7 @@ class CBT_Theme_Patterns {
 		$templates_to_update = array_unique( $templates_to_update );
 
 		// Only update templates that reference the pattern
-		CBT_Theme_Templates::add_templates_to_local( 'all', null, null, null, $templates_to_update );
+		CBT_Theme_Templates::add_templates_to_local( 'all', null, null, $options, $templates_to_update );
 
 		// List all template and pattern files in the theme
 		$base_dir       = get_stylesheet_directory();
@@ -132,6 +139,9 @@ class CBT_Theme_Patterns {
 			}
 		}
 
+		// Wrap the pattern content in the PHP file structure with metadata header
+		$pattern = self::wrap_pattern_in_php_file( $pattern );
+
 		return $pattern;
 	}
 
@@ -160,41 +170,38 @@ class CBT_Theme_Patterns {
 				$pattern        = self::prepare_pattern_for_export( $pattern, $options );
 				$pattern_exists = false;
 
-				// Check pattern is synced before adding to theme.
-				if ( 'unsynced' !== $pattern->sync_status ) {
-					// Check pattern name doesn't already exist before creating the file.
-					$existing_patterns = glob( $patterns_dir . DIRECTORY_SEPARATOR . '*.php' );
-					foreach ( $existing_patterns as $existing_pattern ) {
-						if ( strpos( $existing_pattern, $pattern->name . '.php' ) !== false ) {
-							$pattern_exists = true;
-						}
+				// Check pattern name doesn't already exist before creating the file.
+				$existing_patterns = glob( $patterns_dir . DIRECTORY_SEPARATOR . '*.php' );
+				foreach ( $existing_patterns as $existing_pattern ) {
+					if ( strpos( $existing_pattern, $pattern->name . '.php' ) !== false ) {
+						$pattern_exists = true;
 					}
-
-					if ( $pattern_exists ) {
-						return new WP_Error(
-							'pattern_already_exists',
-							sprintf(
-								/* Translators: Pattern name. */
-								__(
-									'A pattern with this name already exists: "%s".',
-									'create-block-theme'
-								),
-								$pattern->name
-							)
-						);
-					}
-
-					// Create the pattern file.
-					file_put_contents(
-						$patterns_dir . DIRECTORY_SEPARATOR . $pattern->name . '.php',
-						$pattern->content
-					);
-
-					self::replace_local_pattern_references( $pattern );
-
-					// Remove it from the database to ensure that these patterns are loaded from the theme.
-					wp_delete_post( $pattern->id, true );
 				}
+
+				if ( $pattern_exists ) {
+					return new WP_Error(
+						'pattern_already_exists',
+						sprintf(
+							/* Translators: Pattern name. */
+							__(
+								'A pattern with this name already exists: "%s".',
+								'create-block-theme'
+							),
+							$pattern->name
+						)
+					);
+				}
+
+				// Create the pattern file.
+				file_put_contents(
+					$patterns_dir . DIRECTORY_SEPARATOR . $pattern->name . '.php',
+					$pattern->content
+				);
+
+				self::replace_local_pattern_references( $pattern, $options );
+
+				// Remove it from the database to ensure that these patterns are loaded from the theme.
+				wp_delete_post( $pattern->id, true );
 			}
 		}
 	}

--- a/src/editor-sidebar/save-panel.js
+++ b/src/editor-sidebar/save-panel.js
@@ -158,9 +158,9 @@ export const SaveThemePanel = () => {
 				/>
 				<CheckboxControl
 					__nextHasNoMarginBottom
-					label={ __( 'Save Synced Patterns', 'create-block-theme' ) }
+					label={ __( 'Save Patterns', 'create-block-theme' ) }
 					help={ __(
-						'Any synced patterns created in the Editor will be moved to the theme. Note that this will delete all synced patterns from the Editor and any references in templates will be made relative to the theme.',
+						'All patterns created in the Editor will be moved to the theme. Note that this will delete all patterns from the Editor and any references in templates will be made relative to the theme.',
 						'create-block-theme'
 					) }
 					checked={ preference.savePatterns }


### PR DESCRIPTION
Enables saving all patterns (both synced and unsynced) to the theme, not just synced patterns. Previously, only synced patterns would be exported when using the "Save Patterns" option.

## What Changed

### User-Facing Changes:
  - The "Save Synced Patterns" option has been renamed to "Save Patterns"
  - All patterns created in the Editor (both synced and unsynced) will now be saved to the theme when this option is enabled
  - Unsynced patterns are now included in the export and removal process

 ### Technical Changes:
  - Refactored pattern processing to store raw content first, then wrap in PHP file structure after processing
  - Options are now threaded through to replace_local_pattern_references() to ensure consistent processing
  - Removed the sync status check that previously filtered out unsynced patterns

##  Why?
This allows theme designers to create their own patterns for themes.

##  Testing Instructions

### Test Case 1: Save All Pattern Types

  1. Go to Appearance → Editor → Patterns
  2. Create 2 patterns - a synced and an unsynced.
  3. Go to Create Block Theme in the editor
  4. Save Changes to Theme
  5. Enable "Save Patterns" checkbox
  6. Click "Save Changes"
  7. ✅ Expected: Both patterns should be saved to /patterns/ directory as .php files
  8. ✅ Expected: Both patterns should be deleted from the Editor
  9. ✅ Expected: Patterns should now load from the theme instead of the database

###  Test Case 2: Duplicate Pattern Names

  1. Manually create a pattern file: wp-content/themes/your-theme/patterns/test-pattern.php
  2. In the Editor, create a new pattern with the title "Test Pattern" (same slug)
  3. Try to save patterns using Create Block Theme
  4. ✅ Expected: Should show an error: "A pattern with this name already exists: test-pattern"

###  Test Case 3: Localization Options

  1. Create a pattern with text content: "Hello World"
  2. Go to Create Block Theme overwrite screen
  3. Enable both:
    - ✅ "Save Patterns"
    - ✅ "Localize Text"
  4. Save changes
  5. Inspect the pattern file
  6. ✅ Expected: Text should be wrapped in localization functions: <?php esc_html_e('Hello World', 'theme-slug');?>

 ### Test Case 4: Image Localization

  1. Create a pattern with an image from the Media Library
  2. Enable both:
    - ✅ "Save Patterns"
    - ✅ "Localize Images"
  3. Save changes
  4. ✅ Expected: Image should be copied to /assets/ directory
  5. ✅ Expected: Pattern should reference the local image path

 ### Test Case 5: Templates Referencing Patterns

  1. Create a pattern and add it to a template
  2. Modify the template (add a paragraph block)
  3. Save with both "Save Template Changes" and "Save Patterns" enabled
  4. ✅ Expected: Both the template and pattern should be saved
  5. ✅ Expected: Template changes should be preserved
  6. ✅ Expected: Pattern reference should be updated correctly

  ### Test Case 6: UI Label Update

  1. Go to Create Block Theme overwrite screen
  2. ✅ Expected: Checkbox should read "Save Patterns" (not "Save Synced Patterns")
  3. ✅ Expected: Help text should say "All patterns created in the Editor will be moved to the theme..."

