### PR TITLE
Sanitize pattern titles and categories

### DIFF
--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -4,10 +4,11 @@ class CBT_Theme_Patterns {
 	public static function pattern_from_template( $template, $new_slug = null ) {
 		$theme_slug      = $new_slug ? $new_slug : wp_get_theme()->get( 'TextDomain' );
 		$pattern_slug    = $theme_slug . '/' . $template->slug;
+		$template_slug   = str_replace( '*/', '* /', $template->slug );
 		$pattern_content = <<<PHP
 		<?php
 		/**
-		 * Title: {$template->slug}
+		 * Title: {$template_slug}
 		 * Slug: {$pattern_slug}
 		 * Inserter: no
 		 */
@@ -29,12 +30,14 @@ class CBT_Theme_Patterns {
 		$pattern->slug         = wp_get_theme()->get( 'TextDomain' ) . '/' . $pattern->name;
 		$pattern_category_list = get_the_terms( $pattern->id, 'wp_pattern_category' );
 		$pattern->categories   = ! empty( $pattern_category_list ) ? join( ', ', wp_list_pluck( $pattern_category_list, 'name' ) ) : '';
+		$pattern_title         = str_replace( '*/', '* /', $pattern->title );
+		$pattern_categories    = str_replace( '*/', '* /', $pattern->categories );
 		$pattern->content      = <<<PHP
 		<?php
 		/**
-		 * Title: {$pattern->title}
+		 * Title: {$pattern_title}
 		 * Slug: {$pattern->slug}
-		 * Categories: {$pattern->categories}
+		 * Categories: {$pattern_categories}
 		 */
 		?>
 		{$pattern_post->post_content}

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -3,8 +3,8 @@
 class CBT_Theme_Patterns {
 	public static function pattern_from_template( $template, $new_slug = null ) {
 		$theme_slug      = $new_slug ? $new_slug : wp_get_theme()->get( 'TextDomain' );
-		$pattern_slug    = $theme_slug . '/' . $template->slug;
 		$template_slug   = str_replace( '*/', '* /', $template->slug );
+		$pattern_slug    = $theme_slug . '/' . $template_slug;
 		$pattern_content = <<<PHP
 		<?php
 		/**

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -3,7 +3,7 @@
 class CBT_Theme_Patterns {
 	public static function pattern_from_template( $template, $new_slug = null ) {
 		$theme_slug      = $new_slug ? $new_slug : wp_get_theme()->get( 'TextDomain' );
-		$template_slug   = str_replace( '*/', '* /', $template->slug );
+		$template_slug   = str_replace( '*/', '*&#47;', $template->slug );
 		$pattern_slug    = $theme_slug . '/' . $template_slug;
 		$pattern_content = <<<PHP
 		<?php
@@ -30,8 +30,8 @@ class CBT_Theme_Patterns {
 		$pattern->slug         = wp_get_theme()->get( 'TextDomain' ) . '/' . $pattern->name;
 		$pattern_category_list = get_the_terms( $pattern->id, 'wp_pattern_category' );
 		$pattern->categories   = ! empty( $pattern_category_list ) ? join( ', ', wp_list_pluck( $pattern_category_list, 'name' ) ) : '';
-		$pattern_title         = str_replace( '*/', '* /', $pattern->title );
-		$pattern_categories    = str_replace( '*/', '* /', $pattern->categories );
+		$pattern_title         = str_replace( '*/', '*&#47;', $pattern->title );
+		$pattern_categories    = str_replace( '*/', '*&#47;', $pattern->categories );
 		$pattern->content      = <<<PHP
 		<?php
 		/**


### PR DESCRIPTION
Sanitize pattern title and category values before writing them into PHP docblock headers in generated pattern files, preventing comment escape via */ sequences.

<img width="1384" height="733" alt="Screenshot 2026-03-16 at 11 47 26" src="https://github.com/user-attachments/assets/e17064f0-4bce-407e-ae12-eaf596f66a23" />
