### PR TITLE
i18n: Escape decoded HTML attributes

### DIFF
--- a/includes/create-theme/theme-locale.php
+++ b/includes/create-theme/theme-locale.php
@@ -152,11 +152,9 @@ class CBT_Theme_Locale {
 			return $string;
 		}
 
-		$string = self::escape_php_single_quoted_string( $string );
-
 		$p = new CBT_Token_Processor( $string );
 		$p->process_tokens();
-		$text             = $p->get_text();
+		$text             = self::escape_php_single_quoted_string( $p->get_text() );
 		$tokens           = $p->get_tokens();
 		$translators_note = $p->get_translators_note();
 		$text_domain      = self::escape_php_single_quoted_string( wp_get_theme()->get( 'TextDomain' ) );
@@ -176,7 +174,7 @@ class CBT_Theme_Locale {
 			return $php_tag;
 		}
 
-		return "<?php esc_html_e('" . $string . "', '$text_domain');?>";
+		return "<?php esc_html_e('" . $text . "', '$text_domain');?>";
 	}
 
 	/**

--- a/includes/create-theme/theme-locale.php
+++ b/includes/create-theme/theme-locale.php
@@ -174,7 +174,8 @@ class CBT_Theme_Locale {
 			return $php_tag;
 		}
 
-		return "<?php esc_html_e('" . $text . "', '$text_domain');?>";
+		$string = self::escape_php_single_quoted_string( $string );
+		return "<?php esc_html_e('" . $string . "', '$text_domain');?>";
 	}
 
 	/**

--- a/includes/create-theme/theme-token-processor.php
+++ b/includes/create-theme/theme-token-processor.php
@@ -10,6 +10,16 @@ class CBT_Token_Processor {
 	private $increment        = 0;
 
 	/**
+	 * Escape a value embedded in a generated PHP single-quoted string.
+	 *
+	 * @param string $value The value to escape.
+	 * @return string The escaped value.
+	 */
+	private function escape_php_single_quoted_string( $value ) {
+		return addcslashes( (string) $value, "\\'" );
+	}
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $string The string to process.
@@ -93,14 +103,18 @@ class CBT_Token_Processor {
 		} elseif ( 'src' === $attr_name ) {
 			$added_media = CBT_Theme_Media::add_media_to_local( array( $attr_value ) );
 			if ( in_array( $attr_value, $added_media, true ) ) {
-				$relative_src = CBT_Theme_Media::get_media_relative_path_from_url( $attr_value );
+				$relative_src = $this->escape_php_single_quoted_string( CBT_Theme_Media::get_media_relative_path_from_url( $attr_value ) );
 				$attr_value   = "' . esc_url( get_stylesheet_directory_uri() ) . '{$relative_src}";
+			} else {
+				$attr_value = $this->escape_php_single_quoted_string( $attr_value );
 			}
 			$token_part .= ' ' . $attr_name . '="' . $attr_value . '"';
 		} elseif ( 'href' === $attr_name ) {
+			$attr_value  = $this->escape_php_single_quoted_string( $attr_value );
 			$attr_value  = "' . esc_url( '$attr_value' ) . '";
 			$token_part .= ' ' . $attr_name . '="' . $attr_value . '"';
 		} else {
+			$attr_value  = $this->escape_php_single_quoted_string( $attr_value );
 			$token_part .= ' ' . $attr_name . '="' . $attr_value . '"';
 		}
 

--- a/tests/CbtThemeLocale/escapeTextContent.php
+++ b/tests/CbtThemeLocale/escapeTextContent.php
@@ -62,6 +62,35 @@ class CBT_Theme_Locale_EscapeTextContent extends CBT_Theme_Locale_UnitTestCase {
 		$this->assert_php_code_does_not_call_function( 'system', $escaped_string );
 	}
 
+	/**
+	 * @dataProvider data_html_attribute_apostrophe_entities
+	 */
+	public function test_escape_text_content_escapes_decoded_href_values( $attribute_value, $decoded_value ) {
+		$string         = '<a href="' . $attribute_value . '">Read</a>';
+		$escaped_string = $this->call_private_method( 'escape_text_content', array( $string ) );
+		$expected_value = addcslashes( $decoded_value, "\\'" );
+
+		$this->assertStringContainsString( "esc_url( '$expected_value' )", $escaped_string );
+	}
+
+	public function data_html_attribute_apostrophe_entities() {
+		return array(
+			'raw apostrophe'            => array( "https://example.com/it's", "https://example.com/it's" ),
+			'decimal entity'            => array( 'https://example.com/it&#39;s', "https://example.com/it's" ),
+			'hexadecimal entity'        => array( 'https://example.com/it&#x27;s', "https://example.com/it's" ),
+			'named apostrophe entity'   => array( 'https://example.com/it&apos;s', "https://example.com/it's" ),
+			'named double quote entity' => array( 'https://example.com/a&quot;b', 'https://example.com/a"b' ),
+			'backslash before entity'   => array( 'https://example.com/it\\&#39;s', "https://example.com/it\\'s" ),
+		);
+	}
+
+	public function test_escape_text_content_escapes_decoded_generic_attribute_values() {
+		$string         = '<span title="It&apos;s ready">Read</span>';
+		$escaped_string = $this->call_private_method( 'escape_text_content', array( $string ) );
+
+		$this->assertStringContainsString( "title=\"It\\'s ready\"", $escaped_string );
+	}
+
 	public function test_escape_text_content_with_already_escaped_string() {
 		$string         = "<?php esc_html_e('This is a test text.', 'test-locale-theme');?>";
 		$escaped_string = $this->call_private_method( 'escape_text_content', array( $string ) );


### PR DESCRIPTION
## Summary

Escape HTML attribute values after token processing during localized export.

This preserves encoded quotes and backslashes after the HTML processor decodes attribute values.

## Test plan

- [x] `vendor/bin/phpunit -c phpunit.xml.dist --verbose --group locale`
- [x] `vendor/bin/phpunit -c phpunit.xml.dist --verbose --filter 'CBT_Theme_Locale_EscapeTextContent|test_token_processor'`
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/create-theme/theme-locale.php includes/create-theme/theme-token-processor.php tests/CbtThemeLocale/escapeTextContent.php`
- [x] Confirmed encoded attribute values remain inert and generated pattern PHP stays parse-clean.
