### PR TITLE
Strip PHP execution tags from pattern body content

### DIFF
--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -21,9 +21,8 @@ class CBT_Theme_Patterns {
 	 * would strip the plugin's own localization helpers and break the
 	 * "Make text translation-ready" feature.
 	 *
-	 * @param string $content User-supplied body content.
-	 * @return string Same content with PHP open tags removed.
-	 */
+	 * @param mixed $content User-supplied body content.
+	 * @return mixed Same content with PHP open tags removed (when input is a non-empty string).
 	public static function strip_php_tags( $content ) {
 		if ( ! is_string( $content ) || '' === $content ) {
 			return $content;

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -23,6 +23,7 @@ class CBT_Theme_Patterns {
 	 *
 	 * @param mixed $content User-supplied body content.
 	 * @return mixed Same content with PHP open tags removed (when input is a non-empty string).
+	 */
 	public static function strip_php_tags( $content ) {
 		if ( ! is_string( $content ) || '' === $content ) {
 			return $content;

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -9,10 +9,10 @@ class CBT_Theme_Patterns {
 	 * before the body is interpolated into the exported `.php` pattern file.
 	 *
 	 * This helper is `public static` because it is invoked from two pipelines:
-	 *  - `pattern_from_wp_block()` in this class (wp_block patterns), where
+	 *  1. `pattern_from_wp_block()` in this class (wp_block patterns), where
 	 *    sanitisation happens BEFORE `prepare_pattern_for_export()` injects
 	 *    trusted `<?php esc_*_e(...);?>` markers.
-	 *  - `CBT_Theme_Templates::prepare_template_for_export()` (templates and
+	 *  -2. `CBT_Theme_Templates::prepare_template_for_export()` (templates and
 	 *    template parts), where sanitisation must happen at the very start —
 	 *    BEFORE `escape_text_in_template()` injects the same trusted markers.
 	 *

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -8,14 +8,23 @@ class CBT_Theme_Patterns {
 	 * legacy variants) in user content is treated as malicious and removed
 	 * before the body is interpolated into the exported `.php` pattern file.
 	 *
-	 * Note: the plugin's own `escape_text_for_pattern()` injects trusted PHP
-	 * into the body LATER in the export pipeline (via `prepare_pattern_for_export`).
-	 * Sanitisation here happens BEFORE that, so trusted PHP is not stripped.
+	 * This helper is `public static` because it is invoked from two pipelines:
+	 *  - `pattern_from_wp_block()` in this class (wp_block patterns), where
+	 *    sanitisation happens BEFORE `prepare_pattern_for_export()` injects
+	 *    trusted `<?php esc_*_e(...);?>` markers.
+	 *  - `CBT_Theme_Templates::prepare_template_for_export()` (templates and
+	 *    template parts), where sanitisation must happen at the very start —
+	 *    BEFORE `escape_text_in_template()` injects the same trusted markers.
+	 *
+	 * In both cases the rule is: sanitise first, inject trusted PHP second,
+	 * build the heredoc third. Calling this AFTER the trusted-PHP injection
+	 * would strip the plugin's own localization helpers and break the
+	 * "Make text translation-ready" feature.
 	 *
 	 * @param string $content User-supplied body content.
 	 * @return string Same content with PHP open tags removed.
 	 */
-	private static function strip_php_tags( $content ) {
+	public static function strip_php_tags( $content ) {
 		if ( ! is_string( $content ) || '' === $content ) {
 			return $content;
 		}
@@ -37,11 +46,20 @@ class CBT_Theme_Patterns {
 		return $content;
 	}
 
+	/**
+	 * Build a pattern .php file from a template stdClass.
+	 *
+	 * IMPORTANT: this function expects `$template->content` to be already
+	 * sanitised by the caller. The pipeline entry point is
+	 * `CBT_Theme_Templates::prepare_template_for_export`, which strips PHP
+	 * tags from `$template->content` BEFORE the trusted-PHP injection done
+	 * by `escape_text_in_template`. Calling `pattern_from_template` with
+	 * un-sanitised user content would re-introduce the PHP injection bug.
+	 */
 	public static function pattern_from_template( $template, $new_slug = null ) {
 		$theme_slug      = $new_slug ? $new_slug : wp_get_theme()->get( 'TextDomain' );
 		$template_slug   = str_replace( '*/', '*&#47;', $template->slug );
 		$pattern_slug    = $theme_slug . '/' . $template_slug;
-		$safe_body       = self::strip_php_tags( $template->content );
 		$pattern_content = <<<PHP
 		<?php
 		/**
@@ -50,7 +68,7 @@ class CBT_Theme_Patterns {
 		 * Inserter: no
 		 */
 		?>
-		{$safe_body}
+		{$template->content}
 		PHP;
 
 		return array(

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -1,6 +1,34 @@
 <?php
 
 class CBT_Theme_Patterns {
+	/**
+	 * Strip PHP execution tags from user-supplied pattern body content.
+	 *
+	 * Block patterns are HTML/block markup, not PHP. Any `<?php` (or short/
+	 * legacy variants) in user content is treated as malicious and removed
+	 * before the body is interpolated into the exported `.php` pattern file.
+	 *
+	 * Note: the plugin's own `escape_text_for_pattern()` injects trusted PHP
+	 * into the body LATER in the export pipeline (via `prepare_pattern_for_export`).
+	 * Sanitisation here happens BEFORE that, so trusted PHP is not stripped.
+	 *
+	 * @param string $content User-supplied body content.
+	 * @return string Same content with PHP open tags removed.
+	 */
+	private static function strip_php_tags( $content ) {
+		if ( ! is_string( $content ) || '' === $content ) {
+			return $content;
+		}
+
+		// Standard PHP open tags: <?php, <?=, <? (short tag).
+		// `php\b` matches <?php followed by a non-word char (PHP's grammar).
+		// `=` matches <?=. The lookahead `(?=\s)` and end-anchor `$` together
+		// catch the bare short tag <? followed by whitespace or EOF.
+		$content = preg_replace( '/<\?(?:php\b|=|(?=\s)|$)/i', '', $content );
+
+		return $content;
+	}
+
 	public static function pattern_from_template( $template, $new_slug = null ) {
 		$theme_slug      = $new_slug ? $new_slug : wp_get_theme()->get( 'TextDomain' );
 		$template_slug   = str_replace( '*/', '*&#47;', $template->slug );
@@ -32,6 +60,7 @@ class CBT_Theme_Patterns {
 		$pattern->categories   = ! empty( $pattern_category_list ) ? join( ', ', wp_list_pluck( $pattern_category_list, 'name' ) ) : '';
 		$pattern_title         = str_replace( '*/', '*&#47;', $pattern->title );
 		$pattern_categories    = str_replace( '*/', '*&#47;', $pattern->categories );
+		$safe_body             = self::strip_php_tags( $pattern_post->post_content );
 		$pattern->content      = <<<PHP
 		<?php
 		/**
@@ -40,7 +69,7 @@ class CBT_Theme_Patterns {
 		 * Categories: {$pattern_categories}
 		 */
 		?>
-		{$pattern_post->post_content}
+		{$safe_body}
 		PHP;
 
 		return $pattern;

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -20,11 +20,13 @@ class CBT_Theme_Patterns {
 			return $content;
 		}
 
-		// Standard PHP open tags: <?php, <?=, <? (short tag).
-		// `php\b` matches <?php followed by a non-word char (PHP's grammar).
-		// `=` matches <?=. The lookahead `(?=\s)` and end-anchor `$` together
-		// catch the bare short tag <? followed by whitespace or EOF.
-		$content = preg_replace( '/<\?(?:php\b|=|(?=\s)|$)/i', '', $content );
+		// Strip ANY `<?` open tag, with a single carve-out for `<?xml` (the
+		// XML declaration, which appears in legitimate SVG content). Without
+		// the negative lookahead, hosts with `short_open_tag=1` would still
+		// execute `<?$x=…`, `<?(…)`, `<?"…"`, `<?//comment`, `<?/*comment*/`,
+		// `<?;`, etc. — none of which match `<?php` or `<?=` literally but
+		// all of which PHP's parser recognises as open tags.
+		$content = preg_replace( '/<\?(?!xml\b)/i', '', $content );
 
 		return $content;
 	}

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -28,6 +28,12 @@ class CBT_Theme_Patterns {
 		// all of which PHP's parser recognises as open tags.
 		$content = preg_replace( '/<\?(?!xml\b)/i', '', $content );
 
+		// Strip legacy `<script language="php">…</script>` blocks. PHP 7+
+		// removed this parser, but custom SAPIs / polyfills could still
+		// honour it. Match the entire block (opening tag → closing tag,
+		// inclusive of inner content).
+		$content = preg_replace( '#<script\s+language\s*=\s*["\']?php["\']?[^>]*>.*?</script>#is', '', $content );
+
 		return $content;
 	}
 

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -12,7 +12,7 @@ class CBT_Theme_Patterns {
 	 *  1. `pattern_from_wp_block()` in this class (wp_block patterns), where
 	 *    sanitisation happens BEFORE `prepare_pattern_for_export()` injects
 	 *    trusted `<?php esc_*_e(...);?>` markers.
-	 *  -2. `CBT_Theme_Templates::prepare_template_for_export()` (templates and
+	 *  2. `CBT_Theme_Templates::prepare_template_for_export()` (templates and
 	 *    template parts), where sanitisation must happen at the very start —
 	 *    BEFORE `escape_text_in_template()` injects the same trusted markers.
 	 *

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -29,13 +29,13 @@ class CBT_Theme_Patterns {
 			return $content;
 		}
 
-		// Strip ANY `<?` open tag, with a single carve-out for `<?xml` (the
-		// XML declaration, which appears in legitimate SVG content). Without
-		// the negative lookahead, hosts with `short_open_tag=1` would still
-		// execute `<?$x=…`, `<?(…)`, `<?"…"`, `<?//comment`, `<?/*comment*/`,
-		// `<?;`, etc. — none of which match `<?php` or `<?=` literally but
-		// all of which PHP's parser recognises as open tags.
-		$content = preg_replace( '/<\?(?!xml\b)/i', '', $content );
+		// Strip ANY `<?` open tag. On hosts with `short_open_tag=1`, PHP parses
+		// `<?` followed by `$`, `(`, `"`, `//`, `/*`, `;`, or `xml` as an open
+		// tag — preserving any of them would either re-execute as PHP or
+		// produce a fatal parse error when the exported `.php` file is loaded.
+		// Block patterns are HTML/block markup, so there's no legitimate
+		// `<?xml` content to preserve.
+		$content = preg_replace( '/<\?/', '', $content );
 
 		// Strip legacy `<script language="php">…</script>` blocks. PHP 7+
 		// removed this parser, but custom SAPIs / polyfills could still

--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -41,6 +41,7 @@ class CBT_Theme_Patterns {
 		$theme_slug      = $new_slug ? $new_slug : wp_get_theme()->get( 'TextDomain' );
 		$template_slug   = str_replace( '*/', '*&#47;', $template->slug );
 		$pattern_slug    = $theme_slug . '/' . $template_slug;
+		$safe_body       = self::strip_php_tags( $template->content );
 		$pattern_content = <<<PHP
 		<?php
 		/**
@@ -49,7 +50,7 @@ class CBT_Theme_Patterns {
 		 * Inserter: no
 		 */
 		?>
-		{$template->content}
+		{$safe_body}
 		PHP;
 
 		return array(

--- a/includes/create-theme/theme-templates.php
+++ b/includes/create-theme/theme-templates.php
@@ -169,12 +169,9 @@ class CBT_Theme_Templates {
 			);
 		}
 
-		// Strip attacker-supplied PHP from the raw template body BEFORE any
-		// trusted-PHP injection (escape_text_in_template below). This was
-		// previously done inside pattern_from_template, but that path runs
-		// AFTER escape_text_in_template — so trusted markers were being
-		// stripped along with attacker payloads. Sanitising here preserves
-		// the legitimate localization output.
+		// Strip PHP tags from the raw template body BEFORE any
+		// trusted-PHP injection (escape_text_in_template below).
+		// Sanitising here preserves the legitimate localization output.
 		$template->content = CBT_Theme_Patterns::strip_php_tags( $template->content );
 
 		$template = self::eliminate_environment_specific_content( $template, $options );

--- a/includes/create-theme/theme-templates.php
+++ b/includes/create-theme/theme-templates.php
@@ -169,6 +169,14 @@ class CBT_Theme_Templates {
 			);
 		}
 
+		// Strip attacker-supplied PHP from the raw template body BEFORE any
+		// trusted-PHP injection (escape_text_in_template below). This was
+		// previously done inside pattern_from_template, but that path runs
+		// AFTER escape_text_in_template — so trusted markers were being
+		// stripped along with attacker payloads. Sanitising here preserves
+		// the legitimate localization output.
+		$template->content = CBT_Theme_Patterns::strip_php_tags( $template->content );
+
 		$template = self::eliminate_environment_specific_content( $template, $options );
 
 		if ( array_key_exists( 'localizeText', $options ) && $options['localizeText'] ) {

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -170,24 +170,41 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 	}
 
 	public function test_pattern_from_template_strips_php_open_tag() {
+		// Sanitisation now lives in prepare_template_for_export (the public
+		// entry point), not in pattern_from_template itself. Exercise the
+		// pipeline that the export code actually uses.
 		$template          = new stdClass();
 		$template->slug    = 'test-template';
 		$template->content = '<p>safe</p><?php phpinfo(); ?>';
-		$result            = CBT_Theme_Patterns::pattern_from_template( $template );
-		$body              = substr( $result['content'], strpos( $result['content'], '?>' ) + 2 );
 
-		$this->assertStringNotContainsString( '<?php', $body );
-		$this->assertStringContainsString( '<p>safe</p>', $body );
+		$options = array(
+			'localizeText'   => false,
+			'localizeImages' => false,
+			'removeNavRefs'  => false,
+		);
+
+		$result = CBT_Theme_Templates::prepare_template_for_export( $template, null, $options );
+
+		$this->assertStringNotContainsString( '<?php', $result->content );
+		$this->assertStringContainsString( '<p>safe</p>', $result->content );
 	}
 
 	public function test_pattern_from_template_strips_script_language_php() {
+		// Sanitisation now lives in prepare_template_for_export (the public
+		// entry point), not in pattern_from_template itself.
 		$template          = new stdClass();
 		$template->slug    = 'test-template';
 		$template->content = '<p>safe</p><script language="php">phpinfo();</script>';
-		$result            = CBT_Theme_Patterns::pattern_from_template( $template );
-		$body              = substr( $result['content'], strpos( $result['content'], '?>' ) + 2 );
 
-		$this->assertStringNotContainsString( '<script', $body );
+		$options = array(
+			'localizeText'   => false,
+			'localizeImages' => false,
+			'removeNavRefs'  => false,
+		);
+
+		$result = CBT_Theme_Templates::prepare_template_for_export( $template, null, $options );
+
+		$this->assertStringNotContainsString( '<script', $result->content );
 	}
 
 	public function test_pattern_from_template_preserves_legitimate_block_markup() {
@@ -209,5 +226,54 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 		// PR #817 escapes `*/` in the slug to `*&#47;`. Confirm still in effect.
 		$this->assertStringContainsString( '*&#47;', $result['content'] );
 		$this->assertStringNotContainsString( 'evil */ break', $result['content'] );
+	}
+
+	public function test_prepare_template_for_export_preserves_trusted_localize_markers() {
+		// When localizeText=true is enabled, CBT_Theme_Templates::escape_text_in_template
+		// injects trusted PHP esc_html_e(...) markers into the template body.
+		// Those trusted markers MUST survive the pattern export — only attacker-injected
+		// PHP should be stripped, not the plugin's own translation helpers.
+		$template          = new stdClass();
+		$template->slug    = 'test-localize';
+		$template->content = '<!-- wp:paragraph --><p>Hello world</p><!-- /wp:paragraph -->';
+
+		$options = array(
+			'localizeText'   => true,
+			'localizeImages' => false,
+			'removeNavRefs'  => false,
+		);
+
+		$result = CBT_Theme_Templates::prepare_template_for_export( $template, null, $options );
+
+		// After export with localizeText=true, the pattern body should contain
+		// a trusted PHP esc_html_e marker INCLUDING its opening tag. If the
+		// strip is wrongly applied, the opening tag is gone, leaving a broken
+		// fragment in the HTML body.
+		$this->assertNotEmpty( $result->pattern, 'paternize_template should populate ->pattern when trusted PHP is injected' );
+		$this->assertStringContainsString( "<?php esc_html_e('Hello world'", $result->pattern, 'Trusted localization marker (with PHP open tag) must survive sanitisation' );
+	}
+
+	public function test_prepare_template_for_export_still_strips_attacker_php() {
+		// Even with localizeText off, attacker PHP in template content MUST be stripped
+		// before paternize / heredoc construction.
+		$template          = new stdClass();
+		$template->slug    = 'test-attacker';
+		$template->content = '<!-- wp:paragraph --><p>safe</p><!-- /wp:paragraph --><?php phpinfo(); ?>';
+
+		$options = array(
+			'localizeText'   => false,
+			'localizeImages' => false,
+			'removeNavRefs'  => false,
+		);
+
+		$result = CBT_Theme_Templates::prepare_template_for_export( $template, null, $options );
+
+		// paternize_template only runs when content contains a PHP open tag.
+		// The strip should have removed it BEFORE paternize ran, so ->pattern
+		// should be unset and ->content should be the original block markup
+		// with the open tag removed. Note: residual `phpinfo` text remains in
+		// the body but is inert HTML once the open tag is gone.
+		$this->assertStringNotContainsString( '<?php', $result->content, 'Attacker PHP open tag must be stripped' );
+		$this->assertFalse( isset( $result->pattern ), 'paternize_template should not run once the attacker open tag is stripped' );
 	}
 }

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -276,4 +276,53 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<?php', $result->content, 'Attacker PHP open tag must be stripped' );
 		$this->assertFalse( isset( $result->pattern ), 'paternize_template should not run once the attacker open tag is stripped' );
 	}
+
+	public function test_add_patterns_to_theme_writes_sanitised_body_to_disk() {
+		// Use whatever theme is currently active in the test environment.
+		// wp-env bootstraps with a working block theme so writes succeed.
+		$patterns_dir          = get_stylesheet_directory() . '/patterns';
+		$expected_pattern_path = $patterns_dir . '/cbt-pattern-rce-probe.php';
+
+		// Track whether we created the patterns/ directory (for cleanup).
+		$created_patterns_dir = ! is_dir( $patterns_dir );
+
+		// Make sure the destination doesn't pre-exist from a prior run.
+		if ( file_exists( $expected_pattern_path ) ) {
+			unlink( $expected_pattern_path );
+		}
+
+		// Create a malicious wp_block post. We bypass KSES the same way the
+		// other tests in this class do (via the make_wp_block_post helper) —
+		// this simulates an Editor user who has the `unfiltered_html` cap.
+		$this->make_wp_block_post(
+			'<p>safe</p><?php file_put_contents("/tmp/cbt_should_not_be_written.txt", "pwned"); ?>',
+			'CBT Pattern RCE Probe'
+		);
+
+		// Run the export. NOTE: add_patterns_to_theme calls wp_delete_post on the
+		// source wp_block at the end — that's intentional plugin behaviour; we
+		// don't need to clean up the post ourselves.
+		CBT_Theme_Patterns::add_patterns_to_theme();
+
+		// Assert the file was written.
+		$this->assertFileExists( $expected_pattern_path, 'Pattern file should have been written to the active theme' );
+
+		// Assert the body of the file does NOT contain executable PHP outside
+		// the metadata docblock.
+		$contents = file_get_contents( $expected_pattern_path );
+		$body     = substr( $contents, strpos( $contents, '?>' ) + 2 );
+
+		$this->assertStringNotContainsString( '<?php', $body, 'Body of generated pattern file must not contain <?php' );
+		$this->assertStringContainsString( '<p>safe</p>', $body, 'Legitimate markup must survive sanitisation' );
+
+		// Cleanup: remove the generated pattern file, and the patterns/ dir if we created it.
+		unlink( $expected_pattern_path );
+		if ( $created_patterns_dir && is_dir( $patterns_dir ) && count( scandir( $patterns_dir ) ) === 2 ) {
+			rmdir( $patterns_dir );
+		}
+
+		// Final paranoia: assert the marker file was NOT written (i.e. the
+		// stripped PHP never executed).
+		$this->assertFileDoesNotExist( '/tmp/cbt_should_not_be_written.txt' );
+	}
 }

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -130,13 +130,9 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 
 	public function test_strip_php_tags_handles_non_string_input() {
 		// Defensive guard — non-string input should not cause errors.
-		// Exercise strip_php_tags() via pattern_from_wp_block() to cover the integration path.
-		$post               = new stdClass();
-		$post->ID           = 0;
-		$post->post_title   = 'Stub';
-		$post->post_content = null;
-		// Should not throw — but pattern_from_wp_block also reads other fields,
-		// so use a real wp_block post and then null out post_content.
+		// Build a real wp_block post (so pattern_from_wp_block can read its other
+		// fields) and then null out post_content to exercise the strip_php_tags
+		// non-string path.
 		$real_post               = $this->make_wp_block_post( '<p>safe</p>' );
 		$real_post->post_content = null;
 		$pattern                 = CBT_Theme_Patterns::pattern_from_wp_block( $real_post );

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -276,27 +276,31 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 	}
 
 	public function test_add_patterns_to_theme_writes_sanitised_body_to_disk() {
-		// Use whatever theme is currently active in the test environment.
-		// wp-env bootstraps with a working block theme so writes succeed.
-		$patterns_dir          = get_stylesheet_directory() . '/patterns';
-		$expected_pattern_path = $patterns_dir . '/cbt-pattern-rce-probe.php';
+		// Run inside a fresh test theme so the side effects of
+		// add_patterns_to_theme — including replace_local_pattern_references()
+		// rewriting existing template/pattern files and clear_user_*_customizations
+		// deleting user-template posts — are scoped to a throwaway directory
+		// and don't pollute subsequent tests in the suite.
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
 
-		// Track whether we created the patterns/ directory (for cleanup).
-		$created_patterns_dir = ! is_dir( $patterns_dir );
+		$test_theme_slug = $this->create_blank_theme();
 
-		// Make sure the destination and marker file don't pre-exist from a prior run.
-		if ( file_exists( $expected_pattern_path ) ) {
-			unlink( $expected_pattern_path );
-		}
-		if ( file_exists( '/tmp/cbt_should_not_be_written.txt' ) ) {
-			unlink( '/tmp/cbt_should_not_be_written.txt' );
+		$expected_pattern_path = get_stylesheet_directory() . '/patterns/cbt-pattern-rce-probe.php';
+		$marker                = '/tmp/cbt_should_not_be_written.txt';
+
+		// The marker file lives outside the theme directory, so uninstall_theme
+		// can't reach it — pre-delete defensively in case a prior failed run
+		// left it behind.
+		if ( file_exists( $marker ) ) {
+			unlink( $marker );
 		}
 
 		// Create a malicious wp_block post. We bypass KSES the same way the
 		// other tests in this class do (via the make_wp_block_post helper) —
 		// this simulates an Editor user who has the `unfiltered_html` cap.
 		$this->make_wp_block_post(
-			'<p>safe</p><?php file_put_contents("/tmp/cbt_should_not_be_written.txt", "pwned"); ?>',
+			'<p>safe</p><?php file_put_contents("' . $marker . '", "pwned"); ?>',
 			'CBT Pattern RCE Probe'
 		);
 
@@ -316,14 +320,47 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<?php', $body, 'Body of generated pattern file must not contain <?php' );
 		$this->assertStringContainsString( '<p>safe</p>', $body, 'Legitimate markup must survive sanitisation' );
 
-		// Cleanup: remove the generated pattern file, and the patterns/ dir if we created it.
-		unlink( $expected_pattern_path );
-		if ( $created_patterns_dir && is_dir( $patterns_dir ) && count( scandir( $patterns_dir ) ) === 2 ) {
-			rmdir( $patterns_dir );
-		}
-
 		// Final paranoia: assert the marker file was NOT written (i.e. the
 		// stripped PHP never executed).
-		$this->assertFileDoesNotExist( '/tmp/cbt_should_not_be_written.txt' );
+		$this->assertFileDoesNotExist( $marker );
+
+		// Cleanup — uninstall_theme removes the entire test theme directory,
+		// taking patterns/, templates/, parts/, etc. with it.
+		$this->uninstall_theme( $test_theme_slug );
+	}
+
+	/**
+	 * Create a fresh test theme via the plugin's REST endpoint and activate it.
+	 *
+	 * Mirrors the helper in Test_Create_Block_Theme_Fonts so this test class
+	 * can isolate side effects of theme-modifying operations.
+	 */
+	private function create_blank_theme() {
+		$test_theme_slug = 'cbttesttheme';
+
+		delete_theme( $test_theme_slug );
+
+		$request = new WP_REST_Request( 'POST', '/create-block-theme/v1/create-blank' );
+		$request->set_param( 'name', $test_theme_slug );
+		$request->set_param( 'description', '' );
+		$request->set_param( 'uri', '' );
+		$request->set_param( 'author', '' );
+		$request->set_param( 'author_uri', '' );
+		$request->set_param( 'tags_custom', '' );
+		$request->set_param( 'recommended_plugins', '' );
+
+		rest_do_request( $request );
+
+		CBT_Theme_JSON_Resolver::clean_cached_data();
+
+		return $test_theme_slug;
+	}
+
+	/**
+	 * Tear down the test theme created by create_blank_theme().
+	 */
+	private function uninstall_theme( $theme_slug ) {
+		CBT_Theme_JSON_Resolver::write_user_settings( array() );
+		delete_theme( $theme_slug );
 	}
 }

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -129,9 +129,8 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 	}
 
 	public function test_strip_php_tags_handles_non_string_input() {
-		// Defensive guard — non-string input should round-trip without error.
-		// We can't call the private helper directly; exercise it via
-		// pattern_from_wp_block by constructing a post stub with non-string content.
+		// Defensive guard — non-string input should not cause errors.
+		// Exercise strip_php_tags() via pattern_from_wp_block() to cover the integration path.
 		$post               = new stdClass();
 		$post->ID           = 0;
 		$post->post_title   = 'Stub';

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -93,7 +93,7 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 
 	public function test_pattern_from_wp_block_strips_short_tag_followed_by_non_letter() {
 		// Short-tag bypasses recognised by PHP when short_open_tag=1. The body
-		// after sanitisation must NOT contain ANY `<?` followed by non-`xml`.
+		// after sanitisation must NOT contain ANY `<?` open tag.
 		$payloads = array(
 			'<p>safe</p><?$x = phpinfo(); ?>',
 			'<p>safe</p><?(phpinfo()); ?>',
@@ -113,16 +113,19 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_pattern_from_wp_block_preserves_xml_declaration() {
-		// The XML declaration `<` + `?xml version="1.0"` + `?` + `>` is
-		// legitimate (appears in SVG content in block markup) and MUST
-		// survive sanitisation.
-		$safe    = '<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3"/></svg>';
-		$post    = $this->make_wp_block_post( $safe );
+	public function test_pattern_from_wp_block_strips_xml_declaration() {
+		// XML declarations are parsed as a short PHP open tag on hosts with
+		// short_open_tag=1, producing a fatal parse error when the exported
+		// pattern is loaded. Block patterns do not legitimately contain XML
+		// declarations, so they are stripped along with PHP tags.
+		$payload = '<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3"/></svg>';
+		$post    = $this->make_wp_block_post( $payload );
 		$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
 		$body    = substr( $pattern->content, strpos( $pattern->content, '?>' ) + 2 );
 
-		$this->assertStringContainsString( '<?xml', $body );
+		$this->assertStringNotContainsString( '<?xml', $body );
+		// The surrounding SVG markup survives — only the `<?` open tag is removed.
+		$this->assertStringContainsString( '<svg', $body );
 	}
 
 	public function test_strip_php_tags_handles_non_string_input() {

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -286,9 +286,12 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 		// Track whether we created the patterns/ directory (for cleanup).
 		$created_patterns_dir = ! is_dir( $patterns_dir );
 
-		// Make sure the destination doesn't pre-exist from a prior run.
+		// Make sure the destination and marker file don't pre-exist from a prior run.
 		if ( file_exists( $expected_pattern_path ) ) {
 			unlink( $expected_pattern_path );
+		}
+		if ( file_exists( '/tmp/cbt_should_not_be_written.txt' ) ) {
+			unlink( '/tmp/cbt_should_not_be_written.txt' );
 		}
 
 		// Create a malicious wp_block post. We bypass KSES the same way the

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -140,4 +140,32 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 		$pattern                 = CBT_Theme_Patterns::pattern_from_wp_block( $real_post );
 		$this->assertNotNull( $pattern );
 	}
+
+	public function test_pattern_from_wp_block_strips_script_language_php() {
+		$payloads = array(
+			'<p>safe</p><script language="php">phpinfo();</script>',
+			'<p>safe</p><script language=\'php\'>phpinfo();</script>',
+			'<p>safe</p><script language=php>phpinfo();</script>',
+			'<p>safe</p><script LANGUAGE="PHP">phpinfo();</script>',
+		);
+		foreach ( $payloads as $payload ) {
+			$post    = $this->make_wp_block_post( $payload );
+			$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+			$body    = substr( $pattern->content, strpos( $pattern->content, '?>' ) + 2 );
+
+			$this->assertStringNotContainsString( 'phpinfo', $body, "Inner PHP should be stripped: $payload" );
+			$this->assertStringNotContainsString( '<script', $body, "Opening <script tag should be stripped: $payload" );
+		}
+	}
+
+	public function test_pattern_from_wp_block_preserves_unrelated_script_tags() {
+		// `<script type="application/json">` and similar non-PHP scripts are legitimate
+		// in block markup and MUST NOT be stripped.
+		$safe    = '<script type="application/json">{"a":1}</script>';
+		$post    = $this->make_wp_block_post( '<p>safe</p>' . $safe );
+		$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+		$body    = substr( $pattern->content, strpos( $pattern->content, '?>' ) + 2 );
+
+		$this->assertStringContainsString( $safe, $body );
+	}
 }

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @package Create_Block_Theme
+ */
+class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
+
+	/**
+	 * Helper: build a wp_block post with the given content, return it as the
+	 * stdClass `pattern_from_wp_block` expects (post object from the loop).
+	 *
+	 * KSES filters are temporarily removed during insertion so the raw payload
+	 * survives storage. This simulates an Editor with `unfiltered_html`
+	 * (default capability on single-site WordPress), which is the threat model
+	 * the strip_php_tags() helper defends against.
+	 */
+	private function make_wp_block_post( $content, $title = 'Test Pattern' ) {
+		kses_remove_filters();
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_title'   => $title,
+				'post_content' => $content,
+			)
+		);
+		kses_init_filters();
+		return get_post( $post_id );
+	}
+
+	public function test_pattern_from_wp_block_strips_php_open_tag() {
+		$post    = $this->make_wp_block_post( '<p>safe</p><?php phpinfo(); ?>' );
+		$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+
+		// The metadata docblock at the top legitimately contains "<?php".
+		// Strip that header before checking the body.
+		$body = substr( $pattern->content, strpos( $pattern->content, '?>' ) + 2 );
+
+		$this->assertStringNotContainsString( '<?php', $body );
+		$this->assertStringContainsString( '<p>safe</p>', $body );
+	}
+
+	public function test_pattern_from_wp_block_strips_short_open_tag() {
+		$post    = $this->make_wp_block_post( '<p>safe</p><?= "rce" ?>' );
+		$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+		$body    = substr( $pattern->content, strpos( $pattern->content, '?>' ) + 2 );
+
+		$this->assertStringNotContainsString( '<?=', $body );
+		$this->assertStringNotContainsString( '<?', $body, 'No PHP open tag of any kind should remain in the body' );
+	}
+
+	public function test_pattern_from_wp_block_strips_bare_short_open_tag() {
+		$post    = $this->make_wp_block_post( '<p>safe</p><? echo 1; ?>' );
+		$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+		$body    = substr( $pattern->content, strpos( $pattern->content, '?>' ) + 2 );
+
+		$this->assertStringNotContainsString( '<? ', $body );
+	}
+
+	public function test_pattern_from_wp_block_strips_uppercase_php_tag() {
+		$post    = $this->make_wp_block_post( '<p>safe</p><?PHP phpinfo(); ?>' );
+		$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+		$body    = substr( $pattern->content, strpos( $pattern->content, '?>' ) + 2 );
+
+		$this->assertStringNotContainsString( '<?PHP', $body );
+		$this->assertStringNotContainsString( '<?php', $body );
+	}
+
+	public function test_pattern_from_wp_block_preserves_legitimate_block_markup() {
+		$safe    = '<!-- wp:paragraph --><p>hello world</p><!-- /wp:paragraph -->';
+		$post    = $this->make_wp_block_post( $safe );
+		$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+
+		$this->assertStringContainsString( $safe, $pattern->content );
+	}
+
+	public function test_pattern_from_wp_block_preserves_metadata_php_block() {
+		// The wrapper PHP docblock MUST survive; only the body is stripped.
+		$post    = $this->make_wp_block_post( '<p>safe</p>' );
+		$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+
+		$this->assertStringContainsString( '<?php', $pattern->content );
+		$this->assertStringContainsString( 'Title:', $pattern->content );
+	}
+
+	public function test_pattern_from_wp_block_keeps_title_escape_intact() {
+		$post    = $this->make_wp_block_post( '<p>safe</p>', 'evil */ break' );
+		$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+
+		// PR #817 escapes `*/` in the title to `*&#47;`. Confirm still in effect.
+		$this->assertStringContainsString( '*&#47;', $pattern->content );
+		$this->assertStringNotContainsString( 'evil */ break', $pattern->content );
+	}
+}

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -249,7 +249,7 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 		// a trusted PHP esc_html_e marker INCLUDING its opening tag. If the
 		// strip is wrongly applied, the opening tag is gone, leaving a broken
 		// fragment in the HTML body.
-		$this->assertNotEmpty( $result->pattern, 'paternize_template should populate ->pattern when trusted PHP is injected' );
+		$this->assertTrue( isset( $result->pattern ) && '' !== $result->pattern, 'paternize_template should populate ->pattern when trusted PHP is injected' );
 		$this->assertStringContainsString( "<?php esc_html_e('Hello world'", $result->pattern, 'Trusted localization marker (with PHP open tag) must survive sanitisation' );
 	}
 

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -168,4 +168,46 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( $safe, $body );
 	}
+
+	public function test_pattern_from_template_strips_php_open_tag() {
+		$template          = new stdClass();
+		$template->slug    = 'test-template';
+		$template->content = '<p>safe</p><?php phpinfo(); ?>';
+		$result            = CBT_Theme_Patterns::pattern_from_template( $template );
+		$body              = substr( $result['content'], strpos( $result['content'], '?>' ) + 2 );
+
+		$this->assertStringNotContainsString( '<?php', $body );
+		$this->assertStringContainsString( '<p>safe</p>', $body );
+	}
+
+	public function test_pattern_from_template_strips_script_language_php() {
+		$template          = new stdClass();
+		$template->slug    = 'test-template';
+		$template->content = '<p>safe</p><script language="php">phpinfo();</script>';
+		$result            = CBT_Theme_Patterns::pattern_from_template( $template );
+		$body              = substr( $result['content'], strpos( $result['content'], '?>' ) + 2 );
+
+		$this->assertStringNotContainsString( '<script', $body );
+	}
+
+	public function test_pattern_from_template_preserves_legitimate_block_markup() {
+		$safe              = '<!-- wp:paragraph --><p>hello</p><!-- /wp:paragraph -->';
+		$template          = new stdClass();
+		$template->slug    = 'test-template';
+		$template->content = $safe;
+		$result            = CBT_Theme_Patterns::pattern_from_template( $template );
+
+		$this->assertStringContainsString( $safe, $result['content'] );
+	}
+
+	public function test_pattern_from_template_keeps_slug_escape_intact() {
+		$template          = new stdClass();
+		$template->slug    = 'evil */ break';
+		$template->content = '<p>safe</p>';
+		$result            = CBT_Theme_Patterns::pattern_from_template( $template );
+
+		// PR #817 escapes `*/` in the slug to `*&#47;`. Confirm still in effect.
+		$this->assertStringContainsString( '*&#47;', $result['content'] );
+		$this->assertStringNotContainsString( 'evil */ break', $result['content'] );
+	}
 }

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -90,4 +90,54 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 		$this->assertStringContainsString( '*&#47;', $pattern->content );
 		$this->assertStringNotContainsString( 'evil */ break', $pattern->content );
 	}
+
+	public function test_pattern_from_wp_block_strips_short_tag_followed_by_non_letter() {
+		// Short-tag bypasses recognised by PHP when short_open_tag=1. The body
+		// after sanitisation must NOT contain ANY `<?` followed by non-`xml`.
+		$payloads = array(
+			'<p>safe</p><?$x = phpinfo(); ?>',
+			'<p>safe</p><?(phpinfo()); ?>',
+			'<p>safe</p><?"" . phpinfo(); ?>',
+			'<p>safe</p><?//comment' . "\n" . 'phpinfo(); ?>',
+			'<p>safe</p><?/*comment*/ phpinfo(); ?>',
+			'<p>safe</p><?;phpinfo(); ?>',
+		);
+		foreach ( $payloads as $payload ) {
+			$post    = $this->make_wp_block_post( $payload );
+			$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+			$body    = substr( $pattern->content, strpos( $pattern->content, '?>' ) + 2 );
+
+			// The security property is that the `<?` open tag is removed —
+			// once neutralised, any residual `phpinfo` text is inert HTML.
+			$this->assertStringNotContainsString( '<?', $body, "Short-tag bypass survived: $payload" );
+		}
+	}
+
+	public function test_pattern_from_wp_block_preserves_xml_declaration() {
+		// The XML declaration `<` + `?xml version="1.0"` + `?` + `>` is
+		// legitimate (appears in SVG content in block markup) and MUST
+		// survive sanitisation.
+		$safe    = '<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3"/></svg>';
+		$post    = $this->make_wp_block_post( $safe );
+		$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+		$body    = substr( $pattern->content, strpos( $pattern->content, '?>' ) + 2 );
+
+		$this->assertStringContainsString( '<?xml', $body );
+	}
+
+	public function test_strip_php_tags_handles_non_string_input() {
+		// Defensive guard — non-string input should round-trip without error.
+		// We can't call the private helper directly; exercise it via
+		// pattern_from_wp_block by constructing a post stub with non-string content.
+		$post               = new stdClass();
+		$post->ID           = 0;
+		$post->post_title   = 'Stub';
+		$post->post_content = null;
+		// Should not throw — but pattern_from_wp_block also reads other fields,
+		// so use a real wp_block post and then null out post_content.
+		$real_post               = $this->make_wp_block_post( '<p>safe</p>' );
+		$real_post->post_content = null;
+		$pattern                 = CBT_Theme_Patterns::pattern_from_wp_block( $real_post );
+		$this->assertNotNull( $pattern );
+	}
 }


### PR DESCRIPTION
Strip PHP open tags from user-supplied pattern body content before it's interpolated into exported `.php` pattern files. Builds on #817, which closed the docblock-breakout vector in the title/categories/slug fields. This PR closes the equivalent vector in the body field.

To test, ensure these tests pass:

 ```bash
  npm run test:unit:php -- --filter Test_Create_Block_Theme_Patterns