### PR TITLE
Add setting to expand typography controls in the block inspector

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -20,7 +20,7 @@ This plugin allows you to:
 - Create a new style variation
 - Export a theme
 - Save user changed templates and styles to the active theme
-- Expand all typography controls in the block inspector while authoring a theme (opt-in, under Editor preferences)
+- Expand the typography controls in the block inspector while authoring a theme (opt-in, under Editor preferences)
 
 All newly created themes or style variations will include changes made within the WordPress Editor.
 

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,7 @@ This plugin allows you to:
 - Create a new style variation
 - Export a theme
 - Save user changed templates and styles to the active theme
+- Expand all typography controls in the block inspector while authoring a theme (opt-in, under Editor preferences)
 
 All newly created themes or style variations will include changes made within the WordPress Editor.
 

--- a/src/editor-enhancements/expand-typography-controls.js
+++ b/src/editor-enhancements/expand-typography-controls.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+// eslint-disable-next-line import/no-unresolved -- Provided as an external at build time via @wordpress/dependency-extraction-webpack-plugin.
 import { addFilter } from '@wordpress/hooks';
 import { select } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';

--- a/src/editor-enhancements/expand-typography-controls.js
+++ b/src/editor-enhancements/expand-typography-controls.js
@@ -41,7 +41,10 @@ export function expandTypographyDefaults( typographySupport ) {
 	}
 	return {
 		...typographySupport,
-		__experimentalDefaultControls: defaults,
+		__experimentalDefaultControls: {
+			...( typographySupport.__experimentalDefaultControls ?? {} ),
+			...defaults,
+		},
 	};
 }
 

--- a/src/editor-enhancements/expand-typography-controls.js
+++ b/src/editor-enhancements/expand-typography-controls.js
@@ -1,0 +1,68 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { select } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+// Mapping verified against
+// gutenberg/packages/block-editor/src/components/global-styles/typography-panel.js
+// fontWeight and fontStyle collapse into the single "fontAppearance" control.
+export const TYPOGRAPHY_SUPPORT_TO_CONTROL = {
+	fontSize: 'fontSize',
+	lineHeight: 'lineHeight',
+	textAlign: 'textAlign',
+	textColumns: 'textColumns',
+	textIndent: 'textIndent',
+	__experimentalFontFamily: 'fontFamily',
+	__experimentalLetterSpacing: 'letterSpacing',
+	__experimentalTextDecoration: 'textDecoration',
+	__experimentalTextTransform: 'textTransform',
+	__experimentalWritingMode: 'writingMode',
+	__experimentalFontWeight: 'fontAppearance',
+	__experimentalFontStyle: 'fontAppearance',
+};
+
+export const PREFERENCE_SCOPE = 'create-block-theme';
+export const PREFERENCE_KEY = 'expandAllTypographyControls';
+
+export function expandTypographyDefaults( typographySupport ) {
+	if ( ! typographySupport || typeof typographySupport !== 'object' ) {
+		return typographySupport;
+	}
+	const defaults = {};
+	for ( const [ supportKey, controlKey ] of Object.entries(
+		TYPOGRAPHY_SUPPORT_TO_CONTROL
+	) ) {
+		if ( typographySupport[ supportKey ] ) {
+			defaults[ controlKey ] = true;
+		}
+	}
+	return {
+		...typographySupport,
+		__experimentalDefaultControls: defaults,
+	};
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'create-block-theme/expand-typography-controls',
+	( settings ) => {
+		const enabled = select( preferencesStore )?.get?.(
+			PREFERENCE_SCOPE,
+			PREFERENCE_KEY
+		);
+		if ( ! enabled || ! settings?.supports?.typography ) {
+			return settings;
+		}
+		return {
+			...settings,
+			supports: {
+				...settings.supports,
+				typography: expandTypographyDefaults(
+					settings.supports.typography
+				),
+			},
+		};
+	}
+);

--- a/src/editor-sidebar/editor-preferences-panel.js
+++ b/src/editor-sidebar/editor-preferences-panel.js
@@ -55,11 +55,11 @@ export const EditorPreferencesPanel = () => {
 					<CheckboxControl
 						__nextHasNoMarginBottom
 						label={ __(
-							'Expand all typography controls in the block inspector',
+							'Expand typography controls in the block inspector',
 							'create-block-theme'
 						) }
 						help={ __(
-							'Shows every typography control by default instead of hiding them behind the ellipsis menu. Applies in the Site Editor only. The editor will reload when you change this.',
+							'Shows the controls in the typography panel by default instead of hiding them behind the ellipsis menu. Applies in the Site Editor only. The editor will reload when you change this.',
 							'create-block-theme'
 						) }
 						checked={ expandAllTypographyControls }

--- a/src/editor-sidebar/editor-preferences-panel.js
+++ b/src/editor-sidebar/editor-preferences-panel.js
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { store as noticesStore } from '@wordpress/notices';
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+	PanelBody,
+	CheckboxControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import ScreenHeader from './screen-header';
+import {
+	PREFERENCE_SCOPE,
+	PREFERENCE_KEY,
+} from '../editor-enhancements/expand-typography-controls';
+
+export const EditorPreferencesPanel = () => {
+	const expandAllTypographyControls = useSelect(
+		( select ) =>
+			!! select( preferencesStore ).get(
+				PREFERENCE_SCOPE,
+				PREFERENCE_KEY
+			),
+		[]
+	);
+
+	const { set: setPreference } = useDispatch( preferencesStore );
+	const { createInfoNotice } = useDispatch( noticesStore );
+
+	const handleToggle = ( value ) => {
+		setPreference( PREFERENCE_SCOPE, PREFERENCE_KEY, value );
+		createInfoNotice( __( 'Applying…', 'create-block-theme' ), {
+			type: 'snackbar',
+		} );
+		window.location.reload();
+	};
+
+	return (
+		<PanelBody>
+			<ScreenHeader
+				title={ __( 'Editor preferences', 'create-block-theme' ) }
+			/>
+			<VStack spacing={ 4 }>
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					label={ __(
+						'Expand all typography controls in the block inspector',
+						'create-block-theme'
+					) }
+					help={ __(
+						'Shows every typography control by default instead of hiding them behind the ellipsis menu. Applies in the Site Editor only. The editor will reload when you change this.',
+						'create-block-theme'
+					) }
+					checked={ expandAllTypographyControls }
+					onChange={ handleToggle }
+				/>
+			</VStack>
+		</PanelBody>
+	);
+};

--- a/src/editor-sidebar/editor-preferences-panel.js
+++ b/src/editor-sidebar/editor-preferences-panel.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { store as noticesStore } from '@wordpress/notices';
 import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
@@ -33,13 +32,16 @@ export const EditorPreferencesPanel = () => {
 	);
 
 	const { set: setPreference } = useDispatch( preferencesStore );
-	const { createInfoNotice } = useDispatch( noticesStore );
 
 	const handleToggle = ( value ) => {
 		setPreference( PREFERENCE_SCOPE, PREFERENCE_KEY, value );
-		createInfoNotice( __( 'Applying…', 'create-block-theme' ), {
-			type: 'snackbar',
-		} );
+		// eslint-disable-next-line no-alert
+		window.alert(
+			__(
+				'Preference updated. The editor will now reload.',
+				'create-block-theme'
+			)
+		);
 		window.location.reload();
 	};
 

--- a/src/editor-sidebar/editor-preferences-panel.js
+++ b/src/editor-sidebar/editor-preferences-panel.js
@@ -8,7 +8,8 @@ import { store as noticesStore } from '@wordpress/notices';
 import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
-	PanelBody,
+	Card,
+	CardBody,
 	CheckboxControl,
 } from '@wordpress/components';
 
@@ -43,25 +44,27 @@ export const EditorPreferencesPanel = () => {
 	};
 
 	return (
-		<PanelBody>
+		<Card size="small" isBorderless>
 			<ScreenHeader
 				title={ __( 'Editor preferences', 'create-block-theme' ) }
 			/>
-			<VStack spacing={ 4 }>
-				<CheckboxControl
-					__nextHasNoMarginBottom
-					label={ __(
-						'Expand all typography controls in the block inspector',
-						'create-block-theme'
-					) }
-					help={ __(
-						'Shows every typography control by default instead of hiding them behind the ellipsis menu. Applies in the Site Editor only. The editor will reload when you change this.',
-						'create-block-theme'
-					) }
-					checked={ expandAllTypographyControls }
-					onChange={ handleToggle }
-				/>
-			</VStack>
-		</PanelBody>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Expand all typography controls in the block inspector',
+							'create-block-theme'
+						) }
+						help={ __(
+							'Shows every typography control by default instead of hiding them behind the ellipsis menu. Applies in the Site Editor only. The editor will reload when you change this.',
+							'create-block-theme'
+						) }
+						checked={ expandAllTypographyControls }
+						onChange={ handleToggle }
+					/>
+				</VStack>
+			</CardBody>
+		</Card>
 	);
 };

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -1,4 +1,11 @@
 /**
+ * Internal dependencies
+ */
+// Side-effect import — must load before block registration so the
+// registerBlockType filter is in place when blocks register.
+import './editor-enhancements/expand-typography-controls';
+
+/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -39,6 +46,7 @@ import {
 	blockMeta,
 	help,
 	trash,
+	cog,
 } from '@wordpress/icons';
 
 /**
@@ -55,6 +63,7 @@ import { downloadExportedTheme } from './resolvers';
 import downloadFile from './utils/download-file';
 import AboutPlugin from './editor-sidebar/about';
 import ResetTheme from './editor-sidebar/reset-theme';
+import { EditorPreferencesPanel } from './editor-sidebar/editor-preferences-panel';
 import './plugin-styles.scss';
 
 function PluginSidebarItem( { icon, path, children, onClick } ) {
@@ -232,6 +241,20 @@ const CreateBlockThemePlugin = () => {
 							<CardBody>
 								<VStack spacing={ 0 }>
 									<PluginSidebarItem
+										path="/editor-preferences"
+										icon={ cog }
+									>
+										{ __(
+											'Editor preferences',
+											'create-block-theme'
+										) }
+									</PluginSidebarItem>
+								</VStack>
+							</CardBody>
+							<CardDivider />
+							<CardBody>
+								<VStack spacing={ 0 }>
+									<PluginSidebarItem
 										path="/about"
 										icon={ help }
 									>
@@ -328,6 +351,10 @@ const CreateBlockThemePlugin = () => {
 
 					<NavigatorScreen path="/reset">
 						<ResetTheme />
+					</NavigatorScreen>
+
+					<NavigatorScreen path="/editor-preferences">
+						<EditorPreferencesPanel />
 					</NavigatorScreen>
 				</NavigatorProvider>
 			</PluginSidebar>

--- a/src/test/expand-typography-controls.test.js
+++ b/src/test/expand-typography-controls.test.js
@@ -1,0 +1,158 @@
+// The module under test imports WordPress packages that are provided as
+// externals at build time and are not installed as npm dependencies. Mock them
+// so Jest can resolve the module to test the pure mapping function.
+jest.mock( '@wordpress/hooks', () => ( { addFilter: jest.fn() } ), {
+	virtual: true,
+} );
+jest.mock( '@wordpress/data', () => ( { select: jest.fn() } ), {
+	virtual: true,
+} );
+jest.mock( '@wordpress/preferences', () => ( { store: 'core/preferences' } ), {
+	virtual: true,
+} );
+
+/**
+ * Internal dependencies
+ */
+// eslint-disable-next-line import/first
+import {
+	expandTypographyDefaults,
+	TYPOGRAPHY_SUPPORT_TO_CONTROL,
+} from '../editor-enhancements/expand-typography-controls';
+
+describe( 'expandTypographyDefaults', () => {
+	it( 'returns input unchanged when null', () => {
+		expect( expandTypographyDefaults( null ) ).toBe( null );
+	} );
+
+	it( 'returns input unchanged when undefined', () => {
+		expect( expandTypographyDefaults( undefined ) ).toBe( undefined );
+	} );
+
+	it( 'returns input unchanged when not an object', () => {
+		expect( expandTypographyDefaults( true ) ).toBe( true );
+	} );
+
+	it( 'yields an empty defaults map when no supports are enabled', () => {
+		expect( expandTypographyDefaults( {} ) ).toEqual( {
+			__experimentalDefaultControls: {},
+		} );
+	} );
+
+	it( 'maps fontSize to fontSize', () => {
+		expect( expandTypographyDefaults( { fontSize: true } ) ).toEqual( {
+			fontSize: true,
+			__experimentalDefaultControls: { fontSize: true },
+		} );
+	} );
+
+	it( 'maps __experimentalFontFamily to fontFamily', () => {
+		expect(
+			expandTypographyDefaults( { __experimentalFontFamily: true } )
+		).toEqual( {
+			__experimentalFontFamily: true,
+			__experimentalDefaultControls: { fontFamily: true },
+		} );
+	} );
+
+	it( 'maps __experimentalFontWeight alone to fontAppearance', () => {
+		expect(
+			expandTypographyDefaults( { __experimentalFontWeight: true } )
+		).toEqual( {
+			__experimentalFontWeight: true,
+			__experimentalDefaultControls: { fontAppearance: true },
+		} );
+	} );
+
+	it( 'maps __experimentalFontStyle alone to fontAppearance', () => {
+		expect(
+			expandTypographyDefaults( { __experimentalFontStyle: true } )
+		).toEqual( {
+			__experimentalFontStyle: true,
+			__experimentalDefaultControls: { fontAppearance: true },
+		} );
+	} );
+
+	it( 'collapses both weight and style into a single fontAppearance entry', () => {
+		const result = expandTypographyDefaults( {
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+		} );
+		expect( result.__experimentalDefaultControls ).toEqual( {
+			fontAppearance: true,
+		} );
+		expect(
+			Object.keys( result.__experimentalDefaultControls ).length
+		).toBe( 1 );
+	} );
+
+	it( 'ignores support keys that are falsy', () => {
+		expect(
+			expandTypographyDefaults( {
+				fontSize: true,
+				lineHeight: false,
+				textAlign: undefined,
+			} )
+		).toEqual( {
+			fontSize: true,
+			lineHeight: false,
+			textAlign: undefined,
+			__experimentalDefaultControls: { fontSize: true },
+		} );
+	} );
+
+	it( 'maps a full realistic supports.typography shape to every expected control', () => {
+		const fullShape = {
+			fontSize: true,
+			lineHeight: true,
+			textAlign: true,
+			textColumns: true,
+			textIndent: true,
+			__experimentalFontFamily: true,
+			__experimentalLetterSpacing: true,
+			__experimentalTextDecoration: true,
+			__experimentalTextTransform: true,
+			__experimentalWritingMode: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+		};
+		expect(
+			expandTypographyDefaults( fullShape ).__experimentalDefaultControls
+		).toEqual( {
+			fontSize: true,
+			lineHeight: true,
+			textAlign: true,
+			textColumns: true,
+			textIndent: true,
+			fontFamily: true,
+			letterSpacing: true,
+			textDecoration: true,
+			textTransform: true,
+			writingMode: true,
+			fontAppearance: true,
+		} );
+	} );
+
+	it( 'preserves other keys on the typography supports object', () => {
+		const input = {
+			fontSize: true,
+			customKey: 'untouched',
+		};
+		const result = expandTypographyDefaults( input );
+		expect( result.customKey ).toBe( 'untouched' );
+		expect( result.__experimentalDefaultControls ).toEqual( {
+			fontSize: true,
+		} );
+	} );
+} );
+
+describe( 'TYPOGRAPHY_SUPPORT_TO_CONTROL', () => {
+	it( 'merges fontWeight and fontStyle into fontAppearance', () => {
+		expect( TYPOGRAPHY_SUPPORT_TO_CONTROL.__experimentalFontWeight ).toBe(
+			'fontAppearance'
+		);
+		expect( TYPOGRAPHY_SUPPORT_TO_CONTROL.__experimentalFontStyle ).toBe(
+			'fontAppearance'
+		);
+	} );
+} );

--- a/src/test/expand-typography-controls.test.js
+++ b/src/test/expand-typography-controls.test.js
@@ -133,6 +133,21 @@ describe( 'expandTypographyDefaults', () => {
 		} );
 	} );
 
+	it( 'preserves unknown keys already set in __experimentalDefaultControls', () => {
+		const input = {
+			fontSize: true,
+			__experimentalDefaultControls: {
+				fontSize: false,
+				someFutureControl: true,
+			},
+		};
+		const result = expandTypographyDefaults( input );
+		expect( result.__experimentalDefaultControls ).toEqual( {
+			fontSize: true,
+			someFutureControl: true,
+		} );
+	} );
+
 	it( 'preserves other keys on the typography supports object', () => {
 		const input = {
 			fontSize: true,


### PR DESCRIPTION
## Summary

Adds an opt-in **Editor preferences** panel in the Create Block Theme sidebar with a single toggle that expands every typography control in the block inspector by default, instead of hiding them behind the ToolsPanel ellipsis menu. Intended for theme authors iterating on typography.

Fixes #823.

## Why

Adjusting typography in the Site Editor takes two steps per control today: open the ellipsis menu, enable the control, then set the value. For theme authors iterating across many blocks and elements, this adds up. The issue has more context (#823), including the related upstream discussions in [gutenberg#41376](https://github.com/WordPress/gutenberg/issues/41376) and [gutenberg#41544.](https://github.com/WordPress/gutenberg/issues/41544)

The narrow scope here — plugin-only, reversible by toggling off or deactivating CBT.

**New files**
- `src/editor-enhancements/expand-typography-controls.js` — mapping table, pure `expandTypographyDefaults()`, and a `blocks.registerBlockType` filter that populates `__experimentalDefaultControls` based on the typography supports the block already declares.
- `src/editor-sidebar/editor-preferences-panel.js` — new panel with a single `CheckboxControl`. Toggle writes the preference, fires `createInfoNotice('Applying…')`, and reloads the editor.
- `src/test/expand-typography-controls.test.js` — 13 unit tests for the pure mapping function (null/undefined, each support key, `fontAppearance` merge, falsy filtering, full shape, key preservation) plus one mapping-table sanity check.

**Modified**
- `src/plugin-sidebar.js` — side-effect import of the filter at the top (so it registers before block registration), `cog` icon, menu item under `/editor-preferences`, new `NavigatorScreen`.
- `readme.txt` — one bullet under Description.

## Design decisions

- **Typography only for v1.** Defer spacing / border / dimensions to a follow-up based on feedback.
- **Reload on toggle.** `blocks.registerBlockType` only fires at registration time. Auto-reload matches the pattern already used.
- **CBT sidebar, not the core Preferences modal.** The preference scope is `create-block-theme`, same store as existing save-panel preferences. It really is only helpful while authoring a theme.
- **Site Editor only.** CBT's sidebar bundle is gated to `$pagenow === 'site-editor.php'` in `includes/class-create-block-theme-editor-tools.php:19`, so the filter doesn't load in the post editor. The help text notes this. Broader coverage (splitting the filter into its own unconditionally-enqueued script) is a plausible v2. 

## Mapping source

Verified against `gutenberg/packages/block-editor/src/components/global-styles/typography-panel.js` on `trunk`. `fontWeight` and `fontStyle` collapse into a single `fontAppearance` control. If the `__experimental*` keys rename in core, only `expand-typography-controls.js` needs to change.

## Open questions for reviewers

From issue #823:
1. **Typography-only v1, or broader?** (spacing, dimensions, border)
2. **Reload vs live apply.** We chose reload for the reasons above; open to reconsidering if reviewers feel strongly.
3. **Visible in-editor indicator** that expansion is active — helpful, or noise?
4. **Site Editor only.** Should this also work in the post editor? Would require splitting the filter module out of the \`site-editor.php\`-gated sidebar bundle.

## Test plan
- [x] Site Editor manual: toggle OFF baseline for Paragraph, Heading, Group, Cover, Quote
- [x] Site Editor manual: toggle ON → reload → all declared typography controls visible on the above
- [x] Third-party block: Jetpack Contact Form's Label block — all typography controls expanded, no crash, no invented controls
- [x] Toggle OFF → reload → controls revert
- [x] Deactivate CBT → default Gutenberg behavior returns
- [x] Preference persists across browser reloads and sessions

A Claude-assisted PR. 

## Here are a few visusal: 

Video:  

https://github.com/user-attachments/assets/3d1bd283-6f51-4e52-b31f-9d080de615ae



<img width="263" height="341" alt="Screenshot 2026-04-24 at 11 17 09" src="https://github.com/user-attachments/assets/9d16a0f8-700c-45a2-816d-2358346d24c1" />

<img width="284" height="264" alt="Screenshot 2026-04-28 at 16 02 26" src="https://github.com/user-attachments/assets/ebb32d51-625c-48cf-86cf-b5de81d73a68" />



<img width="280" height="525" alt="Screenshot 2026-04-24 at 11 17 48" src="https://github.com/user-attachments/assets/ac5afb0b-410f-4542-ade5-46bddba5a3de" />