### PR TITLE
Update "Tested up to" version to 6.9

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg, mikachan, onemaggie, pbking, scruffian, mmaattiiaass, jffng, madhudollu, egregor, vcanales, jeffikus, cwhitmore
 Tags: themes, theme, block-theme
 Requires at least: 6.7
-Tested up to: 6.8
+Tested up to: 6.9
 Stable tag: 2.7.0
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
This updates the "Tested up to" version to WordPress 6.9.

I'll release a new version of the plugin after this has been merged.