### PR TITLE
Add /theme-settings REST endpoint + CBT_Theme_Settings_Save service

### DIFF
--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -414,7 +414,20 @@ class CBT_Theme_API {
 	 * missing keys leave the existing theme.json untouched.
 	 */
 	function rest_save_theme_settings( $request ) {
-		$result = CBT_Theme_Settings_Save::run( $request->get_json_params() );
+		// `get_json_params()` returns null (or a scalar) for empty or
+		// non-object request bodies. The service signature requires an array,
+		// so guard here and return a 400 rather than letting the type hint
+		// fatal at the service boundary.
+		$payload = $request->get_json_params();
+		if ( ! is_array( $payload ) ) {
+			return new WP_Error(
+				'cbt_invalid_payload',
+				__( 'Request body must be a JSON object.', 'create-block-theme' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$result = CBT_Theme_Settings_Save::run( $payload );
 
 		if ( is_wp_error( $result ) ) {
 			return $result;

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/create-theme/theme-utils.php';
 require_once __DIR__ . '/create-theme/theme-readme.php';
 require_once __DIR__ . '/create-theme/theme-fonts.php';
 require_once __DIR__ . '/create-theme/theme-create.php';
+require_once __DIR__ . '/create-theme/theme-settings-save.php';
 
 /**
  * The api functionality of the plugin leveraged by the site editor UI.
@@ -63,6 +64,17 @@ class CBT_Theme_API {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_save_theme' ),
+				'permission_callback' => function () {
+					return current_user_can( 'edit_theme_options' );
+				},
+			)
+		);
+		register_rest_route(
+			'create-block-theme/v1',
+			'/theme-settings',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'rest_save_theme_settings' ),
 				'permission_callback' => function () {
 					return current_user_can( 'edit_theme_options' );
 				},
@@ -390,6 +402,28 @@ class CBT_Theme_API {
 			array(
 				'status'  => 'SUCCESS',
 				'message' => __( 'Theme Saved.', 'create-block-theme' ),
+			)
+		);
+	}
+
+	/**
+	 * Persist a partial theme.json payload from the Edit Theme Settings modal.
+	 *
+	 * Accepts the keys `settings`, `customTemplates`, `templateParts`, and
+	 * `removedShadowDefaults`. Only keys present in the payload are written;
+	 * missing keys leave the existing theme.json untouched.
+	 */
+	function rest_save_theme_settings( $request ) {
+		$result = CBT_Theme_Settings_Save::run( $request->get_json_params() );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return new WP_REST_Response(
+			array(
+				'status'     => 'SUCCESS',
+				'theme_json' => $result,
 			)
 		);
 	}

--- a/includes/create-theme/resolver_additions.php
+++ b/includes/create-theme/resolver_additions.php
@@ -137,11 +137,14 @@ function cbt_augment_resolver_with_utilities() {
 			$theme_json = wp_json_encode( $theme_json_data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 			$target     = static::get_file_path_from_theme( 'theme.json' );
 
-			// Atomic write: write to a sibling temp file, then rename into place.
-			// If the write or rename fails partway, the original theme.json is
-			// untouched. `file_put_contents` would truncate-then-write, leaving
-			// a corrupt file on interruption.
-			$tmp = $target . '.tmp';
+			// Atomic write with a request-unique temp file: write to a
+			// per-request sibling temp file, then rename into place. A
+			// per-request name prevents two concurrent saves from clobbering
+			// each other's staging payload (a shared `theme.json.tmp` is unsafe
+			// — request A could rename request B's truncated contents, or one
+			// could unlink the other's temp file mid-write). Each request
+			// cleans up only its own temp file on failure.
+			$tmp = $target . '.' . uniqid( '', true ) . '.tmp';
 			// Suppress warnings so a permission/disk error returns false cleanly
 			// rather than emitting a PHP warning that may be promoted to an
 			// exception. Callers must check the boolean return value.

--- a/includes/create-theme/resolver_additions.php
+++ b/includes/create-theme/resolver_additions.php
@@ -135,8 +135,13 @@ function cbt_augment_resolver_with_utilities() {
 
 		public static function write_theme_file_contents( $theme_json_data ) {
 			$theme_json = wp_json_encode( $theme_json_data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-			file_put_contents( static::get_file_path_from_theme( 'theme.json' ), $theme_json );
+			// Suppress warnings so a permission/disk error returns false cleanly
+			// rather than emitting a PHP warning that may be promoted to an
+			// exception. Callers must check the boolean return value.
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			$bytes = @file_put_contents( static::get_file_path_from_theme( 'theme.json' ), $theme_json );
 			static::clean_cached_data();
+			return false !== $bytes;
 		}
 
 		public static function write_user_settings( $user_settings ) {

--- a/includes/create-theme/resolver_additions.php
+++ b/includes/create-theme/resolver_additions.php
@@ -135,13 +135,34 @@ function cbt_augment_resolver_with_utilities() {
 
 		public static function write_theme_file_contents( $theme_json_data ) {
 			$theme_json = wp_json_encode( $theme_json_data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+			$target     = static::get_file_path_from_theme( 'theme.json' );
+
+			// Atomic write: write to a sibling temp file, then rename into place.
+			// If the write or rename fails partway, the original theme.json is
+			// untouched. `file_put_contents` would truncate-then-write, leaving
+			// a corrupt file on interruption.
+			$tmp = $target . '.tmp';
 			// Suppress warnings so a permission/disk error returns false cleanly
 			// rather than emitting a PHP warning that may be promoted to an
 			// exception. Callers must check the boolean return value.
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-			$bytes = @file_put_contents( static::get_file_path_from_theme( 'theme.json' ), $theme_json );
+			$bytes = @file_put_contents( $tmp, $theme_json );
+			if ( false === $bytes ) {
+				return false;
+			}
+
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			if ( ! @rename( $tmp, $target ) ) {
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				@unlink( $tmp );
+				return false;
+			}
+
 			static::clean_cached_data();
-			return false !== $bytes;
+			// Bust the WP-level theme cache too — `clean_cached_data()` only
+			// clears the JSON resolver's caches, not `wp_get_theme()`.
+			wp_get_theme()->cache_delete();
+			return true;
 		}
 
 		public static function write_user_settings( $user_settings ) {

--- a/includes/create-theme/resolver_additions.php
+++ b/includes/create-theme/resolver_additions.php
@@ -135,7 +135,14 @@ function cbt_augment_resolver_with_utilities() {
 
 		public static function write_theme_file_contents( $theme_json_data ) {
 			$theme_json = wp_json_encode( $theme_json_data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-			$target     = static::get_file_path_from_theme( 'theme.json' );
+			// `wp_json_encode` returns false if the data contains an
+			// unencodable value (resources, NAN/INF after wrapping, etc.).
+			// Bail before opening a temp file so theme.json is never
+			// truncated or replaced with empty content.
+			if ( false === $theme_json ) {
+				return false;
+			}
+			$target = static::get_file_path_from_theme( 'theme.json' );
 
 			// Atomic write with a request-unique temp file: write to a
 			// per-request sibling temp file, then rename into place. A

--- a/includes/create-theme/theme-settings-save.php
+++ b/includes/create-theme/theme-settings-save.php
@@ -4,15 +4,21 @@
  *
  * Persists Edit Theme Settings modal payloads to the active theme's theme.json.
  * Accepts a partial-`theme.json` payload (only the keys the user edited),
- * deep-merges it into the existing file, and writes the result. Reifies the
- * `removedShadowDefaults` operational key into the standard
- * `settings.shadow.defaultPresets` + `settings.shadow.presets` shape.
+ * deep-merges it into the existing file using JSON Merge Patch semantics
+ * (RFC 7396), and writes the result. Reifies the `removedShadowDefaults`
+ * operational key into the standard `settings.shadow.defaultPresets` +
+ * `settings.shadow.presets` shape.
  *
  * Callers must enforce capability checks (`edit_theme_options`) before
  * invoking `run()`. The service performs payload-shape validation and
  * sanitization but does not authenticate.
  *
+ * Known limitation: concurrent edits are last-write-wins. Two clients with
+ * the modal open simultaneously will silently overwrite each other. ETag /
+ * If-Match handling can be added if this becomes a problem in practice.
+ *
  * @package Create_Block_Theme
+ * @see https://datatracker.ietf.org/doc/html/rfc7396 JSON Merge Patch
  */
 class CBT_Theme_Settings_Save {
 
@@ -26,6 +32,13 @@ class CBT_Theme_Settings_Save {
 	/**
 	 * Keys whose string values are user-facing labels and benefit from
 	 * `sanitize_text_field()` (HTML stripping, whitespace normalization).
+	 *
+	 * This is an allowlist. Adding a new label-class field to theme.json
+	 * upstream means adding it here — otherwise it falls through to
+	 * `wp_kses_no_null` and HTML will not be stripped. Trade-off accepted:
+	 * the inverse rule ("strip HTML by default, allowlist CSS-value fields")
+	 * silently corrupts CSS for new fields, which is worse than missing a
+	 * label sanitization update.
 	 */
 	const TEXT_FIELD_KEYS = array( 'name', 'title', 'label', 'description' );
 
@@ -259,11 +272,28 @@ class CBT_Theme_Settings_Save {
 	}
 
 	/**
-	 * Deep-merge $payload into $current. At every level, associative-array
-	 * values are merged recursively; lists, scalars, and empty arrays replace
-	 * the existing value. Missing parent keys are created.
+	 * Deep-merge $payload into $current using JSON Merge Patch (RFC 7396)
+	 * semantics, with one PHP-imposed accommodation.
 	 *
-	 * The operational key `removedShadowDefaults` is dropped here — it's
+	 * Rules:
+	 *
+	 * - **`null` deletes the key.** Sending `{"settings":{"color":{"custom":null}}}`
+	 *   removes `settings.color.custom` from the result. Deleting a missing
+	 *   key is a no-op.
+	 * - **Empty object (`{}`) is a no-op.** Per RFC 7396, an empty object means
+	 *   "no change at this key." PHP cannot distinguish a JSON `{}` from a JSON
+	 *   `[]` after `json_decode(..., true)` (both become empty PHP arrays), so
+	 *   we use a heuristic: if the existing value at this key is a list, an
+	 *   empty payload value clears that list; otherwise it is treated as a
+	 *   no-op. This means clients that intend to clear a list MUST already
+	 *   know the field is list-typed (which is how the modal is built).
+	 * - **Associative-object values are merged recursively.** Leaves replace.
+	 * - **List values replace wholesale** — RFC 7396 does not support
+	 *   per-element list patching. To remove one palette entry, send the full
+	 *   new palette.
+	 * - **Missing parent keys are created** when assigning into them.
+	 *
+	 * The operational key `removedShadowDefaults` is skipped here — it's
 	 * handled separately by `reify_shadow_removals()`.
 	 *
 	 * @param array $current
@@ -276,6 +306,25 @@ class CBT_Theme_Settings_Save {
 			if ( 'removedShadowDefaults' === $key ) {
 				continue;
 			}
+
+			// RFC 7396: null deletes the key.
+			if ( null === $value ) {
+				unset( $result[ $key ] );
+				continue;
+			}
+
+			// Empty array: RFC 7396 says `{}` is a no-op. PHP can't tell `{}`
+			// from `[]`, so we infer intent from the existing value:
+			//   - existing value is a list → caller intends to clear it.
+			//   - otherwise (existing is assoc, missing, or scalar) → no-op.
+			if ( is_array( $value ) && empty( $value ) ) {
+				if ( isset( $result[ $key ] ) && is_array( $result[ $key ] ) && self::is_list( $result[ $key ] ) ) {
+					$result[ $key ] = array();
+				}
+				continue;
+			}
+
+			// Deep merge associative-object → associative-object.
 			if (
 				is_array( $value ) &&
 				! self::is_list( $value ) &&

--- a/includes/create-theme/theme-settings-save.php
+++ b/includes/create-theme/theme-settings-save.php
@@ -169,24 +169,42 @@ class CBT_Theme_Settings_Save {
 			}
 		}
 
-		// Validate `name` slugs on customTemplates and templateParts entries
-		// (the `name` field is used as the file-system slug, e.g. templates/<name>.html).
-		foreach ( array( 'customTemplates', 'templateParts' ) as $list_key ) {
+		// Validate required keys + slug format on customTemplates and templateParts
+		// entries. `name` is required on both (used as the file-system slug,
+		// e.g. templates/<name>.html). `area` is required on templateParts;
+		// `title` is required on customTemplates.
+		$entry_required_keys = array(
+			'customTemplates' => array( 'name', 'title' ),
+			'templateParts'   => array( 'name', 'area' ),
+		);
+		foreach ( $entry_required_keys as $list_key => $required_keys ) {
 			if ( ! isset( $payload[ $list_key ] ) ) {
 				continue;
 			}
 			foreach ( $payload[ $list_key ] as $entry ) {
-				if ( ! isset( $entry['name'] ) ) {
-					continue;
+				foreach ( $required_keys as $required_key ) {
+					if ( ! isset( $entry[ $required_key ] ) || ! is_string( $entry[ $required_key ] ) || '' === $entry[ $required_key ] ) {
+						return new WP_Error(
+							'cbt_invalid_payload',
+							sprintf(
+								/* translators: 1: list key, 2: required key */
+								__( 'Entries of "%1$s" must have a non-empty string "%2$s" field.', 'create-block-theme' ),
+								$list_key,
+								$required_key
+							),
+							array( 'status' => 400 )
+						);
+					}
 				}
-				if ( ! is_string( $entry['name'] ) || sanitize_key( $entry['name'] ) !== $entry['name'] || '' === $entry['name'] ) {
+				// `name` must be a valid slug (used as filename).
+				if ( sanitize_key( $entry['name'] ) !== $entry['name'] ) {
 					return new WP_Error(
 						'cbt_invalid_payload',
 						sprintf(
 							/* translators: 1: list key, 2: invalid name */
 							__( 'Invalid "%1$s" entry name "%2$s". Names must be lowercase alphanumeric with dashes or underscores.', 'create-block-theme' ),
 							$list_key,
-							is_scalar( $entry['name'] ) ? (string) $entry['name'] : '?'
+							$entry['name']
 						),
 						array( 'status' => 400 )
 					);

--- a/includes/create-theme/theme-settings-save.php
+++ b/includes/create-theme/theme-settings-save.php
@@ -112,7 +112,13 @@ class CBT_Theme_Settings_Save {
 
 			$merged = self::merge( $current, $sanitized );
 
-			if ( array_key_exists( 'removedShadowDefaults', $sanitized ) ) {
+			// `isset()` (not `array_key_exists()`): the operational reify only
+			// runs when a real array of slugs was supplied. A `null` value at
+			// this key is treated as absent — equivalent to omitting the key
+			// from the payload entirely. This prevents `removedShadowDefaults:
+			// null` from reaching `reify_shadow_removals()` and violating its
+			// `array $removed_slugs` type.
+			if ( isset( $sanitized['removedShadowDefaults'] ) ) {
 				$merged = self::reify_shadow_removals( $merged, $sanitized['removedShadowDefaults'] );
 			}
 
@@ -136,8 +142,9 @@ class CBT_Theme_Settings_Save {
 
 	/**
 	 * Validate payload shape. Rejects unknown top-level keys and shape
-	 * mismatches. Returns the payload with the operational key extracted but
-	 * otherwise unchanged on success.
+	 * mismatches. Returns the payload unchanged on success. The operational
+	 * `removedShadowDefaults` key is handled later — skipped by `merge()` and
+	 * applied separately by `reify_shadow_removals()`.
 	 *
 	 * @param array $payload Raw payload from the request.
 	 * @return array|WP_Error
@@ -365,7 +372,10 @@ class CBT_Theme_Settings_Save {
 	 * - **Associative-object values are merged recursively.** Leaves replace.
 	 * - **List values replace wholesale** — RFC 7396 does not support
 	 *   per-element list patching. To remove one palette entry, send the full
-	 *   new palette.
+	 *   new palette. This means a caller editing only one entry must round-trip
+	 *   the entire list, so a non-modal caller (e.g., a hypothetical WP-CLI
+	 *   command per #828) needs to read-modify-write to avoid clobbering other
+	 *   entries. Intentional under the modal-owns-canonical-list design.
 	 * - **Missing parent keys are created** when assigning into them.
 	 *
 	 * The operational key `removedShadowDefaults` is skipped here — it's

--- a/includes/create-theme/theme-settings-save.php
+++ b/includes/create-theme/theme-settings-save.php
@@ -75,12 +75,16 @@ class CBT_Theme_Settings_Save {
 		$sanitized = self::sanitize( $validated );
 
 		// Serialize concurrent saves on a single host: hold an exclusive lock
-		// on a sibling lockfile around the read-merge-write sequence. This
-		// prevents two requests from reading stale state, merging in
-		// parallel, and one overwriting the other's disjoint changes. On
-		// distributed hosts where flock isn't honored (some NFS configs)
-		// this degrades to best-effort, hence the documented limitation.
-		$lock_path = get_stylesheet_directory() . '/theme.json.lock';
+		// on a process-temp lockfile (scoped by theme slug) around the
+		// read-merge-write sequence. This prevents two requests from reading
+		// stale state, merging in parallel, and one overwriting the other's
+		// disjoint changes. On distributed hosts where flock isn't honored
+		// (some NFS configs) this degrades to best-effort, hence the
+		// documented limitation.
+		//
+		// Stored in `get_temp_dir()` rather than the theme directory so the
+		// file isn't included in theme exports.
+		$lock_path = get_temp_dir() . 'cbt-theme-settings-' . md5( get_stylesheet() ) . '.lock';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 		$lock_handle = @fopen( $lock_path, 'c' );
 		if ( false === $lock_handle ) {

--- a/includes/create-theme/theme-settings-save.php
+++ b/includes/create-theme/theme-settings-save.php
@@ -13,9 +13,15 @@
  * invoking `run()`. The service performs payload-shape validation and
  * sanitization but does not authenticate.
  *
- * Known limitation: concurrent edits are last-write-wins. Two clients with
- * the modal open simultaneously will silently overwrite each other. ETag /
- * If-Match handling can be added if this becomes a problem in practice.
+ * Concurrent saves on a single host are serialized via `flock()` on a
+ * sibling lockfile (`theme.json.lock`), so disjoint edits from two clients
+ * compose correctly. The remaining limitation is conflicting same-key
+ * edits, which are still last-write-wins (the second save sees the first
+ * save's state after taking the lock, merges its payload on top, and the
+ * conflicting field gets the second client's value). Distributed hosts
+ * where `flock()` is not honored (some NFS configurations) degrade to
+ * best-effort. ETag / If-Match handling is a candidate follow-up if the
+ * remaining conflict case becomes a problem in practice.
  *
  * @package Create_Block_Theme
  * @see https://datatracker.ietf.org/doc/html/rfc7396 JSON Merge Patch
@@ -68,18 +74,51 @@ class CBT_Theme_Settings_Save {
 
 		$sanitized = self::sanitize( $validated );
 
-		$current = CBT_Theme_JSON_Resolver::get_theme_file_contents();
-		if ( ! is_array( $current ) ) {
-			$current = array();
+		// Serialize concurrent saves on a single host: hold an exclusive lock
+		// on a sibling lockfile around the read-merge-write sequence. This
+		// prevents two requests from reading stale state, merging in
+		// parallel, and one overwriting the other's disjoint changes. On
+		// distributed hosts where flock isn't honored (some NFS configs)
+		// this degrades to best-effort, hence the documented limitation.
+		$lock_path = get_stylesheet_directory() . '/theme.json.lock';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		$lock_handle = @fopen( $lock_path, 'c' );
+		if ( false === $lock_handle ) {
+			return new WP_Error(
+				'cbt_lock_failed',
+				__( 'Could not acquire theme.json save lock. Check filesystem permissions on the active theme directory.', 'create-block-theme' ),
+				array( 'status' => 503 )
+			);
+		}
+		if ( ! flock( $lock_handle, LOCK_EX ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+			fclose( $lock_handle );
+			return new WP_Error(
+				'cbt_lock_failed',
+				__( 'Could not acquire theme.json save lock.', 'create-block-theme' ),
+				array( 'status' => 503 )
+			);
 		}
 
-		$merged = self::merge( $current, $sanitized );
+		try {
+			$current = CBT_Theme_JSON_Resolver::get_theme_file_contents();
+			if ( ! is_array( $current ) ) {
+				$current = array();
+			}
 
-		if ( array_key_exists( 'removedShadowDefaults', $sanitized ) ) {
-			$merged = self::reify_shadow_removals( $merged, $sanitized['removedShadowDefaults'] );
+			$merged = self::merge( $current, $sanitized );
+
+			if ( array_key_exists( 'removedShadowDefaults', $sanitized ) ) {
+				$merged = self::reify_shadow_removals( $merged, $sanitized['removedShadowDefaults'] );
+			}
+
+			$wrote = CBT_Theme_JSON_Resolver::write_theme_file_contents( $merged );
+		} finally {
+			flock( $lock_handle, LOCK_UN );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+			fclose( $lock_handle );
 		}
 
-		$wrote = CBT_Theme_JSON_Resolver::write_theme_file_contents( $merged );
 		if ( true !== $wrote ) {
 			return new WP_Error(
 				'cbt_write_failed',
@@ -114,12 +153,24 @@ class CBT_Theme_Settings_Save {
 			}
 		}
 
-		if ( isset( $payload['settings'] ) && ! is_array( $payload['settings'] ) ) {
-			return new WP_Error(
-				'cbt_invalid_payload',
-				__( '"settings" must be an object.', 'create-block-theme' ),
-				array( 'status' => 400 )
-			);
+		if ( isset( $payload['settings'] ) ) {
+			if ( ! is_array( $payload['settings'] ) ) {
+				return new WP_Error(
+					'cbt_invalid_payload',
+					__( '"settings" must be an object.', 'create-block-theme' ),
+					array( 'status' => 400 )
+				);
+			}
+			// Reject JSON lists in an object position. Empty array is
+			// ambiguous in PHP (both `{}` and `[]` decode to `[]`) and is
+			// allowed — `merge()` handles it as a no-op.
+			if ( ! empty( $payload['settings'] ) && self::is_list( $payload['settings'] ) ) {
+				return new WP_Error(
+					'cbt_invalid_payload',
+					__( '"settings" must be an object, not a list.', 'create-block-theme' ),
+					array( 'status' => 400 )
+				);
+			}
 		}
 
 		foreach ( array( 'customTemplates', 'templateParts' ) as $list_key ) {
@@ -132,6 +183,19 @@ class CBT_Theme_Settings_Save {
 					sprintf(
 						/* translators: %s: payload key */
 						__( '"%s" must be an array.', 'create-block-theme' ),
+						$list_key
+					),
+					array( 'status' => 400 )
+				);
+			}
+			// Require a JSON list, not a JSON object. Empty array is ambiguous
+			// in PHP and is allowed.
+			if ( ! empty( $payload[ $list_key ] ) && ! self::is_list( $payload[ $list_key ] ) ) {
+				return new WP_Error(
+					'cbt_invalid_payload',
+					sprintf(
+						/* translators: %s: payload key */
+						__( '"%s" must be a list, not an object.', 'create-block-theme' ),
 						$list_key
 					),
 					array( 'status' => 400 )
@@ -157,6 +221,13 @@ class CBT_Theme_Settings_Save {
 				return new WP_Error(
 					'cbt_invalid_payload',
 					__( '"removedShadowDefaults" must be an array of slugs.', 'create-block-theme' ),
+					array( 'status' => 400 )
+				);
+			}
+			if ( ! empty( $payload['removedShadowDefaults'] ) && ! self::is_list( $payload['removedShadowDefaults'] ) ) {
+				return new WP_Error(
+					'cbt_invalid_payload',
+					__( '"removedShadowDefaults" must be a list, not an object.', 'create-block-theme' ),
 					array( 'status' => 400 )
 				);
 			}
@@ -333,6 +404,10 @@ class CBT_Theme_Settings_Save {
 				! self::is_list( $result[ $key ] )
 			) {
 				$result[ $key ] = self::merge( $result[ $key ], $value );
+			} elseif ( is_array( $value ) && self::is_list( $value ) ) {
+				// Normalize lists to a contiguous index. Defends against any
+				// sparse-keyed array slipping past validation.
+				$result[ $key ] = array_values( $value );
 			} else {
 				$result[ $key ] = $value;
 			}

--- a/includes/create-theme/theme-settings-save.php
+++ b/includes/create-theme/theme-settings-save.php
@@ -24,6 +24,23 @@ class CBT_Theme_Settings_Save {
 	);
 
 	/**
+	 * Keys whose string values are user-facing labels and benefit from
+	 * `sanitize_text_field()` (HTML stripping, whitespace normalization).
+	 */
+	const TEXT_FIELD_KEYS = array( 'name', 'title', 'label', 'description' );
+
+	/**
+	 * Keys whose string values are slug-formatted and pass through `sanitize_key()`.
+	 * Used for both leaf scalars and entries of slug-list keys (e.g., `postTypes`).
+	 */
+	const SLUG_FIELD_KEYS = array( 'slug', 'area' );
+
+	/**
+	 * Keys whose values are lists of slug strings (the entries — not the key — are slugs).
+	 */
+	const SLUG_LIST_KEYS = array( 'postTypes' );
+
+	/**
 	 * Persist a partial theme.json payload to the active theme's theme.json.
 	 *
 	 * @param array $payload Partial-theme.json payload from the modal.
@@ -49,7 +66,14 @@ class CBT_Theme_Settings_Save {
 			$merged = self::reify_shadow_removals( $merged, $sanitized['removedShadowDefaults'] );
 		}
 
-		CBT_Theme_JSON_Resolver::write_theme_file_contents( $merged );
+		$wrote = CBT_Theme_JSON_Resolver::write_theme_file_contents( $merged );
+		if ( true !== $wrote ) {
+			return new WP_Error(
+				'cbt_write_failed',
+				__( 'Failed to write theme.json. Check filesystem permissions on the active theme directory.', 'create-block-theme' ),
+				array( 'status' => 500 )
+			);
+		}
 
 		return $merged;
 	}
@@ -131,6 +155,42 @@ class CBT_Theme_Settings_Save {
 						array( 'status' => 400 )
 					);
 				}
+				if ( sanitize_key( $slug ) !== $slug || '' === $slug ) {
+					return new WP_Error(
+						'cbt_invalid_payload',
+						sprintf(
+							/* translators: %s: invalid slug */
+							__( 'Invalid shadow slug "%s". Slugs must be lowercase alphanumeric with dashes or underscores.', 'create-block-theme' ),
+							$slug
+						),
+						array( 'status' => 400 )
+					);
+				}
+			}
+		}
+
+		// Validate `name` slugs on customTemplates and templateParts entries
+		// (the `name` field is used as the file-system slug, e.g. templates/<name>.html).
+		foreach ( array( 'customTemplates', 'templateParts' ) as $list_key ) {
+			if ( ! isset( $payload[ $list_key ] ) ) {
+				continue;
+			}
+			foreach ( $payload[ $list_key ] as $entry ) {
+				if ( ! isset( $entry['name'] ) ) {
+					continue;
+				}
+				if ( ! is_string( $entry['name'] ) || sanitize_key( $entry['name'] ) !== $entry['name'] || '' === $entry['name'] ) {
+					return new WP_Error(
+						'cbt_invalid_payload',
+						sprintf(
+							/* translators: 1: list key, 2: invalid name */
+							__( 'Invalid "%1$s" entry name "%2$s". Names must be lowercase alphanumeric with dashes or underscores.', 'create-block-theme' ),
+							$list_key,
+							is_scalar( $entry['name'] ) ? (string) $entry['name'] : '?'
+						),
+						array( 'status' => 400 )
+					);
+				}
 			}
 		}
 
@@ -138,22 +198,44 @@ class CBT_Theme_Settings_Save {
 	}
 
 	/**
-	 * Recursively sanitize string leaves in the payload. Booleans and numbers
-	 * pass through; arrays recurse; strings are run through `sanitize_text_field`.
+	 * Recursively sanitize the payload, applying a context-aware sanitizer per
+	 * leaf based on the parent key.
 	 *
-	 * @param mixed $value
+	 * - `name`/`title`/`label`/`description` → `sanitize_text_field()` (HTML-stripped labels).
+	 * - `slug`/`area` → `sanitize_key()` (already validated to be slug-safe; this is belt-and-braces).
+	 * - Entries inside `postTypes` lists → `sanitize_key()`.
+	 * - Everything else (CSS values like `shadow`, `color`, `gradient`, `fontFamily`)
+	 *   → `wp_kses_no_null()` (strip NULL bytes only; preserve whitespace, parens, commas).
+	 *
+	 * Booleans and numbers pass through unchanged.
+	 *
+	 * @param mixed  $value      Value to sanitize.
+	 * @param string $parent_key The key under which `$value` lives (empty for the root).
+	 *                           For list entries, the list's key name.
 	 * @return mixed
 	 */
-	public static function sanitize( $value ) {
+	public static function sanitize( $value, $parent_key = '' ) {
 		if ( is_array( $value ) ) {
 			$out = array();
 			foreach ( $value as $k => $v ) {
-				$out[ $k ] = self::sanitize( $v );
+				// Associative-key children inherit their own key as context.
+				// List-entry children inherit the list's key as context.
+				$child_context = is_string( $k ) ? $k : $parent_key;
+				$out[ $k ]     = self::sanitize( $v, $child_context );
 			}
 			return $out;
 		}
 		if ( is_string( $value ) ) {
-			return sanitize_text_field( $value );
+			if ( in_array( $parent_key, self::TEXT_FIELD_KEYS, true ) ) {
+				return sanitize_text_field( $value );
+			}
+			if (
+				in_array( $parent_key, self::SLUG_FIELD_KEYS, true ) ||
+				in_array( $parent_key, self::SLUG_LIST_KEYS, true )
+			) {
+				return sanitize_key( $value );
+			}
+			return wp_kses_no_null( $value );
 		}
 		return $value;
 	}

--- a/includes/create-theme/theme-settings-save.php
+++ b/includes/create-theme/theme-settings-save.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * Theme Settings Save
+ *
+ * Persists Edit Theme Settings modal payloads to the active theme's theme.json.
+ * Accepts a partial-`theme.json` payload (only the keys the user edited),
+ * deep-merges it into the existing file, and writes the result. Reifies the
+ * `removedShadowDefaults` operational key into the standard
+ * `settings.shadow.defaultPresets` + `settings.shadow.presets` shape.
+ *
+ * Callers must enforce capability checks (`edit_theme_options`) before
+ * invoking `run()`. The service performs payload-shape validation and
+ * sanitization but does not authenticate.
+ *
+ * @package Create_Block_Theme
+ */
+class CBT_Theme_Settings_Save {
+
+	const ALLOWED_TOP_LEVEL_KEYS = array(
+		'settings',
+		'customTemplates',
+		'templateParts',
+		'removedShadowDefaults',
+	);
+
+	/**
+	 * Persist a partial theme.json payload to the active theme's theme.json.
+	 *
+	 * @param array $payload Partial-theme.json payload from the modal.
+	 * @return array|WP_Error Merged theme.json on success, WP_Error on validation
+	 *                       or write failure.
+	 */
+	public static function run( array $payload ) {
+		$validated = self::validate( $payload );
+		if ( is_wp_error( $validated ) ) {
+			return $validated;
+		}
+
+		$sanitized = self::sanitize( $validated );
+
+		$current = CBT_Theme_JSON_Resolver::get_theme_file_contents();
+		if ( ! is_array( $current ) ) {
+			$current = array();
+		}
+
+		$merged = self::merge( $current, $sanitized );
+
+		if ( array_key_exists( 'removedShadowDefaults', $sanitized ) ) {
+			$merged = self::reify_shadow_removals( $merged, $sanitized['removedShadowDefaults'] );
+		}
+
+		CBT_Theme_JSON_Resolver::write_theme_file_contents( $merged );
+
+		return $merged;
+	}
+
+	/**
+	 * Validate payload shape. Rejects unknown top-level keys and shape
+	 * mismatches. Returns the payload with the operational key extracted but
+	 * otherwise unchanged on success.
+	 *
+	 * @param array $payload Raw payload from the request.
+	 * @return array|WP_Error
+	 */
+	public static function validate( array $payload ) {
+		foreach ( $payload as $key => $value ) {
+			if ( ! in_array( $key, self::ALLOWED_TOP_LEVEL_KEYS, true ) ) {
+				return new WP_Error(
+					'cbt_invalid_payload',
+					sprintf(
+						/* translators: %s: unknown payload key */
+						__( 'Unknown top-level key: %s', 'create-block-theme' ),
+						$key
+					),
+					array( 'status' => 400 )
+				);
+			}
+		}
+
+		if ( isset( $payload['settings'] ) && ! is_array( $payload['settings'] ) ) {
+			return new WP_Error(
+				'cbt_invalid_payload',
+				__( '"settings" must be an object.', 'create-block-theme' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		foreach ( array( 'customTemplates', 'templateParts' ) as $list_key ) {
+			if ( ! isset( $payload[ $list_key ] ) ) {
+				continue;
+			}
+			if ( ! is_array( $payload[ $list_key ] ) ) {
+				return new WP_Error(
+					'cbt_invalid_payload',
+					sprintf(
+						/* translators: %s: payload key */
+						__( '"%s" must be an array.', 'create-block-theme' ),
+						$list_key
+					),
+					array( 'status' => 400 )
+				);
+			}
+			foreach ( $payload[ $list_key ] as $entry ) {
+				if ( ! is_array( $entry ) ) {
+					return new WP_Error(
+						'cbt_invalid_payload',
+						sprintf(
+							/* translators: %s: payload key */
+							__( 'Entries of "%s" must be objects.', 'create-block-theme' ),
+							$list_key
+						),
+						array( 'status' => 400 )
+					);
+				}
+			}
+		}
+
+		if ( isset( $payload['removedShadowDefaults'] ) ) {
+			if ( ! is_array( $payload['removedShadowDefaults'] ) ) {
+				return new WP_Error(
+					'cbt_invalid_payload',
+					__( '"removedShadowDefaults" must be an array of slugs.', 'create-block-theme' ),
+					array( 'status' => 400 )
+				);
+			}
+			foreach ( $payload['removedShadowDefaults'] as $slug ) {
+				if ( ! is_string( $slug ) ) {
+					return new WP_Error(
+						'cbt_invalid_payload',
+						__( 'Entries of "removedShadowDefaults" must be strings.', 'create-block-theme' ),
+						array( 'status' => 400 )
+					);
+				}
+			}
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Recursively sanitize string leaves in the payload. Booleans and numbers
+	 * pass through; arrays recurse; strings are run through `sanitize_text_field`.
+	 *
+	 * @param mixed $value
+	 * @return mixed
+	 */
+	public static function sanitize( $value ) {
+		if ( is_array( $value ) ) {
+			$out = array();
+			foreach ( $value as $k => $v ) {
+				$out[ $k ] = self::sanitize( $v );
+			}
+			return $out;
+		}
+		if ( is_string( $value ) ) {
+			return sanitize_text_field( $value );
+		}
+		return $value;
+	}
+
+	/**
+	 * Deep-merge $payload into $current. At every level, associative-array
+	 * values are merged recursively; lists, scalars, and empty arrays replace
+	 * the existing value. Missing parent keys are created.
+	 *
+	 * The operational key `removedShadowDefaults` is dropped here — it's
+	 * handled separately by `reify_shadow_removals()`.
+	 *
+	 * @param array $current
+	 * @param array $payload
+	 * @return array
+	 */
+	public static function merge( array $current, array $payload ) {
+		$result = $current;
+		foreach ( $payload as $key => $value ) {
+			if ( 'removedShadowDefaults' === $key ) {
+				continue;
+			}
+			if (
+				is_array( $value ) &&
+				! self::is_list( $value ) &&
+				isset( $result[ $key ] ) &&
+				is_array( $result[ $key ] ) &&
+				! self::is_list( $result[ $key ] )
+			) {
+				$result[ $key ] = self::merge( $result[ $key ], $value );
+			} else {
+				$result[ $key ] = $value;
+			}
+		}
+		return $result;
+	}
+
+	/**
+	 * Translate `removedShadowDefaults: [slug, ...]` into the theme.json shape:
+	 * `settings.shadow.defaultPresets: false` plus the kept core shadow
+	 * defaults re-registered under `settings.shadow.presets`. User-defined
+	 * presets (slugs that are not core defaults) are preserved.
+	 *
+	 * Idempotent: running the same removal twice produces the same output.
+	 *
+	 * @param array    $merged        Merged theme.json (post `merge()`).
+	 * @param string[] $removed_slugs Slugs of core defaults to remove.
+	 * @return array
+	 */
+	public static function reify_shadow_removals( array $merged, array $removed_slugs ) {
+		$core_presets = self::get_core_shadow_presets();
+		if ( empty( $core_presets ) ) {
+			return $merged;
+		}
+
+		$core_slugs = array_column( $core_presets, 'slug' );
+		$kept       = array_values(
+			array_filter(
+				$core_presets,
+				static function ( $preset ) use ( $removed_slugs ) {
+					return ! in_array( $preset['slug'], $removed_slugs, true );
+				}
+			)
+		);
+
+		$existing = isset( $merged['settings']['shadow']['presets'] ) && is_array( $merged['settings']['shadow']['presets'] )
+			? $merged['settings']['shadow']['presets']
+			: array();
+
+		// Strip any existing presets whose slug matches a core default slug —
+		// we re-register the kept defaults below, so this prevents duplication.
+		$user_customs = array_values(
+			array_filter(
+				$existing,
+				static function ( $preset ) use ( $core_slugs ) {
+					return isset( $preset['slug'] ) && ! in_array( $preset['slug'], $core_slugs, true );
+				}
+			)
+		);
+
+		if ( ! isset( $merged['settings'] ) || ! is_array( $merged['settings'] ) ) {
+			$merged['settings'] = array();
+		}
+		if ( ! isset( $merged['settings']['shadow'] ) || ! is_array( $merged['settings']['shadow'] ) ) {
+			$merged['settings']['shadow'] = array();
+		}
+
+		$merged['settings']['shadow']['defaultPresets'] = false;
+		$merged['settings']['shadow']['presets']        = array_merge( $user_customs, $kept );
+
+		return $merged;
+	}
+
+	/**
+	 * Fetch the core shadow defaults via `wp_get_global_settings`. Returns an
+	 * empty array if core does not expose shadow defaults (older WP versions
+	 * or unusual environments) — in which case shadow reification is a no-op
+	 * and the caller's `defaultPresets` flag round-trips literally.
+	 *
+	 * `wp_get_global_settings` returns presets keyed by origin
+	 * (`['default' => [...]]`); we extract the `default` slot.
+	 *
+	 * @return array<int, array{slug: string, name?: string, shadow: string}>
+	 */
+	public static function get_core_shadow_presets() {
+		if ( ! function_exists( 'wp_get_global_settings' ) ) {
+			return array();
+		}
+		$presets = wp_get_global_settings( array( 'shadow', 'presets' ) );
+		if ( is_array( $presets ) && isset( $presets['default'] ) && is_array( $presets['default'] ) ) {
+			return $presets['default'];
+		}
+		return array();
+	}
+
+	/**
+	 * Detect whether an array is a list (sequential integer keys starting at 0).
+	 * Mirrors PHP 8.1+ `array_is_list()`.
+	 *
+	 * @param array $arr
+	 * @return bool
+	 */
+	private static function is_list( array $arr ) {
+		if ( function_exists( 'array_is_list' ) ) {
+			return array_is_list( $arr );
+		}
+		if ( array() === $arr ) {
+			return true;
+		}
+		$expected = 0;
+		foreach ( $arr as $key => $_v ) {
+			if ( $key !== $expected++ ) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/tests/test-theme-settings-save.php
+++ b/tests/test-theme-settings-save.php
@@ -243,4 +243,153 @@ class Test_CBT_Theme_Settings_Save extends WP_UnitTestCase {
 		$slugs       = array_column( $out['settings']['shadow']['presets'], 'slug' );
 		$this->assertContains( 'my-custom-shadow', $slugs );
 	}
+
+	/* ---------------------------------------------------------------- *
+	 * sanitize() — context-aware (CSS values must round-trip)
+	 * ---------------------------------------------------------------- */
+
+	public function test_sanitize_preserves_complex_shadow_value() {
+		$shadow = '6px 6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0)';
+		$out    = CBT_Theme_Settings_Save::sanitize(
+			array(
+				'settings' => array(
+					'shadow' => array(
+						'presets' => array(
+							array(
+								'slug'   => 'outlined',
+								'name'   => 'Outlined',
+								'shadow' => $shadow,
+							),
+						),
+					),
+				),
+			)
+		);
+		$this->assertSame( $shadow, $out['settings']['shadow']['presets'][0]['shadow'] );
+	}
+
+	public function test_sanitize_preserves_gradient_value() {
+		$gradient = 'linear-gradient(135deg, rgb(6, 147, 227) 0%, rgb(155, 81, 224) 100%)';
+		$out      = CBT_Theme_Settings_Save::sanitize(
+			array(
+				'settings' => array(
+					'color' => array(
+						'gradients' => array(
+							array(
+								'slug'     => 'vivid',
+								'name'     => 'Vivid',
+								'gradient' => $gradient,
+							),
+						),
+					),
+				),
+			)
+		);
+		$this->assertSame( $gradient, $out['settings']['color']['gradients'][0]['gradient'] );
+	}
+
+	public function test_sanitize_post_types_entries_are_slug_normalized() {
+		$out = CBT_Theme_Settings_Save::sanitize(
+			array(
+				'customTemplates' => array(
+					array(
+						'name'      => 'page-wide',
+						'title'     => 'Wide Page',
+						'postTypes' => array( 'Page', 'POST' ),
+					),
+				),
+			)
+		);
+		// `sanitize_key` lowercases.
+		$this->assertSame( array( 'page', 'post' ), $out['customTemplates'][0]['postTypes'] );
+	}
+
+	/* ---------------------------------------------------------------- *
+	 * validate() — slug rejection
+	 * ---------------------------------------------------------------- */
+
+	public function test_validate_rejects_removed_shadow_slug_with_invalid_chars() {
+		$result = CBT_Theme_Settings_Save::validate(
+			array( 'removedShadowDefaults' => array( 'natural', 'has spaces' ) )
+		);
+		$this->assertWPError( $result );
+		$this->assertSame( 'cbt_invalid_payload', $result->get_error_code() );
+	}
+
+	public function test_validate_rejects_custom_template_name_with_invalid_chars() {
+		$result = CBT_Theme_Settings_Save::validate(
+			array(
+				'customTemplates' => array(
+					array(
+						'name'  => 'Has Caps',
+						'title' => 'Caps Page',
+					),
+				),
+			)
+		);
+		$this->assertWPError( $result );
+	}
+
+	public function test_validate_accepts_well_formed_slugs() {
+		$payload = array(
+			'removedShadowDefaults' => array( 'natural', 'sharp_2' ),
+			'customTemplates'       => array(
+				array(
+					'name'  => 'page-wide-2',
+					'title' => 'Wide Page',
+				),
+			),
+		);
+		$this->assertSame( $payload, CBT_Theme_Settings_Save::validate( $payload ) );
+	}
+
+	/* ---------------------------------------------------------------- *
+	 * run() — write-failure path
+	 *
+	 * Verified via integration: a hardened service should surface a write
+	 * failure as WP_Error rather than returning the merged payload as if it
+	 * had been persisted. Smoke tests the unhappy path of
+	 * `CBT_Theme_JSON_Resolver::write_theme_file_contents`.
+	 * ---------------------------------------------------------------- */
+
+	public function test_run_returns_wp_error_on_write_failure() {
+		// Create a temp theme directory with a read-only theme.json. Point the
+		// resolver at it via the stylesheet_directory filter; file_put_contents
+		// will fail because the file is not writable, which the service must
+		// surface as WP_Error rather than reporting SUCCESS.
+		$tmp_dir    = sys_get_temp_dir() . '/cbt-test-' . uniqid();
+		$theme_json = $tmp_dir . '/theme.json';
+		mkdir( $tmp_dir );
+		file_put_contents( $theme_json, '{}' );
+		chmod( $theme_json, 0444 );
+		// Best-effort guard: skip if running as root (chmod is meaningless).
+		if ( is_writable( $theme_json ) ) {
+			chmod( $theme_json, 0644 );
+			unlink( $theme_json );
+			rmdir( $tmp_dir );
+			$this->markTestSkipped( 'Cannot make file read-only in this environment.' );
+		}
+
+		$filter = static function () use ( $tmp_dir ) {
+			return $tmp_dir;
+		};
+		add_filter( 'stylesheet_directory', $filter );
+		add_filter( 'template_directory', $filter );
+
+		$result = CBT_Theme_Settings_Save::run(
+			array( 'settings' => array( 'color' => array( 'custom' => true ) ) )
+		);
+
+		remove_filter( 'stylesheet_directory', $filter );
+		remove_filter( 'template_directory', $filter );
+
+		// Cleanup.
+		chmod( $theme_json, 0644 );
+		unlink( $theme_json );
+		rmdir( $tmp_dir );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'cbt_write_failed', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
 }

--- a/tests/test-theme-settings-save.php
+++ b/tests/test-theme-settings-save.php
@@ -473,6 +473,82 @@ class Test_CBT_Theme_Settings_Save extends WP_UnitTestCase {
 	}
 
 	/* ---------------------------------------------------------------- *
+	 * validate() — JSON shape (object vs list) enforcement
+	 *
+	 * PHP's `json_decode(..., true)` flattens `{}` and `[]` to the same empty
+	 * array, but a non-empty JSON list passed where an object is expected
+	 * (or vice versa) is detectable and should be rejected.
+	 * ---------------------------------------------------------------- */
+
+	public function test_validate_rejects_settings_passed_as_non_empty_list() {
+		$result = CBT_Theme_Settings_Save::validate(
+			array( 'settings' => array( array( 'foo' => 'bar' ) ) )
+		);
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'object', $result->get_error_message() );
+	}
+
+	public function test_validate_rejects_custom_templates_passed_as_object() {
+		$result = CBT_Theme_Settings_Save::validate(
+			array(
+				'customTemplates' => array(
+					'page-wide' => array(
+						'name'  => 'page-wide',
+						'title' => 'Wide Page',
+					),
+				),
+			)
+		);
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'list', $result->get_error_message() );
+	}
+
+	public function test_validate_rejects_removed_shadow_defaults_passed_as_object() {
+		$result = CBT_Theme_Settings_Save::validate(
+			array( 'removedShadowDefaults' => array( 'natural' => true ) )
+		);
+		$this->assertWPError( $result );
+	}
+
+	public function test_validate_accepts_empty_arrays_for_either_shape() {
+		// Empty arrays are intentionally permitted regardless of expected
+		// shape — they're handled in merge() (no-op for object positions,
+		// clear for list positions where the existing value is a list).
+		$payload = array(
+			'settings'              => array(),
+			'customTemplates'       => array(),
+			'templateParts'         => array(),
+			'removedShadowDefaults' => array(),
+		);
+		$this->assertSame( $payload, CBT_Theme_Settings_Save::validate( $payload ) );
+	}
+
+	/* ---------------------------------------------------------------- *
+	 * merge() — list normalization
+	 * ---------------------------------------------------------------- */
+
+	public function test_merge_writes_lists_with_sequential_keys() {
+		// Routes a proper list payload through the `is_list`-true branch and
+		// confirms it lands with sequential integer keys (i.e., emits as a
+		// JSON list, not an object, when serialized).
+		$current = array();
+		$payload = array(
+			'customTemplates' => array(
+				array(
+					'name'  => 'a',
+					'title' => 'A',
+				),
+				array(
+					'name'  => 'b',
+					'title' => 'B',
+				),
+			),
+		);
+		$out     = CBT_Theme_Settings_Save::merge( $current, $payload );
+		$this->assertSame( array( 0, 1 ), array_keys( $out['customTemplates'] ) );
+	}
+
+	/* ---------------------------------------------------------------- *
 	 * run() — write-failure path
 	 *
 	 * Verified via integration: a hardened service should surface a write
@@ -518,7 +594,17 @@ class Test_CBT_Theme_Settings_Save extends WP_UnitTestCase {
 		rmdir( $tmp_dir );
 
 		$this->assertWPError( $result );
-		$this->assertSame( 'cbt_write_failed', $result->get_error_code() );
-		$this->assertSame( 500, $result->get_error_data()['status'] );
+		// A read-only theme directory blocks both lockfile creation and the
+		// atomic write. Accept either failure code; both are correct surfaces
+		// for "the filesystem said no" and both protect against the original
+		// silent-success bug.
+		$this->assertContains(
+			$result->get_error_code(),
+			array( 'cbt_lock_failed', 'cbt_write_failed' )
+		);
+		$this->assertContains(
+			(int) $result->get_error_data()['status'],
+			array( 500, 503 )
+		);
 	}
 }

--- a/tests/test-theme-settings-save.php
+++ b/tests/test-theme-settings-save.php
@@ -343,6 +343,56 @@ class Test_CBT_Theme_Settings_Save extends WP_UnitTestCase {
 		$this->assertSame( $payload, CBT_Theme_Settings_Save::validate( $payload ) );
 	}
 
+	public function test_validate_rejects_custom_template_entry_missing_title() {
+		$result = CBT_Theme_Settings_Save::validate(
+			array( 'customTemplates' => array( array( 'name' => 'page-wide' ) ) )
+		);
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'title', $result->get_error_message() );
+	}
+
+	public function test_validate_rejects_template_part_entry_missing_area() {
+		$result = CBT_Theme_Settings_Save::validate(
+			array( 'templateParts' => array( array( 'name' => 'sidebar' ) ) )
+		);
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'area', $result->get_error_message() );
+	}
+
+	public function test_validate_rejects_entry_with_empty_required_key() {
+		$result = CBT_Theme_Settings_Save::validate(
+			array(
+				'customTemplates' => array(
+					array(
+						'name'  => 'page-wide',
+						'title' => '',
+					),
+				),
+			)
+		);
+		$this->assertWPError( $result );
+	}
+
+	public function test_validate_rejects_template_part_missing_name() {
+		$result = CBT_Theme_Settings_Save::validate(
+			array( 'templateParts' => array( array( 'area' => 'header' ) ) )
+		);
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'name', $result->get_error_message() );
+	}
+
+	public function test_validate_accepts_complete_template_part_entry() {
+		$payload = array(
+			'templateParts' => array(
+				array(
+					'name' => 'sidebar',
+					'area' => 'uncategorized',
+				),
+			),
+		);
+		$this->assertSame( $payload, CBT_Theme_Settings_Save::validate( $payload ) );
+	}
+
 	/* ---------------------------------------------------------------- *
 	 * run() — write-failure path
 	 *

--- a/tests/test-theme-settings-save.php
+++ b/tests/test-theme-settings-save.php
@@ -607,4 +607,48 @@ class Test_CBT_Theme_Settings_Save extends WP_UnitTestCase {
 			array( 500, 503 )
 		);
 	}
+
+	/* ---------------------------------------------------------------- *
+	 * writer — encoding-failure path must not touch the existing file
+	 * ---------------------------------------------------------------- */
+
+	public function test_writer_does_not_overwrite_on_encoding_failure() {
+		// Set up a temp theme directory with a known theme.json. Point the
+		// resolver at it via the stylesheet_directory filter. Call the writer
+		// with an unencodable payload (a PHP resource). The writer must
+		// return false and leave the original theme.json byte-for-byte
+		// untouched. Guards against the bug where wp_json_encode returns
+		// false and we'd otherwise truncate the existing file or write an
+		// empty string in its place.
+		$tmp_dir       = sys_get_temp_dir() . '/cbt-encode-test-' . uniqid();
+		$theme_json    = $tmp_dir . '/theme.json';
+		$known_content = '{"version":3,"settings":{"existing":"data"}}';
+		mkdir( $tmp_dir );
+		file_put_contents( $theme_json, $known_content );
+
+		$filter = static function () use ( $tmp_dir ) {
+			return $tmp_dir;
+		};
+		add_filter( 'stylesheet_directory', $filter );
+		add_filter( 'template_directory', $filter );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		$resource = fopen( 'php://memory', 'r' );
+		$payload  = array( 'unencodable' => $resource );
+		$result   = CBT_Theme_JSON_Resolver::write_theme_file_contents( $payload );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		fclose( $resource );
+
+		remove_filter( 'stylesheet_directory', $filter );
+		remove_filter( 'template_directory', $filter );
+
+		$on_disk = file_get_contents( $theme_json );
+
+		// Cleanup before asserts so the temp tree is removed even if asserts fail.
+		unlink( $theme_json );
+		rmdir( $tmp_dir );
+
+		$this->assertFalse( $result, 'Writer should return false when wp_json_encode fails.' );
+		$this->assertSame( $known_content, $on_disk, 'theme.json must be byte-for-byte unchanged on encode failure.' );
+	}
 }

--- a/tests/test-theme-settings-save.php
+++ b/tests/test-theme-settings-save.php
@@ -651,4 +651,76 @@ class Test_CBT_Theme_Settings_Save extends WP_UnitTestCase {
 		$this->assertFalse( $result, 'Writer should return false when wp_json_encode fails.' );
 		$this->assertSame( $known_content, $on_disk, 'theme.json must be byte-for-byte unchanged on encode failure.' );
 	}
+
+	/* ---------------------------------------------------------------- *
+	 * REST handler — malformed request bodies must return 400, not 500
+	 * ---------------------------------------------------------------- */
+
+	public function test_rest_handler_rejects_empty_body() {
+		// An empty body decodes to null. Without the handler-level guard,
+		// the service signature would TypeError on `array $payload`.
+		$api     = new CBT_Theme_API();
+		$request = new WP_REST_Request( 'POST', '/create-block-theme/v1/theme-settings' );
+		$result  = $api->rest_save_theme_settings( $request );
+		$this->assertWPError( $result );
+		$this->assertSame( 'cbt_invalid_payload', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	public function test_rest_handler_rejects_scalar_body() {
+		$api     = new CBT_Theme_API();
+		$request = new WP_REST_Request( 'POST', '/create-block-theme/v1/theme-settings' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( '42' );
+		$result = $api->rest_save_theme_settings( $request );
+		$this->assertWPError( $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	public function test_rest_handler_rejects_null_body() {
+		$api     = new CBT_Theme_API();
+		$request = new WP_REST_Request( 'POST', '/create-block-theme/v1/theme-settings' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( 'null' );
+		$result = $api->rest_save_theme_settings( $request );
+		$this->assertWPError( $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	/* ---------------------------------------------------------------- *
+	 * run() — `removedShadowDefaults: null` is a no-op, not a TypeError
+	 * ---------------------------------------------------------------- */
+
+	public function test_run_treats_null_removed_shadow_defaults_as_no_op() {
+		// Set up a temp theme directory so run() can complete its write.
+		$tmp_dir    = sys_get_temp_dir() . '/cbt-null-rsd-test-' . uniqid();
+		$theme_json = $tmp_dir . '/theme.json';
+		mkdir( $tmp_dir );
+		file_put_contents( $theme_json, '{}' );
+
+		$filter = static function () use ( $tmp_dir ) {
+			return $tmp_dir;
+		};
+		add_filter( 'stylesheet_directory', $filter );
+		add_filter( 'template_directory', $filter );
+
+		$result = CBT_Theme_Settings_Save::run(
+			array(
+				'settings'              => array( 'color' => array( 'custom' => true ) ),
+				'removedShadowDefaults' => null,
+			)
+		);
+
+		remove_filter( 'stylesheet_directory', $filter );
+		remove_filter( 'template_directory', $filter );
+
+		// Cleanup.
+		unlink( $theme_json );
+		rmdir( $tmp_dir );
+
+		// Should not WP_Error and should not have reified — shadow section
+		// should be absent from the merged result because reify never ran.
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'shadow', $result['settings'] ?? array() );
+	}
 }

--- a/tests/test-theme-settings-save.php
+++ b/tests/test-theme-settings-save.php
@@ -199,6 +199,85 @@ class Test_CBT_Theme_Settings_Save extends WP_UnitTestCase {
 	}
 
 	/* ---------------------------------------------------------------- *
+	 * merge() — RFC 7396 semantics
+	 * ---------------------------------------------------------------- */
+
+	public function test_merge_null_deletes_existing_key() {
+		$current = array(
+			'settings' => array(
+				'color' => array(
+					'custom'         => true,
+					'defaultPalette' => true,
+				),
+			),
+		);
+		$payload = array(
+			'settings' => array( 'color' => array( 'custom' => null ) ),
+		);
+		$out     = CBT_Theme_Settings_Save::merge( $current, $payload );
+		$this->assertArrayNotHasKey( 'custom', $out['settings']['color'] );
+		$this->assertTrue( $out['settings']['color']['defaultPalette'] );
+	}
+
+	public function test_merge_null_for_missing_key_is_no_op() {
+		$current = array( 'settings' => array( 'color' => array( 'custom' => true ) ) );
+		$payload = array( 'settings' => array( 'color' => array( 'doesNotExist' => null ) ) );
+		$out     = CBT_Theme_Settings_Save::merge( $current, $payload );
+		$this->assertTrue( $out['settings']['color']['custom'] );
+		$this->assertArrayNotHasKey( 'doesNotExist', $out['settings']['color'] );
+	}
+
+	public function test_merge_empty_object_at_top_level_is_no_op() {
+		// The footgun the JSON-Merge-Patch contract closes: `settings: {}` must
+		// not wipe everything in the existing settings tree.
+		$current = array(
+			'settings' => array(
+				'color'   => array( 'custom' => true ),
+				'spacing' => array( 'padding' => true ),
+			),
+		);
+		$payload = array( 'settings' => array() );
+		$out     = CBT_Theme_Settings_Save::merge( $current, $payload );
+		$this->assertSame( $current, $out );
+	}
+
+	public function test_merge_empty_object_nested_is_no_op() {
+		$current = array(
+			'settings' => array(
+				'color' => array(
+					'custom'  => true,
+					'palette' => array( array( 'slug' => 'a' ) ),
+				),
+			),
+		);
+		$payload = array( 'settings' => array( 'color' => array() ) );
+		$out     = CBT_Theme_Settings_Save::merge( $current, $payload );
+		$this->assertSame( $current, $out );
+	}
+
+	public function test_merge_empty_for_existing_list_still_clears() {
+		// `palette: []` should still clear the palette, because palette is a
+		// list (its current value is a sequential array).
+		$current = array(
+			'settings' => array(
+				'color' => array( 'palette' => array( array( 'slug' => 'a' ) ) ),
+			),
+		);
+		$payload = array( 'settings' => array( 'color' => array( 'palette' => array() ) ) );
+		$out     = CBT_Theme_Settings_Save::merge( $current, $payload );
+		$this->assertSame( array(), $out['settings']['color']['palette'] );
+	}
+
+	public function test_merge_empty_for_missing_list_is_no_op() {
+		// payload `customTemplates: []` against a theme.json that doesn't have
+		// a customTemplates key at all → no-op (don't create an empty list).
+		$current = array( 'settings' => array() );
+		$payload = array( 'customTemplates' => array() );
+		$out     = CBT_Theme_Settings_Save::merge( $current, $payload );
+		$this->assertArrayNotHasKey( 'customTemplates', $out );
+	}
+
+	/* ---------------------------------------------------------------- *
 	 * reify_shadow_removals()
 	 * ---------------------------------------------------------------- */
 
@@ -403,21 +482,21 @@ class Test_CBT_Theme_Settings_Save extends WP_UnitTestCase {
 	 * ---------------------------------------------------------------- */
 
 	public function test_run_returns_wp_error_on_write_failure() {
-		// Create a temp theme directory with a read-only theme.json. Point the
-		// resolver at it via the stylesheet_directory filter; file_put_contents
-		// will fail because the file is not writable, which the service must
-		// surface as WP_Error rather than reporting SUCCESS.
+		// Create a temp theme directory with a theme.json, then make the
+		// directory read-only so the atomic write (write-temp-then-rename)
+		// can't create its `theme.json.tmp` sibling. The service must surface
+		// the failure as WP_Error rather than reporting SUCCESS.
 		$tmp_dir    = sys_get_temp_dir() . '/cbt-test-' . uniqid();
 		$theme_json = $tmp_dir . '/theme.json';
 		mkdir( $tmp_dir );
 		file_put_contents( $theme_json, '{}' );
-		chmod( $theme_json, 0444 );
+		chmod( $tmp_dir, 0555 );
 		// Best-effort guard: skip if running as root (chmod is meaningless).
-		if ( is_writable( $theme_json ) ) {
-			chmod( $theme_json, 0644 );
+		if ( is_writable( $tmp_dir ) ) {
+			chmod( $tmp_dir, 0755 );
 			unlink( $theme_json );
 			rmdir( $tmp_dir );
-			$this->markTestSkipped( 'Cannot make file read-only in this environment.' );
+			$this->markTestSkipped( 'Cannot make directory read-only in this environment.' );
 		}
 
 		$filter = static function () use ( $tmp_dir ) {
@@ -434,7 +513,7 @@ class Test_CBT_Theme_Settings_Save extends WP_UnitTestCase {
 		remove_filter( 'template_directory', $filter );
 
 		// Cleanup.
-		chmod( $theme_json, 0644 );
+		chmod( $tmp_dir, 0755 );
 		unlink( $theme_json );
 		rmdir( $tmp_dir );
 

--- a/tests/test-theme-settings-save.php
+++ b/tests/test-theme-settings-save.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * @package Create_Block_Theme
+ */
+class Test_CBT_Theme_Settings_Save extends WP_UnitTestCase {
+
+	/* ---------------------------------------------------------------- *
+	 * validate()
+	 * ---------------------------------------------------------------- */
+
+	public function test_validate_accepts_known_top_level_keys() {
+		$payload = array(
+			'settings'              => array( 'color' => array( 'custom' => true ) ),
+			'customTemplates'       => array(),
+			'templateParts'         => array(),
+			'removedShadowDefaults' => array( 'natural' ),
+		);
+		$this->assertSame( $payload, CBT_Theme_Settings_Save::validate( $payload ) );
+	}
+
+	public function test_validate_rejects_unknown_top_level_key() {
+		$result = CBT_Theme_Settings_Save::validate( array( 'unexpected' => 1 ) );
+		$this->assertWPError( $result );
+		$this->assertSame( 'cbt_invalid_payload', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	public function test_validate_rejects_settings_not_array() {
+		$result = CBT_Theme_Settings_Save::validate( array( 'settings' => 'oops' ) );
+		$this->assertWPError( $result );
+	}
+
+	public function test_validate_rejects_custom_templates_entries_not_objects() {
+		$result = CBT_Theme_Settings_Save::validate(
+			array( 'customTemplates' => array( 'not-an-object' ) )
+		);
+		$this->assertWPError( $result );
+	}
+
+	public function test_validate_rejects_removed_shadow_defaults_entries_not_strings() {
+		$result = CBT_Theme_Settings_Save::validate(
+			array( 'removedShadowDefaults' => array( 1 ) )
+		);
+		$this->assertWPError( $result );
+	}
+
+	/* ---------------------------------------------------------------- *
+	 * sanitize()
+	 * ---------------------------------------------------------------- */
+
+	public function test_sanitize_strips_tags_from_string_values() {
+		$out = CBT_Theme_Settings_Save::sanitize(
+			array(
+				'settings' => array(
+					'color' => array(
+						'palette' => array(
+							array(
+								'slug'  => 'brand',
+								'name'  => '<script>alert(1)</script>Brand',
+								'color' => '#fff',
+							),
+						),
+					),
+				),
+			)
+		);
+		$this->assertSame( 'Brand', $out['settings']['color']['palette'][0]['name'] );
+	}
+
+	public function test_sanitize_preserves_booleans_and_numbers() {
+		$out = CBT_Theme_Settings_Save::sanitize(
+			array(
+				'settings' => array(
+					'color'   => array(
+						'custom'         => false,
+						'defaultPalette' => true,
+					),
+					'spacing' => array( 'padding' => 16 ),
+				),
+			)
+		);
+		$this->assertSame( false, $out['settings']['color']['custom'] );
+		$this->assertSame( true, $out['settings']['color']['defaultPalette'] );
+		$this->assertSame( 16, $out['settings']['spacing']['padding'] );
+	}
+
+	public function test_sanitize_preserves_camel_case_keys() {
+		$out = CBT_Theme_Settings_Save::sanitize(
+			array( 'settings' => array( 'color' => array( 'defaultPalette' => true ) ) )
+		);
+		$this->assertArrayHasKey( 'defaultPalette', $out['settings']['color'] );
+	}
+
+	/* ---------------------------------------------------------------- *
+	 * merge()
+	 * ---------------------------------------------------------------- */
+
+	public function test_merge_partial_settings_color_palette_leaves_other_keys_untouched() {
+		$current = array(
+			'settings' => array(
+				'color'   => array(
+					'palette'   => array(
+						array(
+							'slug'  => 'old',
+							'color' => '#000',
+						),
+					),
+					'gradients' => array(
+						array(
+							'slug'     => 'g1',
+							'gradient' => 'linear-gradient(red,blue)',
+						),
+					),
+					'custom'    => true,
+				),
+				'spacing' => array( 'padding' => true ),
+			),
+		);
+		$payload = array(
+			'settings' => array(
+				'color' => array(
+					'palette' => array(
+						array(
+							'slug'  => 'new',
+							'color' => '#fff',
+						),
+					),
+				),
+			),
+		);
+		$out     = CBT_Theme_Settings_Save::merge( $current, $payload );
+		$this->assertSame( 'new', $out['settings']['color']['palette'][0]['slug'] );
+		$this->assertSame( 'g1', $out['settings']['color']['gradients'][0]['slug'] );
+		$this->assertTrue( $out['settings']['color']['custom'] );
+		$this->assertTrue( $out['settings']['spacing']['padding'] );
+	}
+
+	public function test_merge_empty_palette_array_clears_palette() {
+		$current = array(
+			'settings' => array(
+				'color' => array( 'palette' => array( array( 'slug' => 'a' ) ) ),
+			),
+		);
+		$payload = array( 'settings' => array( 'color' => array( 'palette' => array() ) ) );
+		$out     = CBT_Theme_Settings_Save::merge( $current, $payload );
+		$this->assertSame( array(), $out['settings']['color']['palette'] );
+	}
+
+	public function test_merge_creates_missing_parent_keys() {
+		$current = array(); // theme.json without any settings
+		$payload = array(
+			'settings' => array(
+				'color' => array(
+					'palette' => array(
+						array(
+							'slug'  => 'brand',
+							'color' => '#fff',
+						),
+					),
+				),
+			),
+		);
+		$out     = CBT_Theme_Settings_Save::merge( $current, $payload );
+		$this->assertSame( 'brand', $out['settings']['color']['palette'][0]['slug'] );
+	}
+
+	public function test_merge_replaces_template_parts_array_wholesale() {
+		$current = array(
+			'templateParts' => array(
+				array(
+					'name' => 'header',
+					'area' => 'header',
+				),
+				array(
+					'name' => 'footer',
+					'area' => 'footer',
+				),
+			),
+		);
+		$payload = array(
+			'templateParts' => array(
+				array(
+					'name' => 'sidebar',
+					'area' => 'uncategorized',
+				),
+			),
+		);
+		$out     = CBT_Theme_Settings_Save::merge( $current, $payload );
+		$this->assertCount( 1, $out['templateParts'] );
+		$this->assertSame( 'sidebar', $out['templateParts'][0]['name'] );
+	}
+
+	public function test_merge_does_not_emit_removed_shadow_defaults_key() {
+		$out = CBT_Theme_Settings_Save::merge(
+			array(),
+			array( 'removedShadowDefaults' => array( 'natural' ) )
+		);
+		$this->assertArrayNotHasKey( 'removedShadowDefaults', $out );
+	}
+
+	/* ---------------------------------------------------------------- *
+	 * reify_shadow_removals()
+	 * ---------------------------------------------------------------- */
+
+	public function test_reify_shadow_removals_sets_default_presets_false_and_re_registers_kept() {
+		$core_presets = CBT_Theme_Settings_Save::get_core_shadow_presets();
+		if ( empty( $core_presets ) ) {
+			$this->markTestSkipped( 'WP core does not expose shadow defaults in this environment.' );
+		}
+		$out = CBT_Theme_Settings_Save::reify_shadow_removals( array(), array( $core_presets[0]['slug'] ) );
+		$this->assertFalse( $out['settings']['shadow']['defaultPresets'] );
+		$kept_slugs = array_column( $out['settings']['shadow']['presets'], 'slug' );
+		$this->assertNotContains( $core_presets[0]['slug'], $kept_slugs );
+		$this->assertCount( count( $core_presets ) - 1, $kept_slugs );
+	}
+
+	public function test_reify_shadow_removals_is_idempotent() {
+		$core_presets = CBT_Theme_Settings_Save::get_core_shadow_presets();
+		if ( empty( $core_presets ) ) {
+			$this->markTestSkipped( 'WP core does not expose shadow defaults in this environment.' );
+		}
+		$once  = CBT_Theme_Settings_Save::reify_shadow_removals( array(), array( $core_presets[0]['slug'] ) );
+		$twice = CBT_Theme_Settings_Save::reify_shadow_removals( $once, array( $core_presets[0]['slug'] ) );
+		$this->assertSame( $once, $twice );
+	}
+
+	public function test_reify_shadow_removals_preserves_user_custom_presets() {
+		$core_presets = CBT_Theme_Settings_Save::get_core_shadow_presets();
+		if ( empty( $core_presets ) ) {
+			$this->markTestSkipped( 'WP core does not expose shadow defaults in this environment.' );
+		}
+		$user_custom = array(
+			'slug'   => 'my-custom-shadow',
+			'name'   => 'Mine',
+			'shadow' => '0 0 5px #000',
+		);
+		$current     = array(
+			'settings' => array(
+				'shadow' => array( 'presets' => array( $user_custom ) ),
+			),
+		);
+		$out         = CBT_Theme_Settings_Save::reify_shadow_removals( $current, array( $core_presets[0]['slug'] ) );
+		$slugs       = array_column( $out['settings']['shadow']['presets'], 'slug' );
+		$this->assertContains( 'my-custom-shadow', $slugs );
+	}
+}


### PR DESCRIPTION
Server-side foundation for the upcoming **Edit Theme Settings** modal. UI is unaffected by this PR — the prototype's Update button remains a no-op until the resolver is wired up in a follow-up.

Closes #837. Part of #836.

## What this adds

A new REST endpoint that accepts a partial-`theme.json` payload from the modal, deep-merges it into the active theme's `theme.json`, and writes the result.

- **Route:** `POST /create-block-theme/v1/theme-settings`
- **Capability:** `edit_theme_options`
- **Service:** `CBT_Theme_Settings_Save` in `includes/create-theme/theme-settings-save.php`. Pure helpers (`validate`, `sanitize`, `merge`, `reify_shadow_removals`) are public for unit testing.

### Payload contract

```json
{
  "settings": { "color": { }, "spacing": { }, "typography": { }, "layout": { } },
  "customTemplates": [],
  "templateParts": [],
  "removedShadowDefaults": ["natural", "sharp"]
}
```

- Only present keys are written. Missing keys leave `theme.json` untouched.
- `settings.*` is deep-merged (leaves replace, lists replace, missing parent keys are created).
- `customTemplates` / `templateParts` are full-list replace (the modal owns the canonical list per the prototype's UI).
- `removedShadowDefaults` is the only **operational** key. It's reified server-side into `settings.shadow.defaultPresets: false` plus the kept WP core shadow defaults re-registered under `settings.shadow.presets`. Centralizes WP-core-defaults knowledge in PHP and keeps the client-side resolver dumb.

### Response

```json
{ "status": "SUCCESS", "theme_json": { } }
```

Returning the merged theme.json lets the client refresh its theme record without a separate fetch.

## Decisions worth flagging

- **No user-customization wipe.** Unlike `CBT_Theme_Save` (whose purpose is promoting user changes into theme files), this endpoint edits the theme's offering. Existing user styles can continue to override what's seen in the editor; users can clear them via Site Editor → Styles → Reset. Open to revisit if testing shows confusion. See #836 for the full reasoning.
- **Shadow reification on the server.** The alternative (client expands `removedShadowDefaults` before sending) would push WP-core-defaults knowledge into JS. Server-side keeps the contract simpler and mirrors the plugin's PHP-heavy style.
- **Validation is shape-only.** Top-level keys are an allowlist; sub-keys under `settings` are not enumerated against the full theme.json schema. Keeps the endpoint forward-compatible with new theme.json keys without requiring a service bump.

## Tests

16 new PHPUnit tests in `tests/test-theme-settings-save.php` covering:

- Validation: known/unknown keys, type mismatches per top-level field
- Sanitization: tags stripped from string leaves, booleans/numbers preserved, camelCase keys preserved
- Merge: partial leaves siblings untouched, empty array clears, missing parent keys created, list replace, operational key dropped
- Shadow reification: `defaultPresets: false` + kept defaults re-registered, idempotent across repeat calls, user customs preserved

Run with `npm run test:unit:php:base`. Full suite (110 tests) passes; lint clean.

## Test plan

- [x] PHPUnit `Test_CBT_Theme_Settings_Save` (16 tests) green
- [x] Full PHP test suite (110 tests) green
- [x] `composer run-script lint` clean
- [x] Smoke test from a REST client (Postman / cURL) against the endpoint with a small payload
- [x] Confirm endpoint round-trips on a theme without a prior `settings.color` key

## Out of scope

- JS resolver, modal state lifting, save UX (next PR — see #838)
- Wiping user customizations (decided against for v1)
- WP-CLI command (parallels #828)