### PR TITLE
Fix: guard `$template->media` reads against undefined property

### DIFF
--- a/includes/create-theme/theme-templates.php
+++ b/includes/create-theme/theme-templates.php
@@ -230,7 +230,7 @@ class CBT_Theme_Templates {
 			);
 
 			// Write the media assets if there are any
-			if ( $template->media ) {
+			if ( ! empty( $template->media ) ) {
 				CBT_Theme_Media::add_media_to_local( $template->media );
 			}
 
@@ -258,7 +258,7 @@ class CBT_Theme_Templates {
 			);
 
 			// Write the media assets if there are any
-			if ( $template->media ) {
+			if ( ! empty( $template->media ) ) {
 				CBT_Theme_Media::add_media_to_local( $template->media );
 			}
 


### PR DESCRIPTION
## Summary

`CBT_Theme_Templates::add_templates_to_local()` reads `$template->media` in two places (templates loop, template parts loop) without checking whether the property exists. The `media` property is only attached by `prepare_template_for_export()` on code paths where there is image media to localize — on every other path, accessing it raises a PHP 8.2+ deprecation notice:

```
Deprecated: Creation of dynamic property … (or)
Undefined property: WP_Block_Template::$media
```

## Change

Wrap both reads with `! empty()`. This mirrors the convention used a few lines later for `$template->pattern` (line 238 / 266), which already uses `isset()`.

```diff
- if ( $template->media ) {
+ if ( ! empty( $template->media ) ) {
      CBT_Theme_Media::add_media_to_local( $template->media );
  }
```

`! empty()` returns `false` for both undefined and falsy values, so the existing runtime behavior is preserved.

## Why this is two lines, not one

There are two near-identical copies of the same loop body — one for templates, one for template parts. Both need the same guard. Worth consolidating eventually, but that is a larger refactor and not the goal here.

## Test plan

- [x] `npm run lint:php` clean
- [x] `npm run test:unit:php` — 94 tests pass on this branch (off trunk)

No new tests added: the bug is a runtime deprecation that doesn't change observable PHPUnit outcomes on PHP 7.4 / 8.0 / 8.1, where the dynamic property assignment is still allowed without a notice. PHP 8.2+ runs in CI cover the deprecation surface.

## How this was discovered

Surfaced by a strict error handler in #833's regression test. That test was narrowed to only catch the `processOnlySavedTemplates` notice so it would not fail on this unrelated pre-existing issue. With this PR merged, the narrowed matcher in #833 could be broadened back to the original strict handler — small follow-up, not blocking.

Closes #834