### PR TITLE
Bump minimum required WordPress version to 6.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Create Block Theme ===
 Contributors: wordpressdotorg, mikachan, onemaggie, pbking, scruffian, mmaattiiaass, jffng, madhudollu, egregor, vcanales, jeffikus, cwhitmore
 Tags: themes, theme, block-theme
-Requires at least: 6.7
+Requires at least: 6.8
 Tested up to: 6.9
 Stable tag: 2.8.0
 Requires PHP: 7.4

--- a/src/editor-sidebar/screen-header.js
+++ b/src/editor-sidebar/screen-header.js
@@ -9,20 +9,15 @@ import {
 	__experimentalSpacer as Spacer,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalHeading as Heading,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalNavigatorToParentButton as NavigatorToParentButton,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 
 const ScreenHeader = ( { title, onBack } ) => {
-	// TODO: Remove the fallback component when the minimum supported WordPress
-	// version was increased to 6.8.
-	const BackButton = Navigator?.BackButton || NavigatorToParentButton;
 	return (
 		<Spacer marginBottom={ 0 } paddingBottom={ 4 }>
 			<HStack spacing={ 2 }>
-				<BackButton
+				<Navigator.BackButton
 					style={ { minWidth: 24, padding: 0 } }
 					icon={ isRTL() ? chevronRight : chevronLeft }
 					size="small"


### PR DESCRIPTION
Similar to #775

Confirm that all features work correctly as before in WP 6.8.