### PR TITLE
Media: Use unique placeholders during export

### DIFF
--- a/includes/create-theme/theme-media.php
+++ b/includes/create-theme/theme-media.php
@@ -462,8 +462,12 @@ class CBT_Theme_Media {
 		// but accepts a leading `/` unchanged. The path uses characters
 		// that wp_json_encode leaves untouched as well.
 		$placeholders     = array();
-		$next_placeholder = static function ( $raw ) use ( &$placeholders ) {
-			$id                  = '/__cbt-local-media-' . count( $placeholders ) . '__';
+		$source_content   = $template->content;
+		$next_placeholder = static function ( $raw ) use ( &$placeholders, $source_content ) {
+			do {
+				$id = '/__cbt-local-media-' . wp_generate_uuid4() . '-' . count( $placeholders ) . '__/';
+			} while ( false !== strpos( $source_content, $id ) || isset( $placeholders[ $id ] ) );
+
 			$placeholders[ $id ] = $raw;
 			return $id;
 		};

--- a/tests/test-theme-media.php
+++ b/tests/test-theme-media.php
@@ -331,6 +331,28 @@ class Test_Create_Block_Theme_Media extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '/assets/images/not-copied.png', $new_template->content );
 	}
 
+	public function test_make_template_images_local_preserves_placeholder_like_content() {
+		$template          = new stdClass();
+		$template->content = '
+			<!-- wp:paragraph {"metadata":{"name":"/__cbt-local-media-0__/"}} -->
+			<p>Keep /__cbt-local-media-0__/ unchanged.</p>
+			<!-- /wp:paragraph -->
+			<!-- wp:image -->
+			<figure class="wp-block-image"><img src="http://example.com/copied.png" alt="" /></figure>
+			<!-- /wp:image -->
+		';
+
+		$new_template = CBT_Theme_Media::make_template_images_local(
+			$template,
+			array( 'http://example.com/copied.png' )
+		);
+
+		$this->assertStringContainsString( '"name":"/__cbt-local-media-0__/"', $new_template->content );
+		$this->assertStringContainsString( 'Keep /__cbt-local-media-0__/ unchanged.', $new_template->content );
+		$this->assertStringContainsString( '/assets/images/copied.png', $new_template->content );
+		$this->assertStringNotContainsString( '__cbt-local-media-', str_replace( '/__cbt-local-media-0__/', '', $new_template->content ) );
+	}
+
 	public function test_prepare_template_for_export_leaves_unvalidated_media_remote() {
 		$template          = new stdClass();
 		$template->slug    = 'test-template';


### PR DESCRIPTION
## Summary

Use unique temporary placeholders when localizing media URLs during theme export.

This keeps placeholder-like text and block metadata unchanged while preserving normal media localization.

## Test plan

- [x] `vendor/bin/phpunit -c phpunit.xml.dist --verbose --filter Test_Create_Block_Theme_Media`
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/create-theme/theme-media.php tests/test-theme-media.php`
- [x] Confirmed placeholder-like content remains unchanged and localized media still uses the theme asset URL.
