### PR TITLE
i18n: Localize label attribute of additional blocks

### DIFF
--- a/includes/create-theme/theme-locale.php
+++ b/includes/create-theme/theme-locale.php
@@ -146,6 +146,11 @@ class CBT_Theme_Locale {
 			case 'core/comments-pagination-previous':
 			case 'core/comments-pagination-next':
 			case 'core/post-navigation-link':
+			case 'core/navigation-link':
+			case 'core/navigation-submenu':
+			case 'core/home-link':
+			case 'core/social-link':
+			case 'core/categories':
 				return array( 'label' );
 			case 'core/post-excerpt':
 				return array( 'moreText' );

--- a/tests/CbtThemeLocale/escapeBlockAttributes.php
+++ b/tests/CbtThemeLocale/escapeBlockAttributes.php
@@ -66,6 +66,31 @@ class CBT_Theme_Locale_EscapeBlockAttributes extends CBT_Theme_Locale_UnitTestCa
 				'expected_markup' => '<!-- wp:post-navigation-link {"label":"<?php esc_attr_e(\'Custom Label\', \'test-locale-theme\');?>"} /-->',
 			),
 
+			'navigation-link with label'              => array(
+				'block_markup'    => '<!-- wp:navigation-link {"label":"About","url":"/about"} /-->',
+				'expected_markup' => '<!-- wp:navigation-link {"label":"<?php esc_attr_e(\'About\', \'test-locale-theme\');?>","url":"/about"} /-->',
+			),
+
+			'navigation-submenu with label'           => array(
+				'block_markup'    => '<!-- wp:navigation-submenu {"label":"Resources","url":"/resources"} /-->',
+				'expected_markup' => '<!-- wp:navigation-submenu {"label":"<?php esc_attr_e(\'Resources\', \'test-locale-theme\');?>","url":"/resources"} /-->',
+			),
+
+			'home-link with label'                    => array(
+				'block_markup'    => '<!-- wp:home-link {"label":"Home"} /-->',
+				'expected_markup' => '<!-- wp:home-link {"label":"<?php esc_attr_e(\'Home\', \'test-locale-theme\');?>"} /-->',
+			),
+
+			'social-link with label'                  => array(
+				'block_markup'    => '<!-- wp:social-link {"url":"https://example.com","service":"chain","label":"My website"} /-->',
+				'expected_markup' => '<!-- wp:social-link {"url":"https://example.com","service":"chain","label":"<?php esc_attr_e(\'My website\', \'test-locale-theme\');?>"} /-->',
+			),
+
+			'categories with label'                   => array(
+				'block_markup'    => '<!-- wp:categories {"displayAsDropdown":true,"label":"Browse by topic"} /-->',
+				'expected_markup' => '<!-- wp:categories {"displayAsDropdown":true,"label":"<?php esc_attr_e(\'Browse by topic\', \'test-locale-theme\');?>"} /-->',
+			),
+
 			'search block with only some attributes'  => array(
 				'block_markup'    => '<!-- wp:search {"placeholder":"Search..."} /-->',
 				'expected_markup' => '<!-- wp:search {"placeholder":"<?php esc_attr_e(\'Search...\', \'test-locale-theme\');?>"} /-->',


### PR DESCRIPTION
## Summary

Extends the "Localize Text" feature so that the `label` attribute of five more core blocks is wrapped in `esc_attr_e()` on theme save:

- `core/navigation-link`
- `core/navigation-submenu`
- `core/home-link`
- `core/social-link`
- `core/categories`

Each is added as a fall-through case in `CBT_Theme_Locale::get_localizable_block_attributes()` (`includes/create-theme/theme-locale.php`) alongside the existing `label`-only blocks. No new mechanism, no behavioural change for blocks already covered.

This continues the band-aid approach acknowledged in #776 — the architectural fix is tracked there.

Refs #825 (one part of it; `core/file` `downloadButtonText` / `fileName` will be a separate PR since those need rich-text/HTML handling).

### Caveat for navigation blocks

Navigation menus stored as `wp_navigation` posts live outside templates and are not affected by this change. The fix only helps when a Navigation block contains inline `navigation-link` / `navigation-submenu` / `home-link` children in the template markup.

## Test plan

- [x] `npm run lint:php` — clean
- [x] `npm run test:unit:php` — verified by CI (PHP 7.4 / 8.0 / 8.1 / 8.2 / 8.3, current and previous WP major).
- [x] Manual smoke in WordPress Studio: ran the production pipeline (`parse_blocks` → `escape_text_content_of_blocks` → `serialize_blocks` → `escape_block_attribute_strings`) on hand-crafted markup for each of the five new blocks. All five produced the expected `<?php esc_attr_e('<label>', '<theme-slug>');?>` wrapping.
