### PR TITLE
Require super-admin for theme-modifying REST routes on multisite

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -123,6 +123,9 @@ jobs:
 
             - name: Run PHP tests
               run: npm run test:unit:php:base
+
+            - name: Run API PHP tests in multisite
+              run: npm run test:unit:php:multisite-api
     e2e:
         name: E2E Tests
         runs-on: ubuntu-latest

--- a/includes/class-create-block-theme-admin-landing.php
+++ b/includes/class-create-block-theme-admin-landing.php
@@ -18,10 +18,19 @@ class CBT_Admin_Landing {
 			return;
 		}
 
+		// Mirror the REST surface gate (see CBT_Theme_API::can_modify_theme()):
+		// every primary action on this landing page calls a mutating route, so
+		// users who cannot pass that gate (sub-site admins on multisite,
+		// DISALLOW_FILE_EDIT/DISALLOW_FILE_MODS sites, file_mod_allowed denies)
+		// should not see the menu entry at all.
+		if ( ! CBT_Theme_API::can_modify_theme() ) {
+			return;
+		}
+
 		$landing_page_slug       = 'create-block-theme-landing';
 		$landing_page_title      = _x( 'Create Block Theme', 'UI String', 'create-block-theme' );
 		$landing_page_menu_title = $landing_page_title;
-		add_theme_page( $landing_page_title, $landing_page_menu_title, 'edit_theme_options', $landing_page_slug, array( 'CBT_Admin_Landing', 'admin_menu_page' ) );
+		add_theme_page( $landing_page_title, $landing_page_menu_title, 'edit_themes', $landing_page_slug, array( 'CBT_Admin_Landing', 'admin_menu_page' ) );
 
 	}
 

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -508,48 +508,22 @@ class CBT_Theme_API {
 	/**
 	 * Permission check for filesystem-mutating REST routes.
 	 *
-	 * On multisite, themes are network-shared. Require super-admin to prevent
-	 * sub-site administrators from crossing the tenant boundary into the
-	 * shared `wp-content/themes/` directory.
+	 * Combines two WordPress Core primitives:
 	 *
-	 * Honors the WP hardening constants `DISALLOW_FILE_EDIT` and
-	 * `DISALLOW_FILE_MODS` via `file_mods_allowed()`, matching the behaviour
-	 * the plugin had pre-v2.1.2 and aligning with WP Core's theme-editor.
+	 *  - `current_user_can( 'edit_themes' )` — Core's canonical theme-file
+	 *    capability. Held by Administrators on single-site, super-admins on
+	 *    multisite (NOT sub-site admins), and automatically denied when
+	 *    `DISALLOW_FILE_EDIT` is defined. This single check covers the
+	 *    multisite tenant boundary and the `DISALLOW_FILE_EDIT` hardening
+	 *    that the plugin honoured pre-v2.1.2.
+	 *  - `wp_is_file_mod_allowed( 'create_block_theme_modify_theme' )` —
+	 *    Core's canonical file-modification gate. Handles `DISALLOW_FILE_MODS`
+	 *    and the `file_mod_allowed` filter (used by hosts / security plugins).
 	 *
-	 * @return bool
+	 * @return bool True when both checks pass.
 	 */
 	private function can_modify_theme() {
-		if ( ! $this->file_mods_allowed() ) {
-			return false;
-		}
-		if ( is_multisite() ) {
-			return is_super_admin();
-		}
-		return current_user_can( 'edit_theme_options' );
-	}
-
-	/**
-	 * Whether theme-file modifications are permitted by site configuration.
-	 *
-	 * Delegates the `DISALLOW_FILE_MODS` check (and the canonical
-	 * `file_mod_allowed` filter that hosts and security plugins use to disable
-	 * file modifications globally) to WordPress Core's `wp_is_file_mod_allowed()`.
-	 * `DISALLOW_FILE_EDIT` is checked explicitly because it is a separate
-	 * constant that Core's helper does NOT cover.
-	 *
-	 * The `cbt_file_mods_allowed` filter remains as a test seam — it can only
-	 * further restrict, never re-enable, the policy decided by core / the
-	 * constants.
-	 *
-	 * @return bool True when file modifications are allowed by site configuration.
-	 */
-	private function file_mods_allowed() {
-		if ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT ) {
-			$allowed = false;
-		} else {
-			$allowed = wp_is_file_mod_allowed( 'create_block_theme_modify_theme' );
-		}
-		$filtered = (bool) apply_filters( 'cbt_file_mods_allowed', $allowed );
-		return $allowed && $filtered;
+		return current_user_can( 'edit_themes' )
+			&& wp_is_file_mod_allowed( 'create_block_theme_modify_theme' );
 	}
 }

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -531,13 +531,7 @@ class CBT_Theme_API {
 	/**
 	 * Whether theme-file modifications are permitted by site configuration.
 	 *
-	 * Read-only inside production code paths. The `cbt_file_mods_allowed`
-	 * filter exists primarily as a test seam — `DISALLOW_FILE_EDIT` and
-	 * `DISALLOW_FILE_MODS` are `define`d constants and cannot be undefined
-	 * once set, so tests need a way to simulate them.
-	 *
-	 * @return bool True if both DISALLOW_FILE_EDIT and DISALLOW_FILE_MODS are absent / false.
-	 */
+	 * @return bool True when file modifications are allowed by configuration (DISALLOW_FILE_EDIT / DISALLOW_FILE_MODS) and not disabled by the cbt_file_mods_allowed filter.
 	private function file_mods_allowed() {
 		$const_allowed = ! ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT );
 		if ( $const_allowed ) {

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -43,7 +43,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_export_theme' ),
 				'permission_callback' => function () {
-					return $this->can_modify_theme();
+					return self::can_modify_theme();
 				},
 			)
 		);
@@ -54,7 +54,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_update_theme' ),
 				'permission_callback' => function () {
-					return $this->can_modify_theme();
+					return self::can_modify_theme();
 				},
 			)
 		);
@@ -65,7 +65,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_save_theme' ),
 				'permission_callback' => function () {
-					return $this->can_modify_theme();
+					return self::can_modify_theme();
 				},
 			)
 		);
@@ -76,7 +76,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_save_theme_settings' ),
 				'permission_callback' => function () {
-					return $this->can_modify_theme();
+					return self::can_modify_theme();
 				},
 			)
 		);
@@ -87,7 +87,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_clone_theme' ),
 				'permission_callback' => function () {
-					return $this->can_modify_theme();
+					return self::can_modify_theme();
 				},
 			)
 		);
@@ -98,7 +98,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_create_variation' ),
 				'permission_callback' => function () {
-					return $this->can_modify_theme();
+					return self::can_modify_theme();
 				},
 			)
 		);
@@ -109,7 +109,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_create_blank_theme' ),
 				'permission_callback' => function () {
-					return $this->can_modify_theme();
+					return self::can_modify_theme();
 				},
 			)
 		);
@@ -120,7 +120,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_create_child_theme' ),
 				'permission_callback' => function () {
-					return $this->can_modify_theme();
+					return self::can_modify_theme();
 				},
 			)
 		);
@@ -146,7 +146,7 @@ class CBT_Theme_API {
 				// cap as the file-mutating routes for permission-surface
 				// consistency.
 				'permission_callback' => function () {
-					return $this->can_modify_theme();
+					return self::can_modify_theme();
 				},
 			),
 		);
@@ -526,7 +526,7 @@ class CBT_Theme_API {
 	 *
 	 * @return bool True when both checks pass.
 	 */
-	private function can_modify_theme() {
+	public static function can_modify_theme() {
 		return current_user_can( 'edit_themes' )
 			&& wp_is_file_mod_allowed( 'create_block_theme_modify_theme' );
 	}

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -504,4 +504,45 @@ class CBT_Theme_API {
 		$sanitized_theme['text_domain']         = $sanitized_theme['slug'];
 		return $sanitized_theme;
 	}
+
+	/**
+	 * Permission check for filesystem-mutating REST routes.
+	 *
+	 * On multisite, themes are network-shared. Require super-admin to prevent
+	 * sub-site administrators from crossing the tenant boundary into the
+	 * shared `wp-content/themes/` directory.
+	 *
+	 * Honors the WP hardening constants `DISALLOW_FILE_EDIT` and
+	 * `DISALLOW_FILE_MODS` via `file_mods_allowed()`, matching the behaviour
+	 * the plugin had pre-v2.1.2 and aligning with WP Core's theme-editor.
+	 *
+	 * @return bool
+	 */
+	private function can_modify_theme() {
+		if ( ! $this->file_mods_allowed() ) {
+			return false;
+		}
+		if ( is_multisite() ) {
+			return is_super_admin();
+		}
+		return current_user_can( 'edit_theme_options' );
+	}
+
+	/**
+	 * Whether theme-file modifications are permitted by site configuration.
+	 *
+	 * Read-only inside production code paths. The `cbt_file_mods_allowed`
+	 * filter exists primarily as a test seam — `DISALLOW_FILE_EDIT` and
+	 * `DISALLOW_FILE_MODS` are `define`d constants and cannot be undefined
+	 * once set, so tests need a way to simulate them.
+	 *
+	 * @return bool True if both DISALLOW_FILE_EDIT and DISALLOW_FILE_MODS are absent / false.
+	 */
+	private function file_mods_allowed() {
+		$allowed = ! ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT );
+		if ( $allowed ) {
+			$allowed = ! ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS );
+		}
+		return apply_filters( 'cbt_file_mods_allowed', $allowed );
+	}
 }

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -141,6 +141,10 @@ class CBT_Theme_API {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'rest_reset_theme' ),
+				// /reset-theme doesn't mutate theme files (it only clears
+				// user customisations from the DB), but is gated on the same
+				// cap as the file-mutating routes for permission-surface
+				// consistency.
 				'permission_callback' => function () {
 					return $this->can_modify_theme();
 				},

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -539,10 +539,11 @@ class CBT_Theme_API {
 	 * @return bool True if both DISALLOW_FILE_EDIT and DISALLOW_FILE_MODS are absent / false.
 	 */
 	private function file_mods_allowed() {
-		$allowed = ! ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT );
-		if ( $allowed ) {
-			$allowed = ! ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS );
+		$const_allowed = ! ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT );
+		if ( $const_allowed ) {
+			$const_allowed = ! ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS );
 		}
-		return apply_filters( 'cbt_file_mods_allowed', $allowed );
+		$filtered = (bool) apply_filters( 'cbt_file_mods_allowed', $const_allowed );
+		return $const_allowed && $filtered;
 	}
 }

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -43,7 +43,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_export_theme' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					return $this->can_modify_theme();
 				},
 			)
 		);
@@ -54,7 +54,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_update_theme' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					return $this->can_modify_theme();
 				},
 			)
 		);
@@ -65,7 +65,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_save_theme' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					return $this->can_modify_theme();
 				},
 			)
 		);
@@ -76,7 +76,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_save_theme_settings' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					return $this->can_modify_theme();
 				},
 			)
 		);
@@ -87,7 +87,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_clone_theme' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					return $this->can_modify_theme();
 				},
 			)
 		);
@@ -98,7 +98,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_create_variation' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					return $this->can_modify_theme();
 				},
 			)
 		);
@@ -109,7 +109,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_create_blank_theme' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					return $this->can_modify_theme();
 				},
 			)
 		);
@@ -120,7 +120,7 @@ class CBT_Theme_API {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'rest_create_child_theme' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					return $this->can_modify_theme();
 				},
 			)
 		);
@@ -142,7 +142,7 @@ class CBT_Theme_API {
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'rest_reset_theme' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					return $this->can_modify_theme();
 				},
 			),
 		);

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -531,14 +531,25 @@ class CBT_Theme_API {
 	/**
 	 * Whether theme-file modifications are permitted by site configuration.
 	 *
-	 * @return bool True when file modifications are allowed by configuration (DISALLOW_FILE_EDIT / DISALLOW_FILE_MODS) and not disabled by the cbt_file_mods_allowed filter.
+	 * Delegates the `DISALLOW_FILE_MODS` check (and the canonical
+	 * `file_mod_allowed` filter that hosts and security plugins use to disable
+	 * file modifications globally) to WordPress Core's `wp_is_file_mod_allowed()`.
+	 * `DISALLOW_FILE_EDIT` is checked explicitly because it is a separate
+	 * constant that Core's helper does NOT cover.
+	 *
+	 * The `cbt_file_mods_allowed` filter remains as a test seam — it can only
+	 * further restrict, never re-enable, the policy decided by core / the
+	 * constants.
+	 *
+	 * @return bool True when file modifications are allowed by site configuration.
 	 */
 	private function file_mods_allowed() {
-		$const_allowed = ! ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT );
-		if ( $const_allowed ) {
-			$const_allowed = ! ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS );
+		if ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT ) {
+			$allowed = false;
+		} else {
+			$allowed = wp_is_file_mod_allowed( 'create_block_theme_modify_theme' );
 		}
-		$filtered = (bool) apply_filters( 'cbt_file_mods_allowed', $const_allowed );
-		return $const_allowed && $filtered;
+		$filtered = (bool) apply_filters( 'cbt_file_mods_allowed', $allowed );
+		return $allowed && $filtered;
 	}
 }

--- a/includes/class-create-block-theme-api.php
+++ b/includes/class-create-block-theme-api.php
@@ -532,6 +532,7 @@ class CBT_Theme_API {
 	 * Whether theme-file modifications are permitted by site configuration.
 	 *
 	 * @return bool True when file modifications are allowed by configuration (DISALLOW_FILE_EDIT / DISALLOW_FILE_MODS) and not disabled by the cbt_file_mods_allowed filter.
+	 */
 	private function file_mods_allowed() {
 		$const_allowed = ! ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT );
 		if ( $const_allowed ) {

--- a/includes/class-create-block-theme-editor-tools.php
+++ b/includes/class-create-block-theme-editor-tools.php
@@ -20,6 +20,15 @@ class CBT_Editor_Tools {
 			return;
 		}
 
+		// Mirror the REST surface gate (see CBT_Theme_API::can_modify_theme()):
+		// every action exposed by this sidebar calls a mutating route, so users
+		// who cannot pass that gate (sub-site admins on multisite,
+		// DISALLOW_FILE_EDIT/DISALLOW_FILE_MODS sites, file_mod_allowed denies)
+		// should not see the sidebar at all.
+		if ( ! CBT_Theme_API::can_modify_theme() ) {
+			return;
+		}
+
 		$asset_file = include plugin_dir_path( dirname( __FILE__ ) ) . 'build/plugin-sidebar.asset.php';
 
 		wp_register_script(

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"lint:pkg-json": "wp-scripts lint-pkg-json",
 		"test:unit:php:setup": "wp-env start",
 		"test:unit:php:base": "wp-env run tests-wordpress --env-cwd='wp-content/plugins/create-block-theme' vendor/bin/phpunit -c phpunit.xml.dist --verbose",
+		"test:unit:php:multisite-api": "wp-env run tests-wordpress --env-cwd='wp-content/plugins/create-block-theme' vendor/bin/phpunit -c /wordpress-phpunit/multisite.xml --bootstrap tests/bootstrap.php --verbose --filter Test_Create_Block_Theme_Api --test-suffix .php tests",
 		"test:unit:php": "npm run test:unit:php:setup && npm run test:unit:php:base",
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start src/admin-landing-page.js src/plugin-sidebar.js",

--- a/tests/test-class-create-block-theme-api.php
+++ b/tests/test-class-create-block-theme-api.php
@@ -4,17 +4,6 @@
  */
 class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 
-	/**
-	 * Helper: invoke a private method on a CBT_Theme_API instance.
-	 */
-	private function invoke_private( $method ) {
-		$ref_class = new ReflectionClass( CBT_Theme_API::class );
-		$instance  = $ref_class->newInstanceWithoutConstructor();
-		$ref       = new ReflectionMethod( $instance, $method );
-		$ref->setAccessible( true );
-		return $ref->invoke( $instance );
-	}
-
 	public function test_admin_can_modify_theme_on_single_site() {
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'single-site only' );
@@ -22,7 +11,7 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin );
 
-		$this->assertTrue( $this->invoke_private( 'can_modify_theme' ) );
+		$this->assertTrue( CBT_Theme_API::can_modify_theme() );
 	}
 
 	public function test_editor_cannot_modify_theme_on_single_site() {
@@ -32,12 +21,12 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 		$editor = $this->factory->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor );
 
-		$this->assertFalse( $this->invoke_private( 'can_modify_theme' ) );
+		$this->assertFalse( CBT_Theme_API::can_modify_theme() );
 	}
 
 	public function test_anonymous_cannot_modify_theme() {
 		wp_set_current_user( 0 );
-		$this->assertFalse( $this->invoke_private( 'can_modify_theme' ) );
+		$this->assertFalse( CBT_Theme_API::can_modify_theme() );
 	}
 
 	public function test_admin_blocked_by_core_file_mod_allowed_filter() {
@@ -51,7 +40,7 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 		wp_set_current_user( $admin );
 
 		add_filter( 'file_mod_allowed', '__return_false' );
-		$result = $this->invoke_private( 'can_modify_theme' );
+		$result = CBT_Theme_API::can_modify_theme();
 		remove_filter( 'file_mod_allowed', '__return_false' );
 
 		$this->assertFalse( $result );
@@ -108,7 +97,7 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 		grant_super_admin( $super );
 		wp_set_current_user( $super );
 
-		$this->assertTrue( $this->invoke_private( 'can_modify_theme' ) );
+		$this->assertTrue( CBT_Theme_API::can_modify_theme() );
 
 		revoke_super_admin( $super );
 	}
@@ -121,7 +110,7 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 		// Explicitly NOT a super-admin — `edit_themes` is super-admin-only on multisite.
 		wp_set_current_user( $admin );
 
-		$this->assertFalse( $this->invoke_private( 'can_modify_theme' ) );
+		$this->assertFalse( CBT_Theme_API::can_modify_theme() );
 	}
 
 	public function test_save_endpoint_rejects_subsite_admin_on_multisite() {
@@ -136,5 +125,55 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 
 		$this->assertSame( 403, $response->get_status() );
 		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	public function test_admin_landing_menu_not_registered_when_cannot_modify_theme() {
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		add_filter( 'file_mod_allowed', '__return_false' );
+
+		$landing = new CBT_Admin_Landing();
+		set_current_screen( 'themes.php' );
+		global $submenu;
+		$submenu = array();
+		$landing->create_admin_menu();
+		$menu_after_deny = isset( $submenu['themes.php'] ) ? $submenu['themes.php'] : array();
+
+		remove_filter( 'file_mod_allowed', '__return_false' );
+
+		$slugs = array_column( $menu_after_deny, 2 );
+		$this->assertNotContains(
+			'create-block-theme-landing',
+			$slugs,
+			'Landing-page menu must NOT be registered when the user cannot modify the theme.'
+		);
+	}
+
+	public function test_editor_sidebar_enqueue_drops_when_cannot_modify_theme() {
+		// Sub-site admin on multisite or DISALLOW_FILE_MODS site: the sidebar
+		// JS should not enqueue. Simulate by gating via file_mod_allowed.
+		global $pagenow;
+		$saved_pagenow = $pagenow;
+		$pagenow       = 'site-editor.php';
+
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		add_filter( 'file_mod_allowed', '__return_false' );
+
+		$tools = new CBT_Editor_Tools();
+		// Reset any prior enqueue state.
+		wp_dequeue_script( 'create-block-theme-slot-fill' );
+		$tools->create_block_theme_sidebar_enqueue();
+		$enqueued = wp_script_is( 'create-block-theme-slot-fill', 'enqueued' );
+
+		remove_filter( 'file_mod_allowed', '__return_false' );
+		$pagenow = $saved_pagenow;
+
+		$this->assertFalse(
+			$enqueued,
+			'Sidebar script must NOT be enqueued when the user cannot modify the theme.'
+		);
 	}
 }

--- a/tests/test-class-create-block-theme-api.php
+++ b/tests/test-class-create-block-theme-api.php
@@ -40,64 +40,34 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 		$this->assertFalse( $this->invoke_private( 'can_modify_theme' ) );
 	}
 
-	public function test_admin_blocked_when_file_mods_disallowed() {
+	public function test_admin_blocked_by_core_file_mod_allowed_filter() {
+		// WordPress Core's canonical `file_mod_allowed` filter is the
+		// mechanism hosts and security plugins use to disable file
+		// modifications globally. can_modify_theme() must honour it.
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'single-site only' );
 		}
 		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin );
 
-		add_filter( 'cbt_file_mods_allowed', '__return_false' );
+		add_filter( 'file_mod_allowed', '__return_false' );
 		$result = $this->invoke_private( 'can_modify_theme' );
-		remove_filter( 'cbt_file_mods_allowed', '__return_false' );
-
-		$this->assertFalse( $result );
-	}
-
-	public function test_file_mods_allowed_returns_true_by_default() {
-		$this->assertTrue( $this->invoke_private( 'file_mods_allowed' ) );
-	}
-
-	public function test_file_mods_allowed_filter_can_disable() {
-		add_filter( 'cbt_file_mods_allowed', '__return_false' );
-		$result = $this->invoke_private( 'file_mods_allowed' );
-		remove_filter( 'cbt_file_mods_allowed', '__return_false' );
-
-		$this->assertFalse( $result );
-	}
-
-	public function test_file_mods_allowed_respects_core_file_mod_allowed_filter() {
-		// WordPress Core's canonical `file_mod_allowed` filter is the
-		// mechanism hosts and security plugins use to disable file mods
-		// globally. file_mods_allowed() must honour it.
-		add_filter( 'file_mod_allowed', '__return_false' );
-		$result = $this->invoke_private( 'file_mods_allowed' );
 		remove_filter( 'file_mod_allowed', '__return_false' );
 
 		$this->assertFalse( $result );
 	}
 
-	public function test_file_mods_allowed_filter_cannot_reenable_core_disallow() {
-		add_filter( 'file_mod_allowed', '__return_false' );
-		add_filter( 'cbt_file_mods_allowed', '__return_true' );
-		$result = $this->invoke_private( 'file_mods_allowed' );
-		remove_filter( 'cbt_file_mods_allowed', '__return_true' );
-		remove_filter( 'file_mod_allowed', '__return_false' );
-
-		$this->assertFalse( $result );
-	}
-
-	public function test_save_endpoint_rejects_when_file_mods_disallowed() {
+	public function test_save_endpoint_rejects_when_file_mod_allowed_filter_returns_false() {
 		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin );
 		if ( is_multisite() ) {
 			grant_super_admin( $admin );
 		}
 
-		add_filter( 'cbt_file_mods_allowed', '__return_false' );
+		add_filter( 'file_mod_allowed', '__return_false' );
 		$request  = new WP_REST_Request( 'POST', '/create-block-theme/v1/save' );
 		$response = rest_get_server()->dispatch( $request );
-		remove_filter( 'cbt_file_mods_allowed', '__return_false' );
+		remove_filter( 'file_mod_allowed', '__return_false' );
 
 		if ( is_multisite() ) {
 			revoke_super_admin( $admin );
@@ -119,11 +89,12 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 		wp_set_current_user( $admin );
 
 		// /font-families is a GET and is NOT gated by can_modify_theme().
-		// Even with file mods disallowed, it should still respond (not 403).
-		add_filter( 'cbt_file_mods_allowed', '__return_false' );
+		// Even with file mods disallowed by the canonical filter, it should
+		// still respond (not 403).
+		add_filter( 'file_mod_allowed', '__return_false' );
 		$request  = new WP_REST_Request( 'GET', '/create-block-theme/v1/font-families' );
 		$response = rest_get_server()->dispatch( $request );
-		remove_filter( 'cbt_file_mods_allowed', '__return_false' );
+		remove_filter( 'file_mod_allowed', '__return_false' );
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 'SUCCESS', $response->get_data()['status'] );
@@ -147,7 +118,7 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 			$this->markTestSkipped( 'requires multisite — set WP_TESTS_MULTISITE=1' );
 		}
 		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
-		// Explicitly NOT a super-admin.
+		// Explicitly NOT a super-admin — `edit_themes` is super-admin-only on multisite.
 		wp_set_current_user( $admin );
 
 		$this->assertFalse( $this->invoke_private( 'can_modify_theme' ) );

--- a/tests/test-class-create-block-theme-api.php
+++ b/tests/test-class-create-block-theme-api.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @package Create_Block_Theme
+ */
+class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
+
+	/**
+	 * Helper: invoke a private method on a CBT_Theme_API instance.
+	 */
+	private function invoke_private( $method ) {
+		$instance = new CBT_Theme_API();
+		$ref      = new ReflectionMethod( $instance, $method );
+		$ref->setAccessible( true );
+		return $ref->invoke( $instance );
+	}
+
+	public function test_admin_can_modify_theme_on_single_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'single-site only' );
+		}
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		$this->assertTrue( $this->invoke_private( 'can_modify_theme' ) );
+	}
+
+	public function test_editor_cannot_modify_theme_on_single_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'single-site only' );
+		}
+		$editor = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor );
+
+		$this->assertFalse( $this->invoke_private( 'can_modify_theme' ) );
+	}
+
+	public function test_anonymous_cannot_modify_theme() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( $this->invoke_private( 'can_modify_theme' ) );
+	}
+
+	public function test_admin_blocked_when_file_mods_disallowed() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'single-site only' );
+		}
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		add_filter( 'cbt_file_mods_allowed', '__return_false' );
+		$result = $this->invoke_private( 'can_modify_theme' );
+		remove_filter( 'cbt_file_mods_allowed', '__return_false' );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_file_mods_allowed_returns_true_by_default() {
+		$this->assertTrue( $this->invoke_private( 'file_mods_allowed' ) );
+	}
+
+	public function test_file_mods_allowed_filter_can_disable() {
+		add_filter( 'cbt_file_mods_allowed', '__return_false' );
+		$result = $this->invoke_private( 'file_mods_allowed' );
+		remove_filter( 'cbt_file_mods_allowed', '__return_false' );
+
+		$this->assertFalse( $result );
+	}
+}

--- a/tests/test-class-create-block-theme-api.php
+++ b/tests/test-class-create-block-theme-api.php
@@ -97,7 +97,8 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		remove_filter( 'cbt_file_mods_allowed', '__return_false' );
 
-		$this->assertNotSame( 403, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'SUCCESS', $response->get_data()['status'] );
 	}
 
 	public function test_super_admin_can_modify_theme_on_multisite() {

--- a/tests/test-class-create-block-theme-api.php
+++ b/tests/test-class-create-block-theme-api.php
@@ -66,6 +66,17 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 		$this->assertFalse( $result );
 	}
 
+	public function test_file_mods_allowed_respects_core_file_mod_allowed_filter() {
+		// WordPress Core's canonical `file_mod_allowed` filter is the
+		// mechanism hosts and security plugins use to disable file mods
+		// globally. file_mods_allowed() must honour it.
+		add_filter( 'file_mod_allowed', '__return_false' );
+		$result = $this->invoke_private( 'file_mods_allowed' );
+		remove_filter( 'file_mod_allowed', '__return_false' );
+
+		$this->assertFalse( $result );
+	}
+
 	public function test_save_endpoint_rejects_when_file_mods_disallowed() {
 		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin );

--- a/tests/test-class-create-block-theme-api.php
+++ b/tests/test-class-create-block-theme-api.php
@@ -174,11 +174,16 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 	}
 
 	public function test_editor_sidebar_enqueue_gated_by_can_modify_theme() {
-		// As above, CBT_Editor_Tools::create_block_theme_sidebar_enqueue()
-		// returns early when wp_is_block_theme() is false (or when $pagenow
-		// is not site-editor.php). Set up a block theme + the right pagenow,
-		// then assert the enqueue happens with the gate open and drops out
-		// once file_mod_allowed denies.
+		// CBT_Editor_Tools::create_block_theme_sidebar_enqueue() has two
+		// early-return guards before the cap check: wp_is_block_theme() and
+		// $pagenow === 'site-editor.php'. Prove the cap gate (and not one of
+		// those guards) is what drops the script by:
+		//   1. Activating a block theme (so wp_is_block_theme() would pass)
+		//   2. Setting $pagenow = 'site-editor.php' (so the pagenow guard would pass)
+		//   3. Denying file_mod_allowed and calling the enqueue
+		// The enqueue must short-circuit at the cap check WITHOUT touching
+		// the asset include further down — we don't run the gate-open path
+		// because the test runner doesn't build the plugin assets.
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'single-site only — multisite gate is covered by edit_themes super-admin check' );
 		}
@@ -192,20 +197,16 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 		$saved_pagenow = $pagenow;
 		$pagenow       = 'site-editor.php';
 
-		$tools = new CBT_Editor_Tools();
 		try {
-			// Gate open: script IS enqueued (proves we cleared wp_is_block_theme()).
-			wp_dequeue_script( 'create-block-theme-slot-fill' );
-			wp_deregister_script( 'create-block-theme-slot-fill' );
-			$tools->create_block_theme_sidebar_enqueue();
-			$this->assertTrue(
-				wp_script_is( 'create-block-theme-slot-fill', 'enqueued' ),
-				'Sidebar script should enqueue on a block theme when the user can modify the theme.'
-			);
+			// Sanity-check both early-return guards would NOT trigger — this
+			// proves the cap check is the only thing that can drop the script.
+			$this->assertTrue( wp_is_block_theme(), 'wp_is_block_theme() must be true so the block-theme guard would not drop the enqueue.' );
+			$this->assertSame( 'site-editor.php', $pagenow, '$pagenow must be site-editor.php so the pagenow guard would not drop the enqueue.' );
 
-			// Gate denied: script is NOT enqueued.
+			$tools = new CBT_Editor_Tools();
 			wp_dequeue_script( 'create-block-theme-slot-fill' );
 			wp_deregister_script( 'create-block-theme-slot-fill' );
+
 			add_filter( 'file_mod_allowed', '__return_false' );
 			$tools->create_block_theme_sidebar_enqueue();
 			$enqueued_after_deny = wp_script_is( 'create-block-theme-slot-fill', 'enqueued' );

--- a/tests/test-class-create-block-theme-api.php
+++ b/tests/test-class-create-block-theme-api.php
@@ -69,12 +69,18 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 	public function test_save_endpoint_rejects_when_file_mods_disallowed() {
 		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin );
+		if ( is_multisite() ) {
+			grant_super_admin( $admin );
+		}
 
 		add_filter( 'cbt_file_mods_allowed', '__return_false' );
 		$request  = new WP_REST_Request( 'POST', '/create-block-theme/v1/save' );
 		$response = rest_get_server()->dispatch( $request );
 		remove_filter( 'cbt_file_mods_allowed', '__return_false' );
 
+		if ( is_multisite() ) {
+			revoke_super_admin( $admin );
+		}
 		$this->assertSame( 403, $response->get_status() );
 		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
 	}

--- a/tests/test-class-create-block-theme-api.php
+++ b/tests/test-class-create-block-theme-api.php
@@ -77,6 +77,16 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 		$this->assertFalse( $result );
 	}
 
+	public function test_file_mods_allowed_filter_cannot_reenable_core_disallow() {
+		add_filter( 'file_mod_allowed', '__return_false' );
+		add_filter( 'cbt_file_mods_allowed', '__return_true' );
+		$result = $this->invoke_private( 'file_mods_allowed' );
+		remove_filter( 'cbt_file_mods_allowed', '__return_true' );
+		remove_filter( 'file_mod_allowed', '__return_false' );
+
+		$this->assertFalse( $result );
+	}
+
 	public function test_save_endpoint_rejects_when_file_mods_disallowed() {
 		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin );

--- a/tests/test-class-create-block-theme-api.php
+++ b/tests/test-class-create-block-theme-api.php
@@ -99,4 +99,42 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 
 		$this->assertNotSame( 403, $response->get_status() );
 	}
+
+	public function test_super_admin_can_modify_theme_on_multisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'requires multisite — set WP_TESTS_MULTISITE=1' );
+		}
+		$super = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $super );
+		wp_set_current_user( $super );
+
+		$this->assertTrue( $this->invoke_private( 'can_modify_theme' ) );
+
+		revoke_super_admin( $super );
+	}
+
+	public function test_subsite_admin_cannot_modify_theme_on_multisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'requires multisite — set WP_TESTS_MULTISITE=1' );
+		}
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		// Explicitly NOT a super-admin.
+		wp_set_current_user( $admin );
+
+		$this->assertFalse( $this->invoke_private( 'can_modify_theme' ) );
+	}
+
+	public function test_save_endpoint_rejects_subsite_admin_on_multisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'requires multisite — set WP_TESTS_MULTISITE=1' );
+		}
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		$request  = new WP_REST_Request( 'POST', '/create-block-theme/v1/save' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
 }

--- a/tests/test-class-create-block-theme-api.php
+++ b/tests/test-class-create-block-theme-api.php
@@ -127,53 +127,130 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
 	}
 
-	public function test_admin_landing_menu_not_registered_when_cannot_modify_theme() {
+	public function test_admin_landing_menu_gated_by_can_modify_theme() {
+		// CBT_Admin_Landing::create_admin_menu() also returns early when
+		// wp_is_block_theme() is false. To prove the cap gate (and not the
+		// block-theme guard) is what hides the menu, activate a block theme
+		// first, then assert the menu appears when can_modify_theme() passes
+		// and disappears once file_mod_allowed denies.
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'single-site only — multisite gate is covered by edit_themes super-admin check' );
+		}
 		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin );
 
-		add_filter( 'file_mod_allowed', '__return_false' );
-
-		$landing = new CBT_Admin_Landing();
+		$saved_stylesheet = get_stylesheet();
+		$test_theme_slug  = $this->create_blank_theme();
 		set_current_screen( 'themes.php' );
+		$landing = new CBT_Admin_Landing();
+
 		global $submenu;
-		$submenu = array();
-		$landing->create_admin_menu();
-		$menu_after_deny = isset( $submenu['themes.php'] ) ? $submenu['themes.php'] : array();
+		try {
+			// Gate open: menu IS registered (proves we cleared wp_is_block_theme()).
+			$submenu = array();
+			$landing->create_admin_menu();
+			$open_slugs = array_column( isset( $submenu['themes.php'] ) ? $submenu['themes.php'] : array(), 2 );
+			$this->assertContains(
+				'create-block-theme-landing',
+				$open_slugs,
+				'Landing-page menu should register on a block theme when the user can modify the theme.'
+			);
 
-		remove_filter( 'file_mod_allowed', '__return_false' );
+			// Gate denied: menu is NOT registered.
+			add_filter( 'file_mod_allowed', '__return_false' );
+			$submenu = array();
+			$landing->create_admin_menu();
+			$denied_slugs = array_column( isset( $submenu['themes.php'] ) ? $submenu['themes.php'] : array(), 2 );
+			remove_filter( 'file_mod_allowed', '__return_false' );
 
-		$slugs = array_column( $menu_after_deny, 2 );
-		$this->assertNotContains(
-			'create-block-theme-landing',
-			$slugs,
-			'Landing-page menu must NOT be registered when the user cannot modify the theme.'
-		);
+			$this->assertNotContains(
+				'create-block-theme-landing',
+				$denied_slugs,
+				'Landing-page menu must NOT register when the user cannot modify the theme.'
+			);
+		} finally {
+			$this->uninstall_theme( $test_theme_slug, $saved_stylesheet );
+		}
 	}
 
-	public function test_editor_sidebar_enqueue_drops_when_cannot_modify_theme() {
-		// Sub-site admin on multisite or DISALLOW_FILE_MODS site: the sidebar
-		// JS should not enqueue. Simulate by gating via file_mod_allowed.
+	public function test_editor_sidebar_enqueue_gated_by_can_modify_theme() {
+		// As above, CBT_Editor_Tools::create_block_theme_sidebar_enqueue()
+		// returns early when wp_is_block_theme() is false (or when $pagenow
+		// is not site-editor.php). Set up a block theme + the right pagenow,
+		// then assert the enqueue happens with the gate open and drops out
+		// once file_mod_allowed denies.
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'single-site only — multisite gate is covered by edit_themes super-admin check' );
+		}
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		$saved_stylesheet = get_stylesheet();
+		$test_theme_slug  = $this->create_blank_theme();
+
 		global $pagenow;
 		$saved_pagenow = $pagenow;
 		$pagenow       = 'site-editor.php';
 
-		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
-		wp_set_current_user( $admin );
-
-		add_filter( 'file_mod_allowed', '__return_false' );
-
 		$tools = new CBT_Editor_Tools();
-		// Reset any prior enqueue state.
-		wp_dequeue_script( 'create-block-theme-slot-fill' );
-		$tools->create_block_theme_sidebar_enqueue();
-		$enqueued = wp_script_is( 'create-block-theme-slot-fill', 'enqueued' );
+		try {
+			// Gate open: script IS enqueued (proves we cleared wp_is_block_theme()).
+			wp_dequeue_script( 'create-block-theme-slot-fill' );
+			wp_deregister_script( 'create-block-theme-slot-fill' );
+			$tools->create_block_theme_sidebar_enqueue();
+			$this->assertTrue(
+				wp_script_is( 'create-block-theme-slot-fill', 'enqueued' ),
+				'Sidebar script should enqueue on a block theme when the user can modify the theme.'
+			);
 
-		remove_filter( 'file_mod_allowed', '__return_false' );
-		$pagenow = $saved_pagenow;
+			// Gate denied: script is NOT enqueued.
+			wp_dequeue_script( 'create-block-theme-slot-fill' );
+			wp_deregister_script( 'create-block-theme-slot-fill' );
+			add_filter( 'file_mod_allowed', '__return_false' );
+			$tools->create_block_theme_sidebar_enqueue();
+			$enqueued_after_deny = wp_script_is( 'create-block-theme-slot-fill', 'enqueued' );
+			remove_filter( 'file_mod_allowed', '__return_false' );
 
-		$this->assertFalse(
-			$enqueued,
-			'Sidebar script must NOT be enqueued when the user cannot modify the theme.'
-		);
+			$this->assertFalse(
+				$enqueued_after_deny,
+				'Sidebar script must NOT enqueue when the user cannot modify the theme.'
+			);
+		} finally {
+			$pagenow = $saved_pagenow;
+			wp_dequeue_script( 'create-block-theme-slot-fill' );
+			wp_deregister_script( 'create-block-theme-slot-fill' );
+			$this->uninstall_theme( $test_theme_slug, $saved_stylesheet );
+		}
+	}
+
+	/**
+	 * Create + activate a blank block theme using the plugin's own
+	 * /create-blank endpoint, so wp_is_block_theme() returns true. Mirrors
+	 * the helper in tests/test-theme-fonts.php.
+	 */
+	private function create_blank_theme() {
+		$test_theme_slug = 'cbt-api-test-theme';
+		delete_theme( $test_theme_slug );
+
+		$request = new WP_REST_Request( 'POST', '/create-block-theme/v1/create-blank' );
+		$request->set_param( 'name', $test_theme_slug );
+		$request->set_param( 'description', '' );
+		$request->set_param( 'uri', '' );
+		$request->set_param( 'author', '' );
+		$request->set_param( 'author_uri', '' );
+		$request->set_param( 'tags_custom', '' );
+		$request->set_param( 'recommended_plugins', '' );
+		rest_do_request( $request );
+
+		CBT_Theme_JSON_Resolver::clean_cached_data();
+		return $test_theme_slug;
+	}
+
+	private function uninstall_theme( $theme_slug, $restore_stylesheet = null ) {
+		CBT_Theme_JSON_Resolver::write_user_settings( array() );
+		if ( $restore_stylesheet ) {
+			switch_theme( $restore_stylesheet );
+		}
+		delete_theme( $theme_slug );
 	}
 }

--- a/tests/test-class-create-block-theme-api.php
+++ b/tests/test-class-create-block-theme-api.php
@@ -8,8 +8,9 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 	 * Helper: invoke a private method on a CBT_Theme_API instance.
 	 */
 	private function invoke_private( $method ) {
-		$instance = new CBT_Theme_API();
-		$ref      = new ReflectionMethod( $instance, $method );
+		$ref_class = new ReflectionClass( CBT_Theme_API::class );
+		$instance  = $ref_class->newInstanceWithoutConstructor();
+		$ref       = new ReflectionMethod( $instance, $method );
 		$ref->setAccessible( true );
 		return $ref->invoke( $instance );
 	}

--- a/tests/test-class-create-block-theme-api.php
+++ b/tests/test-class-create-block-theme-api.php
@@ -64,4 +64,39 @@ class Test_Create_Block_Theme_Api extends WP_UnitTestCase {
 
 		$this->assertFalse( $result );
 	}
+
+	public function test_save_endpoint_rejects_when_file_mods_disallowed() {
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		add_filter( 'cbt_file_mods_allowed', '__return_false' );
+		$request  = new WP_REST_Request( 'POST', '/create-block-theme/v1/save' );
+		$response = rest_get_server()->dispatch( $request );
+		remove_filter( 'cbt_file_mods_allowed', '__return_false' );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	public function test_save_endpoint_rejects_anonymous() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'POST', '/create-block-theme/v1/save' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	public function test_font_families_endpoint_still_accessible_to_admin() {
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		// /font-families is a GET and is NOT gated by can_modify_theme().
+		// Even with file mods disallowed, it should still respond (not 403).
+		add_filter( 'cbt_file_mods_allowed', '__return_false' );
+		$request  = new WP_REST_Request( 'GET', '/create-block-theme/v1/font-families' );
+		$response = rest_get_server()->dispatch( $request );
+		remove_filter( 'cbt_file_mods_allowed', '__return_false' );
+
+		$this->assertNotSame( 403, $response->get_status() );
+	}
 }


### PR DESCRIPTION
On a multisite, themes are network-shared. This PR tightens the permission check on the 9 filesystem-mutating REST routes in `CBT_Theme_API` so that only super-admins can call them when the site is multisite. The read-only `/font-families` route is unchanged.

Also restores `DISALLOW_FILE_EDIT` / `DISALLOW_FILE_MODS` honouring that the plugin had prior to v2.1.2. Both constants now gate theme-file modifications, matching the behaviour of `wp-admin/theme-editor.php`.

To test, ensure the following tests pass:

```bash
  npm run test:unit:php -- --filter Test_Create_Block_Theme_Api