### PR TITLE
Fix: Localize repeated background images in Cover block (#794)

### DIFF
--- a/includes/create-theme/theme-media.php
+++ b/includes/create-theme/theme-media.php
@@ -56,25 +56,36 @@ class CBT_Theme_Media {
 				}
 			}
 
-			// Gets the absolute URLs of background images in these blocks
+			// Gets the absolute URLs of background images in Cover blocks
 			if ( 'core/cover' === $block['blockName'] ) {
+				// 1) Parse inline styles for background-image
 				$html = new WP_HTML_Tag_Processor( $block['innerHTML'] );
 				while ( $html->next_tag( 'div' ) ) {
 					$style = $html->get_attribute( 'style' );
 					if ( $style ) {
 						$matches = array();
-						preg_match( '/background-image: url\((.*)\)/', $style, $matches );
+						// Match url(...) with or without quotes
+						preg_match( '/background-image:\s*url\(("|\')?(.*?)(\1)\)/i', $style, $matches );
 						if ( isset( $matches[1] ) ) {
-							$url = $matches[1];
+							// In quoted match, the URL is in group 2; otherwise group 2 also holds the URL
+							$url = isset( $matches[2] ) ? $matches[2] : $matches[1];
 							if ( CBT_Theme_Utils::is_absolute_url( $url ) ) {
 								$media[] = $url;
 							}
 						}
 					}
 				}
+
+				// 2) Handle repeated background set via block attributes
+				if ( isset( $block['attrs']['style']['background']['backgroundImage']['url'] ) ) {
+					$cover_bg_url = $block['attrs']['style']['background']['backgroundImage']['url'];
+					if ( CBT_Theme_Utils::is_absolute_url( $cover_bg_url ) ) {
+						$media[] = $cover_bg_url;
+					}
+				}
 			}
 
-			// Gets the absolute URLs of background images in these blocks
+			// Gets the absolute URLs of background images in Group blocks
 			if ( 'core/group' === $block['blockName'] ) {
 				if ( isset( $block['attrs']['style']['background']['backgroundImage']['url'] ) && CBT_Theme_Utils::is_absolute_url( $block['attrs']['style']['background']['backgroundImage']['url'] ) ) {
 					$media[] = $block['attrs']['style']['background']['backgroundImage']['url'];

--- a/tests/test-theme-templates.php
+++ b/tests/test-theme-templates.php
@@ -372,4 +372,20 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'This is text to localize', $new_template->content );
 	}
 
+	public function test_localize_cover_repeated_background_via_attrs() {
+		$template          = new stdClass();
+		$template->content = '<!-- wp:cover {"style":{"background":{"backgroundImage":{"url":"http://example.com/bg.png","repeat":"repeat"}}}} -->\n'
+			. '<div class="wp-block-cover"><div class="wp-block-cover__inner-container"></div></div><!-- /wp:cover -->';
+		$new_template      = CBT_Theme_Templates::prepare_template_for_export( $template, null, array( 'localizeMedia' => true ) );
+		$this->assertStringContainsString( '<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/bg.png', $new_template->content );
+	}
+
+	public function test_localize_cover_repeated_background_inline_style() {
+		$template          = new stdClass();
+		$template->content = '<!-- wp:cover -->\n'
+			. '<div class="wp-block-cover" style="background-image:url(\'http://example.com/pattern.webp\');background-repeat:repeat"></div><!-- /wp:cover -->';
+		$new_template      = CBT_Theme_Templates::prepare_template_for_export( $template, null, array( 'localizeMedia' => true ) );
+		$this->assertStringContainsString( '<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pattern.webp', $new_template->content );
+	}
+
 }

--- a/tests/test-theme-templates.php
+++ b/tests/test-theme-templates.php
@@ -376,7 +376,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 		$template          = new stdClass();
 		$template->content = '<!-- wp:cover {"style":{"background":{"backgroundImage":{"url":"http://example.com/bg.png","repeat":"repeat"}}}} -->\n'
 			. '<div class="wp-block-cover"><div class="wp-block-cover__inner-container"></div></div><!-- /wp:cover -->';
-		$new_template      = CBT_Theme_Templates::prepare_template_for_export( $template, null, array( 'localizeMedia' => true ) );
+		$new_template      = CBT_Theme_Templates::prepare_template_for_export( $template, null, array( 'localizeImages' => true ) );
 		$this->assertStringContainsString( '<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/bg.png', $new_template->content );
 	}
 
@@ -384,7 +384,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 		$template          = new stdClass();
 		$template->content = '<!-- wp:cover -->\n'
 			. '<div class="wp-block-cover" style="background-image:url(\'http://example.com/pattern.webp\');background-repeat:repeat"></div><!-- /wp:cover -->';
-		$new_template      = CBT_Theme_Templates::prepare_template_for_export( $template, null, array( 'localizeMedia' => true ) );
+		$new_template      = CBT_Theme_Templates::prepare_template_for_export( $template, null, array( 'localizeImages' => true ) );
 		$this->assertStringContainsString( '<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pattern.webp', $new_template->content );
 	}
 

--- a/tests/test-theme-templates.php
+++ b/tests/test-theme-templates.php
@@ -374,6 +374,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 
 	public function test_localize_cover_repeated_background_via_attrs() {
 		$template          = new stdClass();
+		$template->slug    = 'test-template';
 		$template->content = '<!-- wp:cover {"style":{"background":{"backgroundImage":{"url":"http://example.com/bg.png","repeat":"repeat"}}}} -->\n'
 			. '<div class="wp-block-cover"><div class="wp-block-cover__inner-container"></div></div><!-- /wp:cover -->';
 		$new_template      = CBT_Theme_Templates::prepare_template_for_export( $template, null, array( 'localizeImages' => true ) );
@@ -382,6 +383,7 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 
 	public function test_localize_cover_repeated_background_inline_style() {
 		$template          = new stdClass();
+		$template->slug    = 'test-template';
 		$template->content = '<!-- wp:cover -->\n'
 			. '<div class="wp-block-cover" style="background-image:url(\'http://example.com/pattern.webp\');background-repeat:repeat"></div><!-- /wp:cover -->';
 		$new_template      = CBT_Theme_Templates::prepare_template_for_export( $template, null, array( 'localizeImages' => true ) );

--- a/tests/test-theme-templates.php
+++ b/tests/test-theme-templates.php
@@ -374,19 +374,17 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 
 	public function test_localize_cover_repeated_background_via_attrs() {
 		$template          = new stdClass();
-		$template->slug    = 'test-template';
 		$template->content = '<!-- wp:cover {"style":{"background":{"backgroundImage":{"url":"http://example.com/bg.png","repeat":"repeat"}}}} -->\n'
 			. '<div class="wp-block-cover"><div class="wp-block-cover__inner-container"></div></div><!-- /wp:cover -->';
-		$new_template      = CBT_Theme_Templates::prepare_template_for_export( $template, null, array( 'localizeImages' => true ) );
+		$new_template      = CBT_Theme_Media::make_template_images_local( $template );
 		$this->assertStringContainsString( '<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/bg.png', $new_template->content );
 	}
 
 	public function test_localize_cover_repeated_background_inline_style() {
 		$template          = new stdClass();
-		$template->slug    = 'test-template';
 		$template->content = '<!-- wp:cover -->\n'
 			. '<div class="wp-block-cover" style="background-image:url(\'http://example.com/pattern.webp\');background-repeat:repeat"></div><!-- /wp:cover -->';
-		$new_template      = CBT_Theme_Templates::prepare_template_for_export( $template, null, array( 'localizeImages' => true ) );
+		$new_template      = CBT_Theme_Media::make_template_images_local( $template );
 		$this->assertStringContainsString( '<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pattern.webp', $new_template->content );
 	}
 


### PR DESCRIPTION
# Fix: Localize repeated background images in Cover block

## Summary
Localizes images used as “repeated background” in `core/cover` when “Localize images” is enabled. These images are copied into the theme’s assets and referenced via theme-relative URLs, removing dependency on the original uploads directory.

## Fixes
- #794

## Changes
- includes/create-theme/theme-media.php
  - Enhance `background-image` URL parsing to support quoted and unquoted `url(...)`.
  - Collect `attrs.style.background.backgroundImage.url` (Cover’s “Repeat background” attribute path).
- tests/test-theme-templates.php
  - Add `test_localize_cover_repeated_background_via_attrs()` to verify attribute-defined repeated backgrounds localize to `/assets/images/bg.png` and are replaced with a theme-relative URL.
  - Add `test_localize_cover_repeated_background_inline_style()` to verify inline `background-image:url(...)` repeated backgrounds localize to `/assets/images/pattern.webp`.

## Rationale
Repeated background images set via the Cover block’s attributes were missed, leaving absolute upload URLs. The media extractor now covers both inline CSS and attribute-defined backgrounds to align with “Localize images”.

## Risk/Compatibility
- Scoped to media extraction logic for Cover/Group backgrounds.
- Follows existing asset path conventions (`/assets/images/`) and parent/child theme URL handling.

## Testing
- Two new unit tests cover attribute and inline style scenarios alongside existing localization tests.

## Checklist
- [x] Changes are limited to localization of Cover repeated backgrounds
- [x] Unit tests added
- [x] No breaking changes to existing APIs or behavior