### PR TITLE
i18n: Preserve block attribute encoding

### DIFF
--- a/includes/create-theme/theme-locale.php
+++ b/includes/create-theme/theme-locale.php
@@ -435,19 +435,19 @@ class CBT_Theme_Locale {
 
 				// If we modified any attributes, re-encode to JSON.
 				if ( $modified ) {
-					$attr_fragments = array();
-					foreach ( $attrs as $attr_name => $attr_value ) {
-						$encoded_attr_name = wp_json_encode( (string) $attr_name, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+					$attrs_for_serialization = $attrs;
+					$replacements            = array();
+					foreach ( $localized_attrs as $attr_name => $localized_value ) {
+						do {
+							$placeholder = '__CBT_LOCALIZED_ATTRIBUTE_' . wp_generate_uuid4() . '__';
+						} while ( false !== strpos( $attrs_json, $placeholder ) || isset( $replacements[ '"' . $placeholder . '"' ] ) );
 
-						if ( array_key_exists( $attr_name, $localized_attrs ) ) {
-							$attr_fragments[] = $encoded_attr_name . ':' . wp_json_encode( $localized_attrs[ $attr_name ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
-							continue;
-						}
-
-						$attr_fragments[] = $encoded_attr_name . ':' . wp_json_encode( $attr_value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+						$attrs_for_serialization[ $attr_name ]    = $placeholder;
+						$replacements[ '"' . $placeholder . '"' ] = wp_json_encode( $localized_value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
 					}
 
-					$new_attrs_json = '{' . implode( ',', $attr_fragments ) . '}';
+					$new_attrs_json = serialize_block_attributes( $attrs_for_serialization );
+					$new_attrs_json = strtr( $new_attrs_json, $replacements );
 					return '<!-- wp:' . $block_name . ' ' . $new_attrs_json . ' ' . $self_closer . '-->';
 				}
 

--- a/tests/CbtThemeLocale/escapeBlockAttributes.php
+++ b/tests/CbtThemeLocale/escapeBlockAttributes.php
@@ -103,6 +103,26 @@ class CBT_Theme_Locale_EscapeBlockAttributes extends CBT_Theme_Locale_UnitTestCa
 		$this->assert_search_block_attributes_json_decodes( $escaped_markup );
 	}
 
+	public function test_escape_block_attributes_preserves_core_encoding_for_other_attributes() {
+		$block_markup = '<!-- wp:navigation-link ' . serialize_block_attributes(
+			array(
+				'label' => 'About',
+				'url'   => '<?php echo "kept encoded"; ?>',
+				'title' => 'Keep -- < > & encoded',
+			)
+		) . ' /-->';
+
+		$blocks         = parse_blocks( $block_markup );
+		$escaped_blocks = CBT_Theme_Locale::escape_text_content_of_blocks( $blocks );
+		$escaped_markup = serialize_blocks( $escaped_blocks );
+		$escaped_markup = CBT_Theme_Locale::escape_block_attribute_strings( $escaped_markup );
+
+		$this->assertStringContainsString( '"label":"<?php esc_attr_e(', $escaped_markup );
+		$this->assertStringContainsString( '"url":"\\u003c?php echo \\u0022kept encoded\\u0022; ?\\u003e"', $escaped_markup );
+		$this->assertStringContainsString( '"title":"Keep \\u002d\\u002d \\u003c \\u003e \\u0026 encoded"', $escaped_markup );
+		$this->assertStringNotContainsString( '"url":"<?php', $escaped_markup );
+	}
+
 	public function data_test_escape_block_attributes() {
 		return array(
 


### PR DESCRIPTION
## Summary

Preserve WordPress Core’s encoding for block attributes during localized export.

Only localized values are substituted after serialization, leaving all other attributes encoded consistently with Core.

## Test plan

- [x] `vendor/bin/phpunit -c phpunit.xml.dist --verbose --filter CBT_Theme_Locale_EscapeBlockAttributes`
- [x] `vendor/bin/phpunit -c phpunit.xml.dist --verbose --group locale`
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/create-theme/theme-locale.php tests/CbtThemeLocale/escapeBlockAttributes.php`
- [x] Confirmed localized labels still work and encoded sibling attributes remain unchanged in generated pattern PHP.
