### PR TITLE
Adding Git Action to enable PR preview

### DIFF
--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -1,0 +1,45 @@
+name: PR Playground Preview
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    preview:
+        name: Add Playground preview button
+        runs-on: ubuntu-latest
+        steps:
+            - name: Post Playground Preview Button
+              uses: WordPress/action-wp-playground-pr-preview@v3
+              with:
+                  blueprint: |
+                      {
+                          "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+                          "landingPage": "/wp-admin/themes.php?page=create-block-theme-landing",
+                          "steps": [
+                              {
+                                  "step": "login",
+                                  "username": "admin",
+                                  "password": "password"
+                              },
+                              {
+                                  "step": "installPlugin",
+                                  "pluginData": {
+                                      "resource": "git:directory",
+                                      "url": "https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git",
+                                      "ref": "${{ github.event.pull_request.head.sha }}",
+                                      "refType": "commit",
+                                      "path": "/"
+                                  },
+                                  "options": {
+                                      "activate": true,
+                                      "targetFolderName": "create-block-theme"
+                                  }
+                              }
+                          ]
+                      }
+                  github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -1,7 +1,7 @@
 name: PR Playground Preview
 
 on:
-    pull_request:
+    pull_request_target:
         types: [opened, synchronize, reopened, edited]
 
 permissions:


### PR DESCRIPTION
This pull request adds an action to include the PR preview button for the new PRs created. The workflow posts a WordPress Playground preview button to PRs using `WordPress/action-wp-playground-pr-preview@v3`. The preview installs Create Block Theme directly from the PR branch,  activates it, logs in as admin, and opens the Create Block Theme landing page.

To learn more about PR preview: https://wordpress.github.io/wordpress-playground/guides/github-action-pr-preview

This PR is related to issue #848 