### PR TITLE
Fix: Sync fluid typography size with fluid.max (#789)

### DIFF
--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/create-theme/theme-utils.php';
 require_once __DIR__ . '/create-theme/theme-readme.php';
 require_once __DIR__ . '/create-theme/theme-fonts.php';
 require_once __DIR__ . '/create-theme/theme-create.php';
+require_once __DIR__ . '/create-theme/theme-fluid-typography.php';
 
 /**
  * The api functionality of the plugin leveraged by the site editor UI.

--- a/includes/create-theme/theme-fluid-typography.php
+++ b/includes/create-theme/theme-fluid-typography.php
@@ -43,10 +43,9 @@ class CBT_Theme_Fluid_Typography {
 	 * Sync fluid typography in global styles before saving.
 	 *
 	 * @param stdClass $prepared_post The prepared post object.
-	 * @param WP_REST_Request $request The REST request object.
 	 * @return stdClass The modified prepared post object.
 	 */
-	public static function sync_global_styles_fluid_typography( $prepared_post, $request ) {
+	public static function sync_global_styles_fluid_typography( $prepared_post ) {
 		if ( ! isset( $prepared_post->post_content ) ) {
 			return $prepared_post;
 		}

--- a/includes/create-theme/theme-fluid-typography.php
+++ b/includes/create-theme/theme-fluid-typography.php
@@ -1,0 +1,69 @@
+<?php
+
+class CBT_Theme_Fluid_Typography {
+
+	/**
+	 * Sync the size property with fluid.max in font sizes.
+	 * This ensures that when fluid typography is edited, the size property
+	 * stays in sync with the maximum fluid size.
+	 *
+	 * @param array $data The theme.json data to process.
+	 * @return array The processed data with synced sizes.
+	 */
+	public static function sync_fluid_typography_sizes( $data ) {
+		if ( ! isset( $data['settings']['typography']['fontSizes'] ) ) {
+			return $data;
+		}
+
+		$font_sizes = $data['settings']['typography']['fontSizes'];
+
+		foreach ( $font_sizes as $key => $font_size ) {
+			// Check if this font size has fluid settings
+			if ( isset( $font_size['fluid'] ) && is_array( $font_size['fluid'] ) ) {
+				// If fluid.max is set, sync it with size
+				if ( isset( $font_size['fluid']['max'] ) ) {
+					$font_sizes[ $key ]['size'] = $font_size['fluid']['max'];
+				}
+			}
+		}
+
+		$data['settings']['typography']['fontSizes'] = $font_sizes;
+
+		return $data;
+	}
+
+	/**
+	 * Hook into the global styles REST API to sync fluid typography sizes.
+	 */
+	public static function init() {
+		add_filter( 'rest_pre_insert_wp_global_styles', array( __CLASS__, 'sync_global_styles_fluid_typography' ), 10, 2 );
+	}
+
+	/**
+	 * Sync fluid typography in global styles before saving.
+	 *
+	 * @param stdClass $prepared_post The prepared post object.
+	 * @param WP_REST_Request $request The REST request object.
+	 * @return stdClass The modified prepared post object.
+	 */
+	public static function sync_global_styles_fluid_typography( $prepared_post, $request ) {
+		if ( ! isset( $prepared_post->post_content ) ) {
+			return $prepared_post;
+		}
+
+		$data = json_decode( $prepared_post->post_content, true );
+
+		if ( ! is_array( $data ) ) {
+			return $prepared_post;
+		}
+
+		$data = self::sync_fluid_typography_sizes( $data );
+
+		$prepared_post->post_content = wp_json_encode( $data );
+
+		return $prepared_post;
+	}
+}
+
+// Initialize the fluid typography sync on plugins_loaded
+add_action( 'plugins_loaded', array( 'CBT_Theme_Fluid_Typography', 'init' ) );

--- a/tests/test-fluid-typography.php
+++ b/tests/test-fluid-typography.php
@@ -53,7 +53,7 @@ class Test_Create_Block_Theme_Fluid_Typography extends WP_UnitTestCase {
 	 * Test that global styles filter works correctly
 	 */
 	public function test_sync_global_styles_fluid_typography() {
-		$prepared_post           = new stdClass();
+		$prepared_post                = new stdClass();
 		$prepared_post->post_content = wp_json_encode(
 			array(
 				'settings' => array(
@@ -118,7 +118,7 @@ class Test_Create_Block_Theme_Fluid_Typography extends WP_UnitTestCase {
 	 * Test that invalid JSON in global styles filter is handled gracefully
 	 */
 	public function test_sync_global_styles_with_invalid_json() {
-		$prepared_post           = new stdClass();
+		$prepared_post                = new stdClass();
 		$prepared_post->post_content = 'invalid json';
 
 		$result = CBT_Theme_Fluid_Typography::sync_global_styles_fluid_typography( $prepared_post );

--- a/tests/test-fluid-typography.php
+++ b/tests/test-fluid-typography.php
@@ -53,7 +53,7 @@ class Test_Create_Block_Theme_Fluid_Typography extends WP_UnitTestCase {
 	 * Test that global styles filter works correctly
 	 */
 	public function test_sync_global_styles_fluid_typography() {
-		$prepared_post                = new stdClass();
+		$prepared_post               = new stdClass();
 		$prepared_post->post_content = wp_json_encode(
 			array(
 				'settings' => array(
@@ -118,7 +118,7 @@ class Test_Create_Block_Theme_Fluid_Typography extends WP_UnitTestCase {
 	 * Test that invalid JSON in global styles filter is handled gracefully
 	 */
 	public function test_sync_global_styles_with_invalid_json() {
-		$prepared_post                = new stdClass();
+		$prepared_post               = new stdClass();
 		$prepared_post->post_content = 'invalid json';
 
 		$result = CBT_Theme_Fluid_Typography::sync_global_styles_fluid_typography( $prepared_post );

--- a/tests/test-fluid-typography.php
+++ b/tests/test-fluid-typography.php
@@ -53,7 +53,7 @@ class Test_Create_Block_Theme_Fluid_Typography extends WP_UnitTestCase {
 	 * Test that global styles filter works correctly
 	 */
 	public function test_sync_global_styles_fluid_typography() {
-		$prepared_post = new stdClass();
+		$prepared_post           = new stdClass();
 		$prepared_post->post_content = wp_json_encode(
 			array(
 				'settings' => array(
@@ -74,9 +74,7 @@ class Test_Create_Block_Theme_Fluid_Typography extends WP_UnitTestCase {
 			)
 		);
 
-		$request = new WP_REST_Request();
-
-		$result = CBT_Theme_Fluid_Typography::sync_global_styles_fluid_typography( $prepared_post, $request );
+		$result = CBT_Theme_Fluid_Typography::sync_global_styles_fluid_typography( $prepared_post );
 
 		$data = json_decode( $result->post_content, true );
 
@@ -120,12 +118,10 @@ class Test_Create_Block_Theme_Fluid_Typography extends WP_UnitTestCase {
 	 * Test that invalid JSON in global styles filter is handled gracefully
 	 */
 	public function test_sync_global_styles_with_invalid_json() {
-		$prepared_post = new stdClass();
+		$prepared_post           = new stdClass();
 		$prepared_post->post_content = 'invalid json';
 
-		$request = new WP_REST_Request();
-
-		$result = CBT_Theme_Fluid_Typography::sync_global_styles_fluid_typography( $prepared_post, $request );
+		$result = CBT_Theme_Fluid_Typography::sync_global_styles_fluid_typography( $prepared_post );
 
 		// Should return the prepared post unchanged
 		$this->assertEquals( 'invalid json', $result->post_content );

--- a/tests/test-fluid-typography.php
+++ b/tests/test-fluid-typography.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * @package Create_Block_Theme
+ * @group fluid-typography
+ */
+class Test_Create_Block_Theme_Fluid_Typography extends WP_UnitTestCase {
+
+	/**
+	 * Test that fluid typography sizes are synced correctly
+	 */
+	public function test_sync_fluid_typography_sizes() {
+		$data = array(
+			'settings' => array(
+				'typography' => array(
+					'fontSizes' => array(
+						array(
+							'slug'  => 'custom-fluid',
+							'name'  => 'Custom Fluid',
+							'fluid' => array(
+								'min' => '1.5rem',
+								'max' => '5.63rem',
+							),
+							'size'  => '3rem', // Old value, should be updated
+						),
+						array(
+							'slug' => 'normal',
+							'name' => 'Normal',
+							'size' => '1rem', // No fluid, should remain unchanged
+						),
+					),
+				),
+			),
+		);
+
+		$result = CBT_Theme_Fluid_Typography::sync_fluid_typography_sizes( $data );
+
+		// Verify the fluid size was synced
+		$this->assertEquals(
+			'5.63rem',
+			$result['settings']['typography']['fontSizes'][0]['size'],
+			'Fluid typography size should be synced with fluid.max'
+		);
+
+		// Verify the non-fluid size remained unchanged
+		$this->assertEquals(
+			'1rem',
+			$result['settings']['typography']['fontSizes'][1]['size'],
+			'Non-fluid typography size should remain unchanged'
+		);
+	}
+
+	/**
+	 * Test that global styles filter works correctly
+	 */
+	public function test_sync_global_styles_fluid_typography() {
+		$prepared_post = new stdClass();
+		$prepared_post->post_content = wp_json_encode(
+			array(
+				'settings' => array(
+					'typography' => array(
+						'fontSizes' => array(
+							array(
+								'slug'  => 'custom-fluid',
+								'name'  => 'Custom Fluid',
+								'fluid' => array(
+									'min' => '1.5rem',
+									'max' => '5.63rem',
+								),
+								'size'  => '3rem',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$request = new WP_REST_Request();
+
+		$result = CBT_Theme_Fluid_Typography::sync_global_styles_fluid_typography( $prepared_post, $request );
+
+		$data = json_decode( $result->post_content, true );
+
+		$this->assertEquals(
+			'5.63rem',
+			$data['settings']['typography']['fontSizes'][0]['size'],
+			'Global styles should have synced fluid typography sizes'
+		);
+	}
+
+	/**
+	 * Test that missing typography doesn't cause errors
+	 */
+	public function test_sync_with_no_typography() {
+		$data = array(
+			'settings' => array(),
+		);
+
+		$result = CBT_Theme_Fluid_Typography::sync_fluid_typography_sizes( $data );
+
+		$this->assertArrayNotHasKey( 'typography', $result['settings'] );
+		$this->assertEqualsCanonicalizing( array(), $result['settings'] );
+	}
+
+	/**
+	 * Test that missing fontSizes doesn't cause errors
+	 */
+	public function test_sync_with_no_font_sizes() {
+		$data = array(
+			'settings' => array(
+				'typography' => array(),
+			),
+		);
+
+		$result = CBT_Theme_Fluid_Typography::sync_fluid_typography_sizes( $data );
+
+		$this->assertArrayNotHasKey( 'fontSizes', $result['settings']['typography'] );
+	}
+
+	/**
+	 * Test that invalid JSON in global styles filter is handled gracefully
+	 */
+	public function test_sync_global_styles_with_invalid_json() {
+		$prepared_post = new stdClass();
+		$prepared_post->post_content = 'invalid json';
+
+		$request = new WP_REST_Request();
+
+		$result = CBT_Theme_Fluid_Typography::sync_global_styles_fluid_typography( $prepared_post, $request );
+
+		// Should return the prepared post unchanged
+		$this->assertEquals( 'invalid json', $result->post_content );
+	}
+}


### PR DESCRIPTION
# Fix: Sync fluid typography size with fluid.max

## Summary
Fixes a bug where the `size` property in theme.json would retain its old value when editing Custom Fluid Typography in the Site Editor. The `fluid.min` and `fluid.max` values would update correctly, but the `size` property (which represents the maximum fluid size fallback) would remain stale.

## Fixes
- #789

## Changes
- includes/create-theme/theme-fluid-typography.php (new file)
  - New `CBT_Theme_Fluid_Typography` class that syncs the `size` property with `fluid.max` whenever fluid typography settings are updated.
  - Hooks into `rest_pre_insert_wp_global_styles` filter to intercept global styles before they're saved.
  - Automatically updates `size` to match `fluid.max` for any font size with fluid settings.

- includes/class-create-block-theme-api.php
  - Added require statement to load the new `theme-fluid-typography.php` file.

- tests/test-fluid-typography.php (new file)
  - Added `Test_Create_Block_Theme_Fluid_Typography` test class with 5 unit tests:
    - `test_sync_fluid_typography_sizes()` - Verifies fluid sizes are synced while non-fluid remain unchanged.
    - `test_sync_global_styles_fluid_typography()` - Verifies the REST filter works correctly.
    - `test_sync_with_no_typography()` - Verifies handling of missing typography.
    - `test_sync_with_no_font_sizes()` - Verifies handling of missing fontSizes.
    - `test_sync_global_styles_with_invalid_json()` - Verifies graceful error handling.

## Rationale
When editing Custom Fluid Typography in the Site Editor (Styles → Typography), WordPress updates the global styles JSON. However, the `size` property (which serves as a fallback for the maximum fluid size) wasn't being updated to match the new `fluid.max` value. This resulted in inconsistent typography definitions where the fluid values were current but the fallback size was stale.

The fix intercepts the global styles save operation and automatically syncs `size` with `fluid.max` for any font size that has fluid settings defined.

## Risk/Compatibility
- Scoped change: Only affects global styles updates for typography font sizes with fluid settings.
- Uses WordPress REST API filter (`rest_pre_insert_wp_global_styles`) which has been available since WordPress 5.9.
- Gracefully handles edge cases (missing typography, missing fontSizes, invalid JSON).
- No changes to existing functionality or APIs.

## Test Coverage
- 5 new unit tests covering the sync logic, global styles filter, and edge cases.
- Tests verify that:
  - Fluid font sizes are synced to their `fluid.max` value
  - Non-fluid sizes remain unchanged
  - Missing typography/fontSizes don't cause errors
  - Invalid JSON is handled gracefully

## Behavior After Fix
### Before

```json
{
  "fontSizes": [
    {
      "slug": "custom-fluid",
      "name": "Custom Fluid",
      "fluid": {
        "min": "1.5rem",
        "max": "5.63rem"
      },
      "size": "3rem"
    }
  ]
}
```
### After

```json
{
  "fontSizes": [
    {
      "slug": "custom-fluid",
      "name": "Custom Fluid",
      "fluid": {
        "min": "1.5rem",
        "max": "5.63rem"
      },
      "size": "5.63rem"
    }
  ]
}