### PR TITLE
i18n: Localise content attribute of the Read More block

### DIFF
--- a/includes/create-theme/theme-locale.php
+++ b/includes/create-theme/theme-locale.php
@@ -149,6 +149,8 @@ class CBT_Theme_Locale {
 				return array( 'label' );
 			case 'core/post-excerpt':
 				return array( 'moreText' );
+			case 'core/read-more':
+				return array( 'content' );
 			default:
 				return null;
 		}

--- a/tests/CbtThemeLocale/escapeBlockAttributes.php
+++ b/tests/CbtThemeLocale/escapeBlockAttributes.php
@@ -84,6 +84,11 @@ class CBT_Theme_Locale_EscapeBlockAttributes extends CBT_Theme_Locale_UnitTestCa
 <!-- /wp:query-pagination -->',
 			),
 
+			'read-more with content'                  => array(
+				'block_markup'    => '<!-- wp:read-more {"content":"View more"} /-->',
+				'expected_markup' => '<!-- wp:read-more {"content":"<?php esc_attr_e(\'View more\', \'test-locale-theme\');?>"} /-->',
+			),
+
 			'block without attributes should remain unchanged' => array(
 				'block_markup'    => '<!-- wp:search /-->',
 				'expected_markup' => '<!-- wp:search /-->',


### PR DESCRIPTION
## Summary

Fixes #807.

The `content` attribute of the Read More block (`<!-- wp:read-more {"content":"..."} /-->`) was not being localised when exporting a block theme. This adds `core/read-more` to the `get_localizable_block_attributes()` map introduced in #788, alongside a corresponding test case.

## Changes

- `includes/create-theme/theme-locale.php` — add `core/read-more => ['content']` to `get_localizable_block_attributes()`
- `tests/CbtThemeLocale/escapeBlockAttributes.php` — add test case for the Read More block `content` attribute

## Testing

Tested manually via WP Playground CLI with the local plugin mounted. Added a Read More block with a custom label, saved changes to theme, and confirmed the exported file contains `<?php esc_attr_e('...', 'theme-slug');?>` in place of the plain string.

_Note: This is my first PR for this repo, and I leaned on Claude for research and testing._ 