### PR TITLE
Downgrade actions/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"lib-font": "^3.0.0"
 			},
 			"devDependencies": {
-				"@actions/core": "^3.0.0",
+				"@actions/core": "^1.10.1",
 				"@emotion/babel-plugin": "^11.13.5",
 				"@playwright/test": "^1.58.2",
 				"@wordpress/base-styles": "^6.16.0",
@@ -35,41 +35,41 @@
 			}
 		},
 		"node_modules/@actions/core": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
-			"integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@actions/exec": "^3.0.0",
-				"@actions/http-client": "^4.0.0"
+				"@actions/exec": "^1.1.1",
+				"@actions/http-client": "^2.0.1"
 			}
 		},
 		"node_modules/@actions/exec": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
-			"integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+			"integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@actions/io": "^3.0.2"
+				"@actions/io": "^1.0.1"
 			}
 		},
 		"node_modules/@actions/http-client": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
-			"integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+			"integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tunnel": "^0.0.6",
-				"undici": "^6.23.0"
+				"undici": "^5.25.4"
 			}
 		},
 		"node_modules/@actions/io": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
-			"integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+			"integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2586,6 +2586,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@fastify/busboy": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
@@ -25606,13 +25616,16 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-			"integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"@fastify/busboy": "^2.0.0"
+			},
 			"engines": {
-				"node": ">=18.17"
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"lib-font": "^3.0.0"
 	},
 	"devDependencies": {
-		"@actions/core": "^3.0.0",
+		"@actions/core": "^1.10.1",
 		"@emotion/babel-plugin": "^11.13.5",
 		"@playwright/test": "^1.58.2",
 		"@wordpress/base-styles": "^6.16.0",


### PR DESCRIPTION
Downgrade `@actions/core` to try and fix the plugin release workflow. 

Example failure: https://github.com/WordPress/create-block-theme/actions/runs/23047612781/job/66940524163