### PR TITLE
Add full and wide width support for blank theme.

### DIFF
--- a/assets/boilerplate/templates/index.html
+++ b/assets/boilerplate/templates/index.html
@@ -2,30 +2,30 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:query {"layout":{"inherit":true}} -->
-	<div class="wp-block-query">
-		<!-- wp:post-template -->
-		<!-- wp:group -->
-		<div class="wp-block-group">
+	<!-- wp:query {"align":"full","layout":{"type":"default"}} -->
+	<div class="wp-block-query alignfull">
+		<!-- wp:post-template {"align":"full","layout":{"type":"default"}} -->
+		<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+		<div class="wp-block-group alignfull">
 			<!-- wp:post-title {"isLink":true} /-->
 			<!-- wp:post-featured-image {"isLink":true} /-->
-			<!-- wp:post-content /-->
-			<!-- wp:group {"layout":{"type":"flex"}, "style":{"typography":{"fontSize":"14px"}}} -->
+			<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
+			<!-- wp:group {"style":{"typography":{"fontSize":"14px"}},"layout":{"type":"flex"}} -->
 			<div class="wp-block-group" style="font-size:14px">
 				<!-- wp:post-author {"showAvatar":false,"showBio":false} /-->
 				<!-- wp:post-date {"isLink":true} /-->
 				<!-- wp:post-terms {"term":"category"} /-->
-				<!-- wp:post-terms {"term": "post_tag"} /-->
+				<!-- wp:post-terms {"term":"post_tag"} /-->
 			</div>
 			<!-- /wp:group -->
-			<!-- wp:spacer {"height":40} -->
+			<!-- wp:spacer {"height":"40px"} -->
 			<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 			<!-- /wp:spacer -->
 		</div>
 		<!-- /wp:group -->
 		<!-- /wp:post-template -->
-		<!-- wp:group {"layout":{"inherit":true}} -->
-			<div class="wp-block-group">
+		<!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
+		<div class="wp-block-group">
 			<!-- wp:query-pagination -->
 				<!-- wp:query-pagination-previous /-->
 
@@ -33,9 +33,9 @@
 
 				<!-- wp:query-pagination-next /-->
 			<!-- /wp:query-pagination -->
-			</div>
-			<!-- /wp:group -->
 		</div>
+		<!-- /wp:group -->
+	</div>
 	<!-- /wp:query -->
 </main>
 <!-- /wp:group -->


### PR DESCRIPTION
Add full and wide width support for blank theme.

This is achieved by setting the `align` property to `full` for blocks like the query block and post-template block. It uses the same method as “Twenty Twenty-Five”. (https://github.com/WordPress/twentytwentyfive/blob/trunk/patterns/template-query-loop.php)


|Before|After|
|-|-|
|<img width="2400" height="2400" alt="before" src="https://github.com/user-attachments/assets/e3dc1f18-fefe-41af-9b92-73657cc29e27" />|<img width="2400" height="2400" alt="after" src="https://github.com/user-attachments/assets/5576b0ae-3bf3-4df3-964e-ab897276ac16" />|