### PR TITLE
Code Quality: Migrate to husky v9 format

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged
+lint-staged

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"start": "wp-scripts start src/admin-landing-page.js src/plugin-sidebar.js",
 		"composer": "wp-env run cli --env-cwd=wp-content/plugins/create-block-theme composer",
 		"update-version": "node update-version-and-changelog.js",
-		"prepare": "husky install",
+		"prepare": "husky",
 		"wp-env": "wp-env",
 		"test:unit": "wp-scripts test-unit-js --config test/unit/jest.config.js"
 	},


### PR DESCRIPTION
See: https://github.com/typicode/husky/releases/tag/v9.0.1 ("How to Migrate" section)

When the commit is performed, the linter formatter will run, but you will see a warning like this:

<img width="804" height="358" alt="image" src="https://github.com/user-attachments/assets/b33bf15f-48cb-4b30-9baf-b85b7ee8a9c8" />

This is because the Husky setting is not compatible with v9.

## Testing Instructions

- Check out this branch locally
- Make some changes
- Commit
- No warning error is displayed

