### PR TITLE
Export: Remove image classes by token

### DIFF
--- a/includes/create-theme/theme-templates.php
+++ b/includes/create-theme/theme-templates.php
@@ -340,12 +340,12 @@ class CBT_Theme_Templates {
 				unset( $block['attrs']['id'] );
 				// Remove the matching class token without changing similar text elsewhere.
 				foreach ( $block['innerContent'] as $inner_key => $inner_content ) {
-					if ( is_null( $inner_content ) ) {
+					if ( is_null( $inner_content ) || false === strpos( $inner_content, $image_class ) ) {
 						continue;
 					}
 
 					$processor = new WP_HTML_Tag_Processor( $inner_content );
-					while ( $processor->next_tag() ) {
+					while ( $processor->next_tag( 'img' ) ) {
 						if ( $processor->has_class( $image_class ) ) {
 							$processor->remove_class( $image_class );
 						}

--- a/includes/create-theme/theme-templates.php
+++ b/includes/create-theme/theme-templates.php
@@ -336,14 +336,21 @@ class CBT_Theme_Templates {
 		if ( in_array( $block['blockName'], array( 'core/image', 'core/cover' ), true ) ) {
 			// remove id attribute from image and cover blocks
 			if ( isset( $block['attrs']['id'] ) ) {
-				$image_id = $block['attrs']['id'];
+				$image_class = 'wp-image-' . $block['attrs']['id'];
 				unset( $block['attrs']['id'] );
-				// remove wp-image-[id] class from inner content
+				// Remove the matching class token without changing similar text elsewhere.
 				foreach ( $block['innerContent'] as $inner_key => $inner_content ) {
 					if ( is_null( $inner_content ) ) {
 						continue;
 					}
-					$block['innerContent'][ $inner_key ] = str_replace( 'wp-image-' . $image_id, '', $inner_content );
+
+					$processor = new WP_HTML_Tag_Processor( $inner_content );
+					while ( $processor->next_tag() ) {
+						if ( $processor->has_class( $image_class ) ) {
+							$processor->remove_class( $image_class );
+						}
+					}
+					$block['innerContent'][ $inner_key ] = $processor->__toString();
 				}
 			}
 		}

--- a/tests/test-theme-templates.php
+++ b/tests/test-theme-templates.php
@@ -123,13 +123,13 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 		$template          = new stdClass();
 		$template->content = '
 			<!-- wp:image {"id":635} -->
-			<figure class="wp-block-image"><img class="custom-wp-image-635 wp-image-635" alt=""/><wp-image-635?template data></figure>
+			<figure class="wp-block-image"><img class="custom-wp-image-635 wp-image-635" alt=""/><figcaption>wp-image-635?template data</figcaption></figure>
 			<!-- /wp:image -->
 		';
 		$new_template      = CBT_Theme_Templates::eliminate_environment_specific_content( $template );
 
 		$this->assertStringContainsString( 'class="custom-wp-image-635"', $new_template->content );
-		$this->assertStringContainsString( '<wp-image-635?template data>', $new_template->content );
+		$this->assertStringContainsString( '<figcaption>wp-image-635?template data</figcaption>', $new_template->content );
 		$this->assertStringNotContainsString( ' wp-image-635"', $new_template->content );
 	}
 

--- a/tests/test-theme-templates.php
+++ b/tests/test-theme-templates.php
@@ -119,6 +119,20 @@ class Test_Create_Block_Theme_Templates extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'wp-image-635', $new_template->content );
 	}
 
+	public function test_eliminate_image_id_only_removes_matching_class_token() {
+		$template          = new stdClass();
+		$template->content = '
+			<!-- wp:image {"id":635} -->
+			<figure class="wp-block-image"><img class="custom-wp-image-635 wp-image-635" alt=""/><wp-image-635?template data></figure>
+			<!-- /wp:image -->
+		';
+		$new_template      = CBT_Theme_Templates::eliminate_environment_specific_content( $template );
+
+		$this->assertStringContainsString( 'class="custom-wp-image-635"', $new_template->content );
+		$this->assertStringContainsString( '<wp-image-635?template data>', $new_template->content );
+		$this->assertStringNotContainsString( ' wp-image-635"', $new_template->content );
+	}
+
 	public function test_eliminate_taxQuery_from_query_loop() {
 		$template          = new stdClass();
 		$template->content = '


### PR DESCRIPTION
## Summary

Remove environment-specific image classes through the HTML processor during export.

This limits the cleanup to the matching class token and preserves similar text elsewhere in block markup.

## Test plan

- [x] `vendor/bin/phpunit -c phpunit.xml.dist --verbose --filter Test_Create_Block_Theme_Templates`
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/create-theme/theme-templates.php tests/test-theme-templates.php`
- [x] Confirmed the image ID and matching class are removed while similar markup remains unchanged.
