### PR TITLE
Add/Edit Color Settings + Palette to color tab

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,7 @@ This plugin allows you to:
 - Create a new style variation
 - Export a theme
 - Save user changed templates and styles to the active theme
+- Edit theme settings (color presets and palette) and save them to the active theme's theme.json
 - Expand the typography controls in the block inspector while authoring a theme (opt-in, under Editor preferences)
 
 All newly created themes or style variations will include changes made within the WordPress Editor.

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -301,7 +301,9 @@ const PaletteSummary = ( { palette, onEdit } ) => (
 	<HStack
 		className="cbt-palette-summary"
 		alignment="center"
-		justify="space-between"
+		justify="flex-start"
+		spacing={ 3 }
+		expanded={ false }
 	>
 		<HStack
 			className="cbt-palette-summary__swatches"

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -578,7 +578,12 @@ export const EditThemeSettingsModal = ( { onRequestClose } ) => {
 	const handleUpdateClick = async () => {
 		setIsSaving( true );
 		try {
-			await postUpdateThemeSettings( {
+			// The endpoint returns the merged theme.json on success. Use it
+			// as the new canonical state instead of relying on a refetch:
+			// `getCurrentTheme` is entity-record-backed and
+			// `invalidateResolution` doesn't reliably re-fetch it before the
+			// user sees the (now-stale) dirty count.
+			const merged = await postUpdateThemeSettings( {
 				settings: {
 					color: {
 						...colorSettings,
@@ -586,12 +591,23 @@ export const EditThemeSettingsModal = ( { onRequestClose } ) => {
 					},
 				},
 			} );
+			const savedColor = merged?.settings?.color || {};
+			const nextColorSettings = pickColorSettings( savedColor );
+			const nextPalette = Array.isArray( savedColor.palette )
+				? [ ...savedColor.palette ]
+				: [];
+			setColorSettings( nextColorSettings );
+			setPalette( nextPalette );
+			setSnapshot( {
+				colorSettings: nextColorSettings,
+				palette: nextPalette,
+			} );
 			createSuccessNotice(
 				__( 'Theme settings saved.', 'create-block-theme' ),
 				{ type: 'snackbar' }
 			);
-			// Refresh the theme entity so panels reseed from the new server
-			// state via the `initialState` effect above.
+			// Also invalidate the entity-record cache so the rest of the UI
+			// (e.g. View theme.json, future modal opens) sees fresh data.
 			invalidateResolution( 'getCurrentTheme' );
 		} catch ( error ) {
 			createErrorNotice(

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -224,6 +224,21 @@ const PaletteRow = ( { entry, onUpdate, onRemove } ) => (
 );
 
 const PalettePanel = ( { value, onChange } ) => {
+	const lastRowRef = useRef( null );
+	const prevLengthRef = useRef( value.length );
+
+	// After a row is appended, slide the new row into view. Compare against
+	// the previous length so edits/removes don't trigger a scroll.
+	useEffect( () => {
+		if ( value.length > prevLengthRef.current && lastRowRef.current ) {
+			lastRowRef.current.scrollIntoView( {
+				behavior: 'smooth',
+				block: 'center',
+			} );
+		}
+		prevLengthRef.current = value.length;
+	}, [ value.length ] );
+
 	const updateEntry = ( index, updated ) =>
 		onChange( value.map( ( e, i ) => ( i === index ? updated : e ) ) );
 
@@ -279,14 +294,22 @@ const PalettePanel = ( { value, onChange } ) => {
 					</HStack>
 					<ItemGroup isBordered isSeparated>
 						{ value.map( ( entry, index ) => (
-							<PaletteRow
+							<div
 								key={ index }
-								entry={ entry }
-								onUpdate={ ( updated ) =>
-									updateEntry( index, updated )
+								ref={
+									index === value.length - 1
+										? lastRowRef
+										: null
 								}
-								onRemove={ () => removeEntry( index ) }
-							/>
+							>
+								<PaletteRow
+									entry={ entry }
+									onUpdate={ ( updated ) =>
+										updateEntry( index, updated )
+									}
+									onRemove={ () => removeEntry( index ) }
+								/>
+							</div>
 						) ) }
 					</ItemGroup>
 				</>

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -239,21 +239,21 @@ const PalettePanel = ( { value, onChange } ) => {
 						spacing={ 3 }
 					>
 						<span
-							className="cbt-palette-column-headers__swatch"
+							className="cbt-palette-column-headers__spacer"
 							aria-hidden="true"
 						/>
 						<FlexBlock>
-							<BaseControl.VisualLabel>
+							<span className="cbt-palette-column-headers__label">
 								{ __( 'Name', 'create-block-theme' ) }
-							</BaseControl.VisualLabel>
+							</span>
 						</FlexBlock>
 						<FlexBlock>
-							<BaseControl.VisualLabel>
+							<span className="cbt-palette-column-headers__label">
 								{ __( 'Slug', 'create-block-theme' ) }
-							</BaseControl.VisualLabel>
+							</span>
 						</FlexBlock>
 						<span
-							className="cbt-palette-column-headers__remove"
+							className="cbt-palette-column-headers__spacer"
 							aria-hidden="true"
 						/>
 					</HStack>

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -372,7 +372,10 @@ const ColorTab = ( {
 			<div ref={ paletteRef }>
 				<PanelBody
 					title={ __( 'Palette', 'create-block-theme' ) }
-					opened={ isPaletteOpen }
+					// When the palette is empty the summary card is hidden,
+					// so force the accordion open to keep the "Add a color"
+					// button discoverable.
+					opened={ isPaletteOpen || palette.length === 0 }
 					onToggle={ setIsPaletteOpen }
 				>
 					<PalettePanel

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -307,7 +307,7 @@ const ColorTab = ( {
 } ) => (
 	<>
 		<PanelBody
-			title={ __( 'Color Settings', 'create-block-theme' ) }
+			title={ __( 'Default and custom presets', 'create-block-theme' ) }
 			initialOpen
 		>
 			<ColorSettingsPanel

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -1,0 +1,460 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	useState,
+	useEffect,
+	useMemo,
+	createInterpolateElement,
+} from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalItem as Item,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalItemGroup as ItemGroup,
+	BaseControl,
+	Button,
+	ColorIndicator,
+	ColorPicker,
+	Dropdown,
+	FlexBlock,
+	Modal,
+	Notice,
+	PanelBody,
+	TabPanel,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { plus, lineSolid } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { postUpdateThemeSettings } from '../resolvers';
+
+const COLOR_SETTINGS_KEYS = [
+	'defaultPalette',
+	'defaultGradients',
+	'defaultDuotone',
+	'custom',
+	'customGradient',
+	'customDuotone',
+	'link',
+];
+
+const COLOR_SETTINGS_DEFAULTS = {
+	defaultPalette: true,
+	defaultGradients: true,
+	defaultDuotone: true,
+	custom: true,
+	customGradient: true,
+	customDuotone: true,
+	link: false,
+};
+
+const ColorSettingsPanel = ( { value, onChange } ) => {
+	const update = ( key ) => ( next ) =>
+		onChange( { ...value, [ key ]: next } );
+
+	return (
+		<VStack spacing={ 8 }>
+			<VStack spacing={ 1 }>
+				<BaseControl.VisualLabel>
+					{ __( 'Default presets', 'create-block-theme' ) }
+				</BaseControl.VisualLabel>
+				<VStack spacing={ 3 }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Default duotone filters',
+							'create-block-theme'
+						) }
+						checked={ value.defaultDuotone }
+						onChange={ update( 'defaultDuotone' ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Default gradients',
+							'create-block-theme'
+						) }
+						checked={ value.defaultGradients }
+						onChange={ update( 'defaultGradients' ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Default palette', 'create-block-theme' ) }
+						checked={ value.defaultPalette }
+						onChange={ update( 'defaultPalette' ) }
+					/>
+				</VStack>
+			</VStack>
+			<VStack spacing={ 1 }>
+				<BaseControl.VisualLabel>
+					{ __( 'Custom presets', 'create-block-theme' ) }
+				</BaseControl.VisualLabel>
+				<VStack spacing={ 3 }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Custom colors', 'create-block-theme' ) }
+						checked={ value.custom }
+						onChange={ update( 'custom' ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Custom duotone filters',
+							'create-block-theme'
+						) }
+						checked={ value.customDuotone }
+						onChange={ update( 'customDuotone' ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Custom gradients', 'create-block-theme' ) }
+						checked={ value.customGradient }
+						onChange={ update( 'customGradient' ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Link color', 'create-block-theme' ) }
+						help={ __(
+							'Enable the link color control.',
+							'create-block-theme'
+						) }
+						checked={ value.link }
+						onChange={ update( 'link' ) }
+					/>
+				</VStack>
+			</VStack>
+		</VStack>
+	);
+};
+
+const PaletteRow = ( { entry, onUpdate, onRemove } ) => (
+	<Item className="cbt-palette-list-item">
+		<HStack alignment="center" spacing={ 3 }>
+			<Dropdown
+				popoverProps={ { placement: 'bottom-start' } }
+				renderToggle={ ( { onToggle, isOpen } ) => (
+					<Button
+						onClick={ onToggle }
+						aria-expanded={ isOpen }
+						label={ __( 'Edit color', 'create-block-theme' ) }
+						showTooltip
+						className="cbt-palette-swatch-button"
+					>
+						<ColorIndicator colorValue={ entry.color } />
+					</Button>
+				) }
+				renderContent={ () => (
+					<ColorPicker
+						color={ entry.color }
+						onChange={ ( color ) =>
+							onUpdate( { ...entry, color } )
+						}
+					/>
+				) }
+			/>
+			<FlexBlock>
+				<TextControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={ __( 'Name', 'create-block-theme' ) }
+					hideLabelFromVision
+					placeholder={ __( 'Name', 'create-block-theme' ) }
+					value={ entry.name }
+					onChange={ ( name ) => onUpdate( { ...entry, name } ) }
+				/>
+			</FlexBlock>
+			<FlexBlock>
+				<TextControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={ __( 'Slug', 'create-block-theme' ) }
+					hideLabelFromVision
+					placeholder={ __( 'Slug', 'create-block-theme' ) }
+					value={ entry.slug }
+					onChange={ ( slug ) => onUpdate( { ...entry, slug } ) }
+				/>
+			</FlexBlock>
+			<Button
+				icon={ lineSolid }
+				label={ __( 'Remove color', 'create-block-theme' ) }
+				onClick={ onRemove }
+				className="cbt-palette-swatch-button"
+			/>
+		</HStack>
+	</Item>
+);
+
+const PalettePanel = ( { value, onChange } ) => {
+	const updateEntry = ( index, updated ) =>
+		onChange( value.map( ( e, i ) => ( i === index ? updated : e ) ) );
+
+	const removeEntry = ( index ) =>
+		onChange( value.filter( ( _, i ) => i !== index ) );
+
+	const addColor = () =>
+		onChange( [
+			...value,
+			{
+				slug: `new-color-${ value.length + 1 }`,
+				name: __( 'New color', 'create-block-theme' ),
+				color: '#000000',
+			},
+		] );
+
+	return (
+		<VStack spacing={ 1 }>
+			<HStack
+				className="cbt-palette-section-header"
+				justify="space-between"
+				alignment="center"
+			>
+				<BaseControl.VisualLabel>
+					{ __( 'Color presets', 'create-block-theme' ) }
+				</BaseControl.VisualLabel>
+				<Button
+					icon={ plus }
+					label={ __( 'Add new color', 'create-block-theme' ) }
+					onClick={ addColor }
+					showTooltip
+				/>
+			</HStack>
+			{ value.length > 0 && (
+				<ItemGroup isBordered isSeparated>
+					{ value.map( ( entry, index ) => (
+						<PaletteRow
+							key={ index }
+							entry={ entry }
+							onUpdate={ ( updated ) =>
+								updateEntry( index, updated )
+							}
+							onRemove={ () => removeEntry( index ) }
+						/>
+					) ) }
+				</ItemGroup>
+			) }
+		</VStack>
+	);
+};
+
+const ColorTab = ( {
+	colorSettings,
+	onChangeColorSettings,
+	palette,
+	onChangePalette,
+} ) => (
+	<>
+		<PanelBody
+			title={ __( 'Color Settings', 'create-block-theme' ) }
+			initialOpen
+		>
+			<ColorSettingsPanel
+				value={ colorSettings }
+				onChange={ onChangeColorSettings }
+			/>
+		</PanelBody>
+		<PanelBody title={ __( 'Palette', 'create-block-theme' ) } initialOpen>
+			<PalettePanel value={ palette } onChange={ onChangePalette } />
+		</PanelBody>
+	</>
+);
+
+const pickColorSettings = ( themeColor ) => {
+	const out = { ...COLOR_SETTINGS_DEFAULTS };
+	for ( const key of COLOR_SETTINGS_KEYS ) {
+		if ( themeColor && key in themeColor ) {
+			out[ key ] = themeColor[ key ];
+		}
+	}
+	return out;
+};
+
+// Per-field dirty diff between the modal's working state and the last-saved
+// snapshot from the server. Returns the number of fields that differ —
+// surfaced in the Update button label.
+const countChanges = ( current, snapshot ) => {
+	let count = 0;
+	for ( const key of COLOR_SETTINGS_KEYS ) {
+		if ( current.colorSettings[ key ] !== snapshot.colorSettings[ key ] ) {
+			count += 1;
+		}
+	}
+	if (
+		JSON.stringify( current.palette ) !== JSON.stringify( snapshot.palette )
+	) {
+		count += 1;
+	}
+	return count;
+};
+
+export const EditThemeSettingsModal = ( { onRequestClose } ) => {
+	const themeData = useSelect(
+		( select ) => select( 'core' ).getCurrentTheme(),
+		[]
+	);
+	const { invalidateResolution } = useDispatch( 'core' );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	const themeColor = themeData?.theme_json?.settings?.color;
+
+	const initialState = useMemo(
+		() => ( {
+			colorSettings: pickColorSettings( themeColor ),
+			palette: themeColor?.palette ? [ ...themeColor.palette ] : [],
+		} ),
+		[ themeColor ]
+	);
+
+	const [ colorSettings, setColorSettings ] = useState(
+		initialState.colorSettings
+	);
+	const [ palette, setPalette ] = useState( initialState.palette );
+	const [ snapshot, setSnapshot ] = useState( initialState );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	// Reseed local state when the server-side theme data refreshes (initial
+	// load, and after a successful save invalidates the resolver).
+	useEffect( () => {
+		setColorSettings( initialState.colorSettings );
+		setPalette( initialState.palette );
+		setSnapshot( initialState );
+	}, [ initialState ] );
+
+	const changeCount = countChanges( { colorSettings, palette }, snapshot );
+	const isDirty = changeCount > 0;
+
+	const handleUpdateClick = async () => {
+		setIsSaving( true );
+		try {
+			await postUpdateThemeSettings( {
+				settings: {
+					color: {
+						...colorSettings,
+						palette,
+					},
+				},
+			} );
+			createSuccessNotice(
+				__( 'Theme settings saved.', 'create-block-theme' ),
+				{ type: 'snackbar' }
+			);
+			// Refresh the theme entity so panels reseed from the new server
+			// state via the `initialState` effect above.
+			invalidateResolution( 'getCurrentTheme' );
+		} catch ( error ) {
+			createErrorNotice(
+				error?.message ||
+					__(
+						'An error occurred while saving theme settings.',
+						'create-block-theme'
+					),
+				{ type: 'snackbar' }
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	const tabs = [
+		{ name: 'color', title: __( 'Color', 'create-block-theme' ) },
+	];
+
+	const renderTab = ( tab ) => {
+		switch ( tab.name ) {
+			case 'color':
+				return (
+					<ColorTab
+						colorSettings={ colorSettings }
+						onChangeColorSettings={ setColorSettings }
+						palette={ palette }
+						onChangePalette={ setPalette }
+					/>
+				);
+			default:
+				return null;
+		}
+	};
+
+	const updateLabel = isDirty
+		? sprintf(
+				/* translators: %d: number of pending changes */
+				__( 'Update (%d changes)', 'create-block-theme' ),
+				changeCount
+		  )
+		: __( 'Update', 'create-block-theme' );
+
+	return (
+		<Modal
+			size="large"
+			title={ sprintf(
+				// translators: %s: theme name.
+				__( 'Theme settings for %s', 'create-block-theme' ),
+				themeData?.name?.raw ?? ''
+			) }
+			onRequestClose={ onRequestClose }
+			className="create-block-theme__edit-theme-settings-modal"
+		>
+			<VStack spacing={ 4 }>
+				<Text>
+					{ __(
+						'Edit the settings of the current theme.',
+						'create-block-theme'
+					) }
+				</Text>
+				<Notice
+					status="warning"
+					isDismissible={ false }
+					className="create-block-theme__edit-theme-settings-modal__disclaimer"
+				>
+					<div>
+						{ __(
+							'Changes you’ve saved in the Site Editor live in the database, not in your theme files.',
+							'create-block-theme'
+						) }
+					</div>
+					<div>
+						{ createInterpolateElement(
+							__(
+								'Click <strong>Save Changes to Theme</strong> first to write them to theme.json — otherwise the edits you make here may conflict with or hide them.',
+								'create-block-theme'
+							),
+							{ strong: <strong /> }
+						) }
+					</div>
+				</Notice>
+				<TabPanel
+					className="create-block-theme__edit-theme-settings-tabs"
+					tabs={ tabs }
+				>
+					{ renderTab }
+				</TabPanel>
+			</VStack>
+			<HStack
+				justify="flex-end"
+				className="create-block-theme__edit-theme-settings-modal__footer"
+			>
+				<Button
+					variant="primary"
+					onClick={ handleUpdateClick }
+					disabled={ ! isDirty || isSaving }
+					isBusy={ isSaving }
+				>
+					{ updateLabel }
+				</Button>
+			</HStack>
+		</Modal>
+	);
+};

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -66,7 +66,7 @@ const ColorSettingsPanel = ( { value, onChange } ) => {
 		onChange( { ...value, [ key ]: next } );
 
 	return (
-		<VStack spacing={ 8 }>
+		<div className="cbt-color-settings-columns">
 			<VStack spacing={ 1 }>
 				<BaseControl.VisualLabel>
 					{ __( 'Default presets', 'create-block-theme' ) }
@@ -74,12 +74,13 @@ const ColorSettingsPanel = ( { value, onChange } ) => {
 				<VStack spacing={ 3 }>
 					<ToggleControl
 						__nextHasNoMarginBottom
-						label={ __(
-							'Default duotone filters',
+						label={ __( 'Default palette', 'create-block-theme' ) }
+						help={ __(
+							'Show WordPress’s default color palette in the editor.',
 							'create-block-theme'
 						) }
-						checked={ value.defaultDuotone }
-						onChange={ update( 'defaultDuotone' ) }
+						checked={ value.defaultPalette }
+						onChange={ update( 'defaultPalette' ) }
 					/>
 					<ToggleControl
 						__nextHasNoMarginBottom
@@ -87,14 +88,25 @@ const ColorSettingsPanel = ( { value, onChange } ) => {
 							'Default gradients',
 							'create-block-theme'
 						) }
+						help={ __(
+							'Show WordPress’s default gradient presets in the editor.',
+							'create-block-theme'
+						) }
 						checked={ value.defaultGradients }
 						onChange={ update( 'defaultGradients' ) }
 					/>
 					<ToggleControl
 						__nextHasNoMarginBottom
-						label={ __( 'Default palette', 'create-block-theme' ) }
-						checked={ value.defaultPalette }
-						onChange={ update( 'defaultPalette' ) }
+						label={ __(
+							'Default duotone filters',
+							'create-block-theme'
+						) }
+						help={ __(
+							'Show WordPress’s default duotone filters in the editor.',
+							'create-block-theme'
+						) }
+						checked={ value.defaultDuotone }
+						onChange={ update( 'defaultDuotone' ) }
 					/>
 				</VStack>
 			</VStack>
@@ -106,8 +118,22 @@ const ColorSettingsPanel = ( { value, onChange } ) => {
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Custom colors', 'create-block-theme' ) }
+						help={ __(
+							'Allow custom colors in the editor color picker.',
+							'create-block-theme'
+						) }
 						checked={ value.custom }
 						onChange={ update( 'custom' ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Custom gradients', 'create-block-theme' ) }
+						help={ __(
+							'Let users create custom gradients in the editor.',
+							'create-block-theme'
+						) }
+						checked={ value.customGradient }
+						onChange={ update( 'customGradient' ) }
 					/>
 					<ToggleControl
 						__nextHasNoMarginBottom
@@ -115,14 +141,12 @@ const ColorSettingsPanel = ( { value, onChange } ) => {
 							'Custom duotone filters',
 							'create-block-theme'
 						) }
+						help={ __(
+							'Let users create custom duotone filters.',
+							'create-block-theme'
+						) }
 						checked={ value.customDuotone }
 						onChange={ update( 'customDuotone' ) }
-					/>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Custom gradients', 'create-block-theme' ) }
-						checked={ value.customGradient }
-						onChange={ update( 'customGradient' ) }
 					/>
 					<ToggleControl
 						__nextHasNoMarginBottom
@@ -136,7 +160,7 @@ const ColorSettingsPanel = ( { value, onChange } ) => {
 					/>
 				</VStack>
 			</VStack>
-		</VStack>
+		</div>
 	);
 };
 

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -533,13 +533,16 @@ export const EditThemeSettingsModal = ( { onRequestClose } ) => {
 						className="create-block-theme__edit-theme-settings-modal__disclaimer"
 					>
 						<div>
-							{ sprintf(
-								/* translators: %s: comma-separated list of customized sections (e.g. "color, typography") */
-								__(
-									'You have changes in the Site Editor that haven’t been written to theme.json: %s.',
-									'create-block-theme'
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: %s: comma-separated list of customized sections, wrapped in <list></list> (e.g. "color, typography") */
+									__(
+										'You have changes in the Site Editor that haven’t been written to theme.json: <list>%s</list>.',
+										'create-block-theme'
+									),
+									customizedSections.join( ', ' )
 								),
-								customizedSections.join( ', ' )
+								{ list: <strong /> }
 							) }
 						</div>
 						<div>

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -543,11 +543,12 @@ const getCustomizedSections = ( userGlobalStyles, edits ) => {
 	visit( userGlobalStyles );
 	visit( edits );
 
-	return Array.from( sections ).map(
-		( key ) =>
-			USER_CUSTOMIZATION_SECTION_LABELS[ key ] ||
-			__( 'other', 'create-block-theme' )
-	);
+	return Array.from( sections ).map( ( key ) => {
+		const label = USER_CUSTOMIZATION_SECTION_LABELS[ key ];
+		return label
+			? label
+			: sprintf( __( 'other (%s)', 'create-block-theme' ), key );
+	} );
 };
 
 // Returns the set of color-settings keys whose current value differs from

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -307,6 +307,73 @@ const pickColorSettings = ( themeColor ) => {
 	return out;
 };
 
+// Human-readable label for each top-level slice of `settings` / `styles`
+// that the user may have customized in the Site Editor. Keys are taken
+// from the canonical theme.json schema; anything not in this map is
+// surfaced under "other" as a catch-all so newly-introduced WP keys don't
+// silently vanish from the warning.
+const USER_CUSTOMIZATION_SECTION_LABELS = {
+	color: __( 'color', 'create-block-theme' ),
+	typography: __( 'typography', 'create-block-theme' ),
+	spacing: __( 'spacing', 'create-block-theme' ),
+	layout: __( 'layout', 'create-block-theme' ),
+	dimensions: __( 'dimensions', 'create-block-theme' ),
+	border: __( 'borders', 'create-block-theme' ),
+	shadow: __( 'shadows', 'create-block-theme' ),
+	background: __( 'background', 'create-block-theme' ),
+	elements: __( 'elements', 'create-block-theme' ),
+	blocks: __( 'block styles', 'create-block-theme' ),
+	filter: __( 'filters', 'create-block-theme' ),
+	css: __( 'additional CSS', 'create-block-theme' ),
+	custom: __( 'custom', 'create-block-theme' ),
+};
+
+const isNonEmpty = ( value ) => {
+	if ( value === null || value === undefined ) {
+		return false;
+	}
+	if ( Array.isArray( value ) ) {
+		return value.length > 0;
+	}
+	if ( typeof value === 'object' ) {
+		return Object.keys( value ).length > 0;
+	}
+	return true;
+};
+
+// Crawl the saved user Global Styles record + any in-editor edits and
+// return the de-duplicated, human-readable list of top-level slices that
+// have user-level customizations diverging from theme.json.
+const getCustomizedSections = ( userGlobalStyles, edits ) => {
+	const sections = new Set();
+
+	const visit = ( record ) => {
+		if ( ! record ) {
+			return;
+		}
+		for ( const top of [ 'settings', 'styles' ] ) {
+			const slice = record[ top ];
+			if ( ! slice || typeof slice !== 'object' ) {
+				continue;
+			}
+			for ( const [ key, value ] of Object.entries( slice ) ) {
+				if ( isNonEmpty( value ) ) {
+					sections.add( key );
+				}
+			}
+		}
+	};
+
+	visit( userGlobalStyles );
+	visit( edits );
+
+	return Array.from( sections ).map(
+		( key ) =>
+			USER_CUSTOMIZATION_SECTION_LABELS[ key ] ||
+			__( 'other', 'create-block-theme' )
+	);
+};
+
 // Per-field dirty diff between the modal's working state and the last-saved
 // snapshot from the server. Returns the number of fields that differ —
 // surfaced in the Update button label.
@@ -330,6 +397,25 @@ export const EditThemeSettingsModal = ( { onRequestClose } ) => {
 		( select ) => select( 'core' ).getCurrentTheme(),
 		[]
 	);
+
+	const customizedSections = useSelect( ( select ) => {
+		const core = select( 'core' );
+		const getId = core.__experimentalGetCurrentGlobalStylesId;
+		if ( typeof getId !== 'function' ) {
+			return [];
+		}
+		const id = getId();
+		if ( ! id ) {
+			return [];
+		}
+		// Saved user-origin record (database).
+		const record = core.getEntityRecord( 'root', 'globalStyles', id );
+		// In-editor edits not yet persisted to the database.
+		const edits = core.getEntityRecordEdits?.( 'root', 'globalStyles', id );
+		return getCustomizedSections( record, edits );
+	}, [] );
+	const hasUserCustomizations = customizedSections.length > 0;
+
 	const { invalidateResolution } = useDispatch( 'core' );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
@@ -440,27 +526,33 @@ export const EditThemeSettingsModal = ( { onRequestClose } ) => {
 						'create-block-theme'
 					) }
 				</Text>
-				<Notice
-					status="warning"
-					isDismissible={ false }
-					className="create-block-theme__edit-theme-settings-modal__disclaimer"
-				>
-					<div>
-						{ __(
-							'Changes you’ve saved in the Site Editor live in the database, not in your theme files.',
-							'create-block-theme'
-						) }
-					</div>
-					<div>
-						{ createInterpolateElement(
-							__(
-								'Click <strong>Save Changes to Theme</strong> first to write them to theme.json — otherwise the edits you make here may conflict with or hide them.',
-								'create-block-theme'
-							),
-							{ strong: <strong /> }
-						) }
-					</div>
-				</Notice>
+				{ hasUserCustomizations && (
+					<Notice
+						status="warning"
+						isDismissible={ false }
+						className="create-block-theme__edit-theme-settings-modal__disclaimer"
+					>
+						<div>
+							{ sprintf(
+								/* translators: %s: comma-separated list of customized sections (e.g. "color, typography") */
+								__(
+									'You have changes in the Site Editor that haven’t been written to theme.json: %s.',
+									'create-block-theme'
+								),
+								customizedSections.join( ', ' )
+							) }
+						</div>
+						<div>
+							{ createInterpolateElement(
+								__(
+									'Click <strong>Save Changes to Theme</strong> first — otherwise the edits you make here may be hidden by those overrides.',
+									'create-block-theme'
+								),
+								{ strong: <strong /> }
+							) }
+						</div>
+					</Notice>
+				) }
 				<TabPanel
 					className="create-block-theme__edit-theme-settings-tabs"
 					tabs={ tabs }

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -6,6 +6,7 @@ import {
 	useState,
 	useEffect,
 	useMemo,
+	useRef,
 	createInterpolateElement,
 } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -334,14 +335,25 @@ const ColorTab = ( {
 	onChangePalette,
 } ) => {
 	const [ isPaletteOpen, setIsPaletteOpen ] = useState( false );
+	const paletteRef = useRef( null );
+
+	const focusPalette = () => {
+		setIsPaletteOpen( true );
+		// Scroll on the next frame so the accordion has expanded (if it was
+		// closed) before we measure its target position. Works on subsequent
+		// clicks too, because scrollIntoView fires unconditionally.
+		window.requestAnimationFrame( () => {
+			paletteRef.current?.scrollIntoView( {
+				behavior: 'smooth',
+				block: 'start',
+			} );
+		} );
+	};
 
 	return (
 		<>
 			{ palette.length > 0 && (
-				<PaletteSummary
-					palette={ palette }
-					onEdit={ () => setIsPaletteOpen( true ) }
-				/>
+				<PaletteSummary palette={ palette } onEdit={ focusPalette } />
 			) }
 			<PanelBody
 				title={ __(
@@ -355,13 +367,18 @@ const ColorTab = ( {
 					onChange={ onChangeColorSettings }
 				/>
 			</PanelBody>
-			<PanelBody
-				title={ __( 'Palette', 'create-block-theme' ) }
-				opened={ isPaletteOpen }
-				onToggle={ setIsPaletteOpen }
-			>
-				<PalettePanel value={ palette } onChange={ onChangePalette } />
-			</PanelBody>
+			<div ref={ paletteRef }>
+				<PanelBody
+					title={ __( 'Palette', 'create-block-theme' ) }
+					opened={ isPaletteOpen }
+					onToggle={ setIsPaletteOpen }
+				>
+					<PalettePanel
+						value={ palette }
+						onChange={ onChangePalette }
+					/>
+				</PanelBody>
+			</div>
 		</>
 	);
 };

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	useState,
 	useEffect,
@@ -61,6 +61,54 @@ const COLOR_SETTINGS_DEFAULTS = {
 	customGradient: true,
 	customDuotone: true,
 	link: false,
+};
+
+// Local-only stable ID for React keys on palette rows. Entries that come
+// from the server (initial load, save response) get a `__cbtRowId` added
+// when we seed local state; entries the user adds get one at creation.
+// Stripped from the payload before sending to the server.
+let nextRowIdCounter = 0;
+const newRowId = () => `cbt-row-${ ++nextRowIdCounter }`;
+
+const augmentPaletteWithIds = ( entries ) =>
+	entries.map( ( entry ) => ( {
+		...entry,
+		__cbtRowId: entry.__cbtRowId || newRowId(),
+	} ) );
+
+const stripPaletteIds = ( entries ) =>
+	entries.map( ( { __cbtRowId: _id, ...rest } ) => rest );
+
+const palettesEqual = ( a, b ) => {
+	if ( a.length !== b.length ) {
+		return false;
+	}
+	for ( let i = 0; i < a.length; i++ ) {
+		if (
+			a[ i ].slug !== b[ i ].slug ||
+			a[ i ].name !== b[ i ].name ||
+			a[ i ].color !== b[ i ].color
+		) {
+			return false;
+		}
+	}
+	return true;
+};
+
+// Find the next free index for an auto-generated `new-color-N` slug so
+// Add → Remove → Add doesn't produce duplicate slugs.
+const nextNewColorIndex = ( entries ) => {
+	let max = 0;
+	for ( const entry of entries ) {
+		const match = /^new-color-(\d+)$/.exec( entry.slug || '' );
+		if ( match ) {
+			const n = parseInt( match[ 1 ], 10 );
+			if ( n > max ) {
+				max = n;
+			}
+		}
+	}
+	return max + 1;
 };
 
 const ColorSettingsPanel = ( { value, onChange } ) => {
@@ -250,7 +298,8 @@ const PalettePanel = ( { value, onChange } ) => {
 		onChange( [
 			...value,
 			{
-				slug: `new-color-${ value.length + 1 }`,
+				__cbtRowId: newRowId(),
+				slug: `new-color-${ nextNewColorIndex( value ) }`,
 				name: __( 'New color', 'create-block-theme' ),
 				color: '#000000',
 			},
@@ -296,7 +345,7 @@ const PalettePanel = ( { value, onChange } ) => {
 					<ItemGroup isBordered isSeparated>
 						{ value.map( ( entry, index ) => (
 							<div
-								key={ index }
+								key={ entry.__cbtRowId }
 								ref={
 									index === value.length - 1
 										? lastRowRef
@@ -501,22 +550,17 @@ const getCustomizedSections = ( userGlobalStyles, edits ) => {
 	);
 };
 
-// Per-field dirty diff between the modal's working state and the last-saved
-// snapshot from the server. Returns the number of fields that differ —
-// surfaced in the Update button label.
-const countChanges = ( current, snapshot ) => {
-	let count = 0;
+// Returns the set of color-settings keys whose current value differs from
+// the last-saved snapshot. Used to drive both the Update-button counter
+// and the minimal-patch payload sent to the server.
+const getDirtyColorKeys = ( current, snapshot ) => {
+	const keys = [];
 	for ( const key of COLOR_SETTINGS_KEYS ) {
-		if ( current.colorSettings[ key ] !== snapshot.colorSettings[ key ] ) {
-			count += 1;
+		if ( current[ key ] !== snapshot[ key ] ) {
+			keys.push( key );
 		}
 	}
-	if (
-		JSON.stringify( current.palette ) !== JSON.stringify( snapshot.palette )
-	) {
-		count += 1;
-	}
-	return count;
+	return keys;
 };
 
 export const EditThemeSettingsModal = ( { onRequestClose } ) => {
@@ -549,10 +593,15 @@ export const EditThemeSettingsModal = ( { onRequestClose } ) => {
 
 	const themeColor = themeData?.theme_json?.settings?.color;
 
+	// `snapshot` is the server-canonical state — palette entries here have
+	// NO `__cbtRowId` since the server never sees that key. Working state
+	// (`palette`) is augmented with row IDs for stable React keys.
 	const initialState = useMemo(
 		() => ( {
 			colorSettings: pickColorSettings( themeColor ),
-			palette: themeColor?.palette ? [ ...themeColor.palette ] : [],
+			palette: Array.isArray( themeColor?.palette )
+				? themeColor.palette
+				: [],
 		} ),
 		[ themeColor ]
 	);
@@ -560,47 +609,85 @@ export const EditThemeSettingsModal = ( { onRequestClose } ) => {
 	const [ colorSettings, setColorSettings ] = useState(
 		initialState.colorSettings
 	);
-	const [ palette, setPalette ] = useState( initialState.palette );
+	const [ palette, setPalette ] = useState( () =>
+		augmentPaletteWithIds( initialState.palette )
+	);
 	const [ snapshot, setSnapshot ] = useState( initialState );
 	const [ isSaving, setIsSaving ] = useState( false );
 
-	// Reseed local state when the server-side theme data refreshes (initial
-	// load, and after a successful save invalidates the resolver).
-	useEffect( () => {
-		setColorSettings( initialState.colorSettings );
-		setPalette( initialState.palette );
-		setSnapshot( initialState );
-	}, [ initialState ] );
-
-	const changeCount = countChanges( { colorSettings, palette }, snapshot );
+	const dirtyColorKeys = useMemo(
+		() => getDirtyColorKeys( colorSettings, snapshot.colorSettings ),
+		[ colorSettings, snapshot.colorSettings ]
+	);
+	const strippedPalette = useMemo(
+		() => stripPaletteIds( palette ),
+		[ palette ]
+	);
+	const paletteDirty = useMemo(
+		() => ! palettesEqual( strippedPalette, snapshot.palette ),
+		[ strippedPalette, snapshot.palette ]
+	);
+	const changeCount = dirtyColorKeys.length + ( paletteDirty ? 1 : 0 );
 	const isDirty = changeCount > 0;
 
+	const hasEmptySlug = palette.some(
+		( entry ) => ! entry.slug || ! entry.slug.trim()
+	);
+
+	// Reseed local state from refreshed server data — but only if the user
+	// hasn't started editing in this session. Otherwise a mid-flight cache
+	// invalidation (e.g. another resolver triggers it) would silently wipe
+	// pending edits.
+	useEffect( () => {
+		if ( isDirty ) {
+			return;
+		}
+		setColorSettings( initialState.colorSettings );
+		setPalette( augmentPaletteWithIds( initialState.palette ) );
+		setSnapshot( initialState );
+		// `isDirty` is intentionally excluded from deps: we only want to
+		// reseed when the server-side data changes, not when the user's
+		// edits transition the dirty flag.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ initialState ] );
+
 	const handleUpdateClick = async () => {
+		// Build a minimal patch: only the keys the user touched in this
+		// session. Avoids overwriting fields another tab/CLI may have
+		// edited concurrently (server-side merge is RFC 7396 last-writes-
+		// wins on lists, so sending an unchanged palette would still
+		// clobber concurrent palette edits).
+		const colorPayload = {};
+		for ( const key of dirtyColorKeys ) {
+			colorPayload[ key ] = colorSettings[ key ];
+		}
+		if ( paletteDirty ) {
+			colorPayload.palette = strippedPalette;
+		}
+		if ( Object.keys( colorPayload ).length === 0 ) {
+			return;
+		}
+
 		setIsSaving( true );
 		try {
 			// The endpoint returns `{ status, theme_json: <merged> }` on
-			// success. Reseed from the merged theme.json directly instead of
-			// relying on a refetch: `getCurrentTheme` is entity-record-backed
-			// and `invalidateResolution` doesn't reliably re-fetch it before
-			// the user sees the (now-stale) dirty count.
+			// success. Reseed snapshot from the merged theme.json directly
+			// instead of relying on a refetch: `getCurrentTheme` is
+			// entity-record-backed and `invalidateResolution` doesn't
+			// reliably re-fetch it before the user sees the dirty count.
 			const response = await postUpdateThemeSettings( {
-				settings: {
-					color: {
-						...colorSettings,
-						palette,
-					},
-				},
+				settings: { color: colorPayload },
 			} );
 			const savedColor = response?.theme_json?.settings?.color || {};
 			const nextColorSettings = pickColorSettings( savedColor );
-			const nextPalette = Array.isArray( savedColor.palette )
-				? [ ...savedColor.palette ]
+			const nextPaletteRaw = Array.isArray( savedColor.palette )
+				? savedColor.palette
 				: [];
 			setColorSettings( nextColorSettings );
-			setPalette( nextPalette );
+			setPalette( augmentPaletteWithIds( nextPaletteRaw ) );
 			setSnapshot( {
 				colorSettings: nextColorSettings,
-				palette: nextPalette,
+				palette: nextPaletteRaw,
 			} );
 			createSuccessNotice(
 				__( 'Theme settings saved.', 'create-block-theme' ),
@@ -646,10 +733,26 @@ export const EditThemeSettingsModal = ( { onRequestClose } ) => {
 	const updateLabel = isDirty
 		? sprintf(
 				/* translators: %d: number of pending changes */
-				__( 'Update (%d changes)', 'create-block-theme' ),
+				_n(
+					'Update (%d change)',
+					'Update (%d changes)',
+					changeCount,
+					'create-block-theme'
+				),
 				changeCount
 		  )
 		: __( 'Update', 'create-block-theme' );
+
+	// Use Intl.ListFormat so the separator (and final "and") match the
+	// user's locale instead of being hard-coded English punctuation.
+	// Falls back to a plain ", " join in environments without it.
+	const sectionList =
+		typeof Intl !== 'undefined' && Intl.ListFormat
+			? new Intl.ListFormat( undefined, {
+					style: 'long',
+					type: 'conjunction',
+			  } ).format( customizedSections )
+			: customizedSections.join( ', ' );
 
 	return (
 		<Modal
@@ -683,7 +786,7 @@ export const EditThemeSettingsModal = ( { onRequestClose } ) => {
 										'You have changes in the Site Editor that haven’t been written to theme.json: <list>%s</list>.',
 										'create-block-theme'
 									),
-									customizedSections.join( ', ' )
+									sectionList
 								),
 								{ list: <strong /> }
 							) }
@@ -713,8 +816,17 @@ export const EditThemeSettingsModal = ( { onRequestClose } ) => {
 				<Button
 					variant="primary"
 					onClick={ handleUpdateClick }
-					disabled={ ! isDirty || isSaving }
+					disabled={ ! isDirty || isSaving || hasEmptySlug }
 					isBusy={ isSaving }
+					label={
+						hasEmptySlug
+							? __(
+									'Every palette entry needs a slug.',
+									'create-block-theme'
+							  )
+							: undefined
+					}
+					showTooltip={ hasEmptySlug }
 				>
 					{ updateLabel }
 				</Button>

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -215,6 +215,7 @@ const PaletteRow = ( { entry, onUpdate, onRemove } ) => (
 			</FlexBlock>
 			<Button
 				icon={ lineSolid }
+				iconSize={ 20 }
 				label={ __( 'Remove color', 'create-block-theme' ) }
 				onClick={ onRemove }
 				className="cbt-palette-swatch-button"

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -547,7 +547,11 @@ const getCustomizedSections = ( userGlobalStyles, edits ) => {
 		const label = USER_CUSTOMIZATION_SECTION_LABELS[ key ];
 		return label
 			? label
-			: sprintf( __( 'other (%s)', 'create-block-theme' ), key );
+			: sprintf(
+					/* translators: %s: the raw setting key (e.g. "spacing") for a customization that doesn't have a friendly label. */
+					__( 'other (%s)', 'create-block-theme' ),
+					key
+			  );
 	} );
 };
 

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -242,18 +242,12 @@ const PalettePanel = ( { value, onChange } ) => {
 		<VStack spacing={ 1 }>
 			<HStack
 				className="cbt-palette-section-header"
-				justify="space-between"
+				justify="flex-end"
 				alignment="center"
 			>
-				<BaseControl.VisualLabel>
-					{ __( 'Color presets', 'create-block-theme' ) }
-				</BaseControl.VisualLabel>
-				<Button
-					icon={ plus }
-					label={ __( 'Add new color', 'create-block-theme' ) }
-					onClick={ addColor }
-					showTooltip
-				/>
+				<Button icon={ plus } variant="tertiary" onClick={ addColor }>
+					{ __( 'Add a color', 'create-block-theme' ) }
+				</Button>
 			</HStack>
 			{ value.length > 0 && (
 				<>

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -361,6 +361,18 @@ const ColorTab = ( {
 } ) => {
 	const [ isPaletteOpen, setIsPaletteOpen ] = useState( false );
 	const paletteRef = useRef( null );
+	const prevPaletteLengthRef = useRef( palette.length );
+
+	// When the palette transitions from empty (force-open) to having entries,
+	// the force-open condition stops applying. Without this, adding the very
+	// first color via the empty-state button would collapse the accordion and
+	// hide the row that was just added.
+	useEffect( () => {
+		if ( prevPaletteLengthRef.current === 0 && palette.length > 0 ) {
+			setIsPaletteOpen( true );
+		}
+		prevPaletteLengthRef.current = palette.length;
+	}, [ palette.length ] );
 
 	const focusPalette = () => {
 		setIsPaletteOpen( true );

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -578,12 +578,12 @@ export const EditThemeSettingsModal = ( { onRequestClose } ) => {
 	const handleUpdateClick = async () => {
 		setIsSaving( true );
 		try {
-			// The endpoint returns the merged theme.json on success. Use it
-			// as the new canonical state instead of relying on a refetch:
-			// `getCurrentTheme` is entity-record-backed and
-			// `invalidateResolution` doesn't reliably re-fetch it before the
-			// user sees the (now-stale) dirty count.
-			const merged = await postUpdateThemeSettings( {
+			// The endpoint returns `{ status, theme_json: <merged> }` on
+			// success. Reseed from the merged theme.json directly instead of
+			// relying on a refetch: `getCurrentTheme` is entity-record-backed
+			// and `invalidateResolution` doesn't reliably re-fetch it before
+			// the user sees the (now-stale) dirty count.
+			const response = await postUpdateThemeSettings( {
 				settings: {
 					color: {
 						...colorSettings,
@@ -591,7 +591,7 @@ export const EditThemeSettingsModal = ( { onRequestClose } ) => {
 					},
 				},
 			} );
-			const savedColor = merged?.settings?.color || {};
+			const savedColor = response?.theme_json?.settings?.color || {};
 			const nextColorSettings = pickColorSettings( savedColor );
 			const nextPalette = Array.isArray( savedColor.palette )
 				? [ ...savedColor.palette ]

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -27,6 +27,7 @@ import {
 	ColorPicker,
 	Dropdown,
 	FlexBlock,
+	Icon,
 	Modal,
 	Notice,
 	PanelBody,
@@ -34,7 +35,7 @@ import {
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
-import { plus, lineSolid } from '@wordpress/icons';
+import { plus, lineSolid, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -293,27 +294,77 @@ const PalettePanel = ( { value, onChange } ) => {
 	);
 };
 
+const SWATCH_PREVIEW_COUNT = 5;
+
+const PaletteSummary = ( { palette, onEdit } ) => (
+	<HStack
+		className="cbt-palette-summary"
+		alignment="center"
+		justify="space-between"
+	>
+		<HStack
+			className="cbt-palette-summary__swatches"
+			alignment="center"
+			spacing={ 0 }
+			expanded={ false }
+		>
+			{ palette
+				.slice( 0, SWATCH_PREVIEW_COUNT )
+				.map( ( entry, index ) => (
+					<ColorIndicator key={ index } colorValue={ entry.color } />
+				) ) }
+		</HStack>
+		<Button
+			variant="tertiary"
+			onClick={ onEdit }
+			className="cbt-palette-summary__edit"
+		>
+			<HStack alignment="center" spacing={ 1 } expanded={ false }>
+				<span>{ __( 'Edit palette', 'create-block-theme' ) }</span>
+				<Icon icon={ chevronRight } />
+			</HStack>
+		</Button>
+	</HStack>
+);
+
 const ColorTab = ( {
 	colorSettings,
 	onChangeColorSettings,
 	palette,
 	onChangePalette,
-} ) => (
-	<>
-		<PanelBody
-			title={ __( 'Default and custom presets', 'create-block-theme' ) }
-			initialOpen
-		>
-			<ColorSettingsPanel
-				value={ colorSettings }
-				onChange={ onChangeColorSettings }
-			/>
-		</PanelBody>
-		<PanelBody title={ __( 'Palette', 'create-block-theme' ) } initialOpen>
-			<PalettePanel value={ palette } onChange={ onChangePalette } />
-		</PanelBody>
-	</>
-);
+} ) => {
+	const [ isPaletteOpen, setIsPaletteOpen ] = useState( false );
+
+	return (
+		<>
+			{ palette.length > 0 && (
+				<PaletteSummary
+					palette={ palette }
+					onEdit={ () => setIsPaletteOpen( true ) }
+				/>
+			) }
+			<PanelBody
+				title={ __(
+					'Default and custom presets',
+					'create-block-theme'
+				) }
+				initialOpen
+			>
+				<ColorSettingsPanel
+					value={ colorSettings }
+					onChange={ onChangeColorSettings }
+				/>
+			</PanelBody>
+			<PanelBody
+				title={ __( 'Palette', 'create-block-theme' ) }
+				opened={ isPaletteOpen }
+				onToggle={ setIsPaletteOpen }
+			>
+				<PalettePanel value={ palette } onChange={ onChangePalette } />
+			</PanelBody>
+		</>
+	);
+};
 
 const pickColorSettings = ( themeColor ) => {
 	const out = { ...COLOR_SETTINGS_DEFAULTS };

--- a/src/editor-sidebar/edit-theme-settings-modal.js
+++ b/src/editor-sidebar/edit-theme-settings-modal.js
@@ -232,18 +232,44 @@ const PalettePanel = ( { value, onChange } ) => {
 				/>
 			</HStack>
 			{ value.length > 0 && (
-				<ItemGroup isBordered isSeparated>
-					{ value.map( ( entry, index ) => (
-						<PaletteRow
-							key={ index }
-							entry={ entry }
-							onUpdate={ ( updated ) =>
-								updateEntry( index, updated )
-							}
-							onRemove={ () => removeEntry( index ) }
+				<>
+					<HStack
+						className="cbt-palette-column-headers"
+						alignment="center"
+						spacing={ 3 }
+					>
+						<span
+							className="cbt-palette-column-headers__swatch"
+							aria-hidden="true"
 						/>
-					) ) }
-				</ItemGroup>
+						<FlexBlock>
+							<BaseControl.VisualLabel>
+								{ __( 'Name', 'create-block-theme' ) }
+							</BaseControl.VisualLabel>
+						</FlexBlock>
+						<FlexBlock>
+							<BaseControl.VisualLabel>
+								{ __( 'Slug', 'create-block-theme' ) }
+							</BaseControl.VisualLabel>
+						</FlexBlock>
+						<span
+							className="cbt-palette-column-headers__remove"
+							aria-hidden="true"
+						/>
+					</HStack>
+					<ItemGroup isBordered isSeparated>
+						{ value.map( ( entry, index ) => (
+							<PaletteRow
+								key={ index }
+								entry={ entry }
+								onUpdate={ ( updated ) =>
+									updateEntry( index, updated )
+								}
+								onRemove={ () => removeEntry( index ) }
+							/>
+						) ) }
+					</ItemGroup>
+				</>
 			) }
 		</VStack>
 	);

--- a/src/editor-sidebar/json-editor-modal.js
+++ b/src/editor-sidebar/json-editor-modal.js
@@ -36,7 +36,9 @@ const ThemeJsonEditorModal = ( { onRequestClose } ) => {
 					return;
 				}
 				setThemeName( active?.name?.raw ?? active?.name ?? '' );
-				setThemeData( JSON.stringify( active?.theme_json ?? {}, null, 2 ) );
+				setThemeData(
+					JSON.stringify( active?.theme_json ?? {}, null, 2 )
+				);
 			} )
 			.catch( ( err ) => {
 				// Leave the modal showing whatever was last rendered, but

--- a/src/editor-sidebar/json-editor-modal.js
+++ b/src/editor-sidebar/json-editor-modal.js
@@ -38,8 +38,14 @@ const ThemeJsonEditorModal = ( { onRequestClose } ) => {
 				setThemeName( active?.name?.raw ?? '' );
 				setThemeData( JSON.stringify( active?.theme_json, null, 2 ) );
 			} )
-			.catch( () => {
-				// Swallow — leave the modal showing whatever was last rendered.
+			.catch( ( err ) => {
+				// Leave the modal showing whatever was last rendered, but
+				// surface the failure to the console so it isn't invisible.
+				// eslint-disable-next-line no-console
+				console.error(
+					'View theme.json: failed to fetch active theme',
+					err
+				);
 			} );
 		return () => {
 			cancelled = true;

--- a/src/editor-sidebar/json-editor-modal.js
+++ b/src/editor-sidebar/json-editor-modal.js
@@ -10,30 +10,41 @@ import { json } from '@codemirror/lang-json';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { Modal } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
 
 const ThemeJsonEditorModal = ( { onRequestClose } ) => {
 	const [ themeData, setThemeData ] = useState( '' );
-	const themeJsonData = useSelect(
-		( select ) => select( 'core' ).getCurrentTheme(),
-		[]
-	);
+	const [ themeName, setThemeName ] = useState( '' );
 	const { invalidateResolution } = useDispatch( 'core' );
 
-	// Force a fresh fetch on every mount so the modal reflects writes the
-	// Edit Theme Settings flow has made to theme.json since the resolver
-	// last resolved.
+	// Fetch directly via the REST API on every mount so the modal always
+	// shows the on-disk theme.json — bypassing the @wordpress/core-data
+	// cache that would otherwise serve stale content when the user opens
+	// View theme.json straight after closing the Edit Theme Settings modal.
+	// Also invalidate the cached resolution so other subscribers refresh.
 	useEffect( () => {
+		let cancelled = false;
 		invalidateResolution( 'getCurrentTheme' );
+		apiFetch( { path: '/wp/v2/themes?status=active' } )
+			.then( ( themes ) => {
+				if ( cancelled ) {
+					return;
+				}
+				const active = Array.isArray( themes ) ? themes[ 0 ] : null;
+				if ( ! active ) {
+					return;
+				}
+				setThemeName( active?.name?.raw ?? '' );
+				setThemeData( JSON.stringify( active?.theme_json, null, 2 ) );
+			} )
+			.catch( () => {
+				// Swallow — leave the modal showing whatever was last rendered.
+			} );
+		return () => {
+			cancelled = true;
+		};
 	}, [ invalidateResolution ] );
-
-	useEffect( () => {
-		if ( themeJsonData ) {
-			setThemeData(
-				JSON.stringify( themeJsonData?.theme_json, null, 2 )
-			);
-		}
-	}, [ themeJsonData ] );
 
 	const handleSave = () => {};
 
@@ -43,7 +54,7 @@ const ThemeJsonEditorModal = ( { onRequestClose } ) => {
 			title={ sprintf(
 				// translators: %s: theme name.
 				__( 'theme.json for %s', 'create-block-theme' ),
-				themeJsonData?.name?.raw ?? ''
+				themeName
 			) }
 			onRequestClose={ onRequestClose }
 			className="create-block-theme__theme-json-modal"

--- a/src/editor-sidebar/json-editor-modal.js
+++ b/src/editor-sidebar/json-editor-modal.js
@@ -10,7 +10,7 @@ import { json } from '@codemirror/lang-json';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { Modal } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 const ThemeJsonEditorModal = ( { onRequestClose } ) => {
 	const [ themeData, setThemeData ] = useState( '' );
@@ -18,6 +18,14 @@ const ThemeJsonEditorModal = ( { onRequestClose } ) => {
 		( select ) => select( 'core' ).getCurrentTheme(),
 		[]
 	);
+	const { invalidateResolution } = useDispatch( 'core' );
+
+	// Force a fresh fetch on every mount so the modal reflects writes the
+	// Edit Theme Settings flow has made to theme.json since the resolver
+	// last resolved.
+	useEffect( () => {
+		invalidateResolution( 'getCurrentTheme' );
+	}, [ invalidateResolution ] );
 
 	useEffect( () => {
 		if ( themeJsonData ) {

--- a/src/editor-sidebar/json-editor-modal.js
+++ b/src/editor-sidebar/json-editor-modal.js
@@ -35,8 +35,8 @@ const ThemeJsonEditorModal = ( { onRequestClose } ) => {
 				if ( ! active ) {
 					return;
 				}
-				setThemeName( active?.name?.raw ?? '' );
-				setThemeData( JSON.stringify( active?.theme_json, null, 2 ) );
+				setThemeName( active?.name?.raw ?? active?.name ?? '' );
+				setThemeData( JSON.stringify( active?.theme_json ?? {}, null, 2 ) );
 			} )
 			.catch( ( err ) => {
 				// Leave the modal showing whatever was last rendered, but

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -58,6 +58,7 @@ import GlobalStylesJsonEditorModal from './editor-sidebar/global-styles-json-edi
 import { SaveThemePanel } from './editor-sidebar/save-panel';
 import { CreateVariationPanel } from './editor-sidebar/create-variation-panel';
 import { ThemeMetadataEditorModal } from './editor-sidebar/metadata-editor-modal';
+import { EditThemeSettingsModal } from './editor-sidebar/edit-theme-settings-modal';
 import ScreenHeader from './editor-sidebar/screen-header';
 import { downloadExportedTheme } from './resolvers';
 import downloadFile from './utils/download-file';
@@ -89,6 +90,8 @@ const CreateBlockThemePlugin = () => {
 		useState( false );
 
 	const [ isMetadataEditorOpen, setIsMetadataEditorOpen ] = useState( false );
+
+	const [ isThemeSettingsOpen, setIsThemeSettingsOpen ] = useState( false );
 
 	const [ cloneCreateType, setCloneCreateType ] = useState( '' );
 
@@ -153,6 +156,17 @@ const CreateBlockThemePlugin = () => {
 									>
 										{ __(
 											'Create Theme Variation',
+											'create-block-theme'
+										) }
+									</PluginSidebarItem>
+									<PluginSidebarItem
+										icon={ cog }
+										onClick={ () =>
+											setIsThemeSettingsOpen( true )
+										}
+									>
+										{ __(
+											'Edit Theme Settings',
 											'create-block-theme'
 										) }
 									</PluginSidebarItem>
@@ -376,6 +390,12 @@ const CreateBlockThemePlugin = () => {
 			{ isMetadataEditorOpen && (
 				<ThemeMetadataEditorModal
 					onRequestClose={ () => setIsMetadataEditorOpen( false ) }
+				/>
+			) }
+
+			{ isThemeSettingsOpen && (
+				<EditThemeSettingsModal
+					onRequestClose={ () => setIsThemeSettingsOpen( false ) }
 				/>
 			) }
 		</>

--- a/src/plugin-sidebar.js
+++ b/src/plugin-sidebar.js
@@ -38,7 +38,7 @@ import {
 	tool,
 	copy,
 	download,
-	edit,
+	pencil,
 	code,
 	chevronLeft,
 	chevronRight,
@@ -171,7 +171,7 @@ const CreateBlockThemePlugin = () => {
 										) }
 									</PluginSidebarItem>
 									<PluginSidebarItem
-										icon={ edit }
+										icon={ pencil }
 										onClick={ () =>
 											setIsMetadataEditorOpen( true )
 										}

--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -43,10 +43,8 @@ $modal-footer-height: 70px;
 }
 
 .cbt-palette-summary {
-	padding: 12px 16px;
-	border: 1px solid #e0e0e0;
-	border-radius: 4px;
-	margin-bottom: 16px;
+	padding: 8px 0;
+	margin-bottom: 8px;
 
 	&__swatches > * + * {
 		// Overlap each subsequent swatch onto its predecessor.

--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -48,6 +48,9 @@ $modal-footer-height: 70px;
 	display: grid;
 	grid-template-columns: 1fr;
 	gap: 32px;
+	// Top-align so the two group headers (and their first toggle) line up
+	// even when the columns contain different numbers of toggles.
+	align-items: start;
 
 	@media (min-width: $break-small) {
 		grid-template-columns: 1fr 1fr;

--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -1,4 +1,5 @@
 @import "~@wordpress/base-styles/colors";
+@import "~@wordpress/base-styles/breakpoints";
 
 $modal-footer-height: 70px;
 
@@ -39,6 +40,18 @@ $modal-footer-height: 70px;
 	margin: 0 -32px;
 	padding: 16px 32px;
 	height: $modal-footer-height;
+}
+
+.cbt-color-settings-columns {
+	// Two side-by-side groups (Default presets / Custom presets) on wider
+	// modals; collapse to a single column at narrow widths.
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 32px;
+
+	@media (min-width: $break-small) {
+		grid-template-columns: 1fr 1fr;
+	}
 }
 
 .cbt-palette-swatch-button {

--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -51,13 +51,28 @@ $modal-footer-height: 70px;
 }
 
 .cbt-palette-column-headers {
+	// Match the horizontal padding @wordpress/components Item applies to row
+	// content so column headers line up with the inputs below.
 	padding: 0 12px;
 
-	&__swatch,
-	&__remove {
+	&__spacer {
 		display: inline-block;
 		width: 24px;
+		height: 24px;
 		flex-shrink: 0;
+	}
+
+	&__label {
+		display: block;
+		// Align with the visible text inside the TextControl input below
+		// (inputs have ~12px internal padding before text).
+		padding-left: 12px;
+		font-size: 11px;
+		font-weight: 500;
+		line-height: 1.4;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+		color: #757575;
 	}
 }
 

--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -42,6 +42,22 @@ $modal-footer-height: 70px;
 	height: $modal-footer-height;
 }
 
+.cbt-palette-summary {
+	padding: 12px 16px;
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	margin-bottom: 16px;
+
+	&__swatches > * + * {
+		// Overlap each subsequent swatch onto its predecessor.
+		margin-left: -8px;
+	}
+
+	&__edit {
+		text-decoration: none;
+	}
+}
+
 .cbt-color-settings-columns {
 	// Two side-by-side groups (Default presets / Custom presets) on wider
 	// modals; collapse to a single column at narrow widths.

--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -50,3 +50,14 @@ $modal-footer-height: 70px;
 	margin-bottom: 8px;
 }
 
+.cbt-palette-column-headers {
+	padding: 0 12px;
+
+	&__swatch,
+	&__remove {
+		display: inline-block;
+		width: 24px;
+		flex-shrink: 0;
+	}
+}
+

--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -12,8 +12,8 @@ $modal-footer-height: 70px;
 }
 
 .create-block-theme__metadata-editor-modal__footer {
-	border-top: 1px solid #ddd;
-	background-color: #fff;
+	border-top: 1px solid $gray-300;
+	background-color: $white;
 	position: absolute;
 	bottom: 0;
 	margin: 0 -32px;
@@ -40,8 +40,8 @@ $modal-footer-height: 70px;
 }
 
 .create-block-theme__edit-theme-settings-modal__footer {
-	border-top: 1px solid #ddd;
-	background-color: #fff;
+	border-top: 1px solid $gray-300;
+	background-color: $white;
 	position: absolute;
 	bottom: 0;
 	margin: 0 -32px;
@@ -116,7 +116,7 @@ $modal-footer-height: 70px;
 		line-height: 1.4;
 		text-transform: uppercase;
 		letter-spacing: 0.5px;
-		color: #757575;
+		color: $gray-700;
 	}
 }
 

--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -27,3 +27,26 @@ $modal-footer-height: 70px;
 	object-fit: cover;
 }
 
+.create-block-theme__edit-theme-settings-modal {
+	padding-bottom: $modal-footer-height;
+}
+
+.create-block-theme__edit-theme-settings-modal__footer {
+	border-top: 1px solid #ddd;
+	background-color: #fff;
+	position: absolute;
+	bottom: 0;
+	margin: 0 -32px;
+	padding: 16px 32px;
+	height: $modal-footer-height;
+}
+
+.cbt-palette-swatch-button {
+	min-width: 24px;
+	padding: 0;
+}
+
+.cbt-palette-section-header {
+	margin-bottom: 8px;
+}
+

--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -64,9 +64,10 @@ $modal-footer-height: 70px;
 
 	&__label {
 		display: block;
-		// Align with the visible text inside the TextControl input below
-		// (inputs have ~12px internal padding before text).
-		padding-left: 12px;
+		// The wrapper above already pads horizontally to match the row's
+		// Item padding, so the label sits at the same x-offset as the
+		// TextControl input directly below it.
+		padding-left: 0;
 		font-size: 11px;
 		font-weight: 500;
 		line-height: 1.4;

--- a/src/plugin-styles.scss
+++ b/src/plugin-styles.scss
@@ -30,6 +30,13 @@ $modal-footer-height: 70px;
 
 .create-block-theme__edit-theme-settings-modal {
 	padding-bottom: $modal-footer-height;
+
+	// Drop the top border on the first PanelBody when it sits below a
+	// non-panel sibling (e.g. our PaletteSummary card) so the boundary
+	// doesn't double-up with the summary's bottom edge.
+	.components-tab-panel__tab-content > :not(.components-panel__body) + .components-panel__body {
+		border-top: 0;
+	}
 }
 
 .create-block-theme__edit-theme-settings-modal__footer {
@@ -78,6 +85,12 @@ $modal-footer-height: 70px;
 
 .cbt-palette-section-header {
 	margin-bottom: 8px;
+
+	// Nudge the right-edge action (e.g. "+ Add a color") -8px so it aligns
+	// with the PanelBody chevron in the accordion header directly above.
+	> :last-child {
+		margin-right: -8px;
+	}
 }
 
 .cbt-palette-column-headers {

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -85,6 +85,17 @@ export async function postUpdateThemeMetadata( theme ) {
 	} );
 }
 
+export async function postUpdateThemeSettings( payload ) {
+	return apiFetch( {
+		path: '/create-block-theme/v1/theme-settings',
+		method: 'POST',
+		data: payload,
+		headers: {
+			'Content-Type': 'application/json',
+		},
+	} );
+}
+
 export async function downloadExportedTheme() {
 	return apiFetch( {
 		path: '/create-block-theme/v1/export',


### PR DESCRIPTION
## Summary

Adds a new **Edit Theme Settings** entry to the Create Block Theme sidebar (cog icon, between Create Theme Variation and Edit Theme Metadata). Clicking it opens a modal with a single Color tab containing two panels:

- **Color Settings** — toggles for default/custom presets (`defaultPalette`, `defaultGradients`, `defaultDuotone`, `custom`, `customGradient`, `customDuotone`) and the `link` color control.
- **Palette** — full CRUD over `settings.color.palette` (add row, edit name and slug, pick color via `ColorPicker`, remove row), with `Name` / `Slug` column headers above the rows.

The modal owns the working state for both panels, seeded from `getCurrentTheme().theme_json.settings.color`. Clicking **Update** posts a partial-`theme.json` payload to `POST /create-block-theme/v1/theme-settings` (the endpoint that landed in #843) and reseeds the panels from the refreshed server state after a successful save. The modal stays open on success so the user can keep editing — `theme.json`-only edits do not need a page reload.

This is the foundation PR for the Edit Theme Settings feature. Gradients, Duotone, and the Dimensions / Typography / Shadows / Templates tabs land in follow-up PRs (#839–#842).

## Screenshots

(See the modal under: Site Editor → Create Block Theme sidebar → Edit Theme Settings)

## Notable UX details

- **Update button** shows `Update (N changes)` when there are pending edits, plain `Update` otherwise. Disabled when nothing has changed and shows a busy state during save.
- **Conditional warning notice** — the disclaimer about Site-Editor-vs-theme.json conflicts is only shown when the active theme has user-level Global Styles customizations (saved record + in-editor edits). The notice lists which top-level slices are customized (e.g. \"color, typography\") so the user knows what would conflict.
- **Notices** — success/error use snackbar notices via `@wordpress/notices`.

## Test plan

- [ ] Open the Site Editor on a block theme; click the CBT cog icon → \"Edit Theme Settings\" appears in the sidebar.
- [ ] Open the modal; the Color tab renders with both Color Settings and Palette panels.
- [ ] Toggle any Color Settings boolean → Update button reflects the change count → click Update → reload editor → toggle state is persisted in `theme.json`.
- [ ] Add a new palette entry, edit name/slug, pick a color → Update → reload → entry is present in `theme.json`.
- [ ] Remove a palette entry → Update → reload → entry is gone from `theme.json`.
- [ ] With no user Global Styles customizations, the warning notice is hidden.
- [ ] With user customizations present, the warning notice appears and lists the customized sections in bold.
- [ ] Trigger a server error (e.g. block the endpoint) → error snackbar surfaces with the message; modal stays open.

## Refs

- Refs #838
- Builds on #843 (REST endpoint)
- Tracking: #836

## Updates since open

- Color Settings panel now uses a 2-column layout (Default / Custom) above `$break-small`, with per-toggle help copy; pushes the Palette panel above the fold.
- Renamed the first Color tab section header from "Color Settings" → "Default and custom presets" (more descriptive, no redundancy with the surrounding tab name).
- Fixed top alignment between the two Color Settings columns (was vertically centered, now top-aligned).
- Sidebar: switched Edit Theme Metadata to the `pencil` icon so its row icon renders consistently with the other menu entries.

## Further updates

- Palette panel: dropped the redundant "Color presets" sub-label and replaced the icon-only `+` with a labeled "+ Add a color" tertiary button.
- Color tab: added a Site-Editor-style Palette summary card at the top of the tab (overlapping swatches + "Edit palette →"). Clicking it expands the Palette accordion (now defaulted to closed when the palette is non-empty); clicking again scrolls the panel into view even when already open.
- Empty palette: force the Palette accordion open so the "+ Add a color" entry stays discoverable; keep it open through the 0 → 1 transition so the first added row doesn't get hidden by the accordion collapsing.
- Palette summary card: borderless and left-aligned with the swatches to reduce visual rule noise.
- Palette: new rows scroll into view automatically after Add.
- Sync with upstream polish direction: bumped palette-row remove icon to 20px, nudged the right-edge `+ Add a color` to align with the PanelBody chevron, dropped the doubled border between the summary card and the first accordion.

## Save / refresh cycle

- After Update, reseed local state from the response's `theme_json` payload so the Update button resets immediately and the in-memory state matches what was just persisted.
- View theme.json fetches `/wp/v2/themes?status=active` directly via `apiFetch` on every open, so closing the Edit Theme Settings modal and going straight to View theme.json shows the on-disk file, not the previous cached snapshot.

## Review feedback addressed

Single commit covering the must-fix + should-fix items from review:

- **Duplicate slugs** on Add → Remove → Add — fixed by deriving next index from max existing `new-color-N` suffix.
- **React keys** — palette rows get a stable client-only `__cbtRowId` assigned at creation (stripped from the payload before send), so removing a middle row no longer leaks Dropdown/ColorPicker state.
- **Empty slug guard** — Update is disabled (with explanatory tooltip) when any row has an empty slug.
- **Plural form** — Update label uses `_n()` so `Update (1 change)` vs. `Update (3 changes)` pluralize correctly.
- **i18n separator** — section list in the warning uses `Intl.ListFormat` for locale-aware joining (with `, `.join() fallback).
- **Minimal patch on save** — only fields the user touched in this session are sent to the endpoint. Stops concurrent palette edits from being clobbered by an unrelated toggle save (the RFC 7396 list-replacement issue Codex flagged).
- **Reseed guard** — refresh-effect skips while the user has unsaved edits, so mid-flight cache invalidations don't wipe in-progress work.
- **changeCount granularity** — toggles count individually; palette counts as one unit (deliberate: reordering / per-row diffs would be a UX rabbit hole).
- **SCSS color vars** — `#757575`/`#ddd`/`#fff` replaced with `$gray-700`/`$gray-300`/`$white` from `@wordpress/base-styles`.
- **Silent catch** — `apiFetch` failures in View theme.json now log to console.

Deferred to follow-ups:

- Different sidebar icon for "Edit Theme Settings" (currently `cog`, same as Editor Preferences) — aesthetic, not blocking.
- `requestAnimationFrame` timing on the Edit-palette scroll — current build opens the PanelBody synchronously, no transition; revisit if a future Gutenberg version animates the accordion.
- In-modal save confirmation beyond the snackbar — disagree that it's needed.
- ETag / If-Match for the endpoint to fully solve concurrent palette edits — endpoint-side follow-up.