### PR TITLE
Export: Stabilize pattern sanitization

### DIFF
--- a/includes/create-theme/theme-patterns.php
+++ b/includes/create-theme/theme-patterns.php
@@ -29,19 +29,21 @@ class CBT_Theme_Patterns {
 			return $content;
 		}
 
-		// Strip ANY `<?` open tag. On hosts with `short_open_tag=1`, PHP parses
-		// `<?` followed by `$`, `(`, `"`, `//`, `/*`, `;`, or `xml` as an open
-		// tag — preserving any of them would either re-execute as PHP or
-		// produce a fatal parse error when the exported `.php` file is loaded.
-		// Block patterns are HTML/block markup, so there's no legitimate
-		// `<?xml` content to preserve.
-		$content = preg_replace( '/<\?/', '', $content );
+		// Repeat until stable because removing one sequence can bring adjacent
+		// fragments together and expose another sequence for the next pass.
+		do {
+			$previous_content = $content;
 
-		// Strip legacy `<script language="php">…</script>` blocks. PHP 7+
-		// removed this parser, but custom SAPIs / polyfills could still
-		// honour it. Match the entire block (opening tag → closing tag,
-		// inclusive of inner content).
-		$content = preg_replace( '#<script\s+language\s*=\s*["\']?php["\']?[^>]*>.*?</script>#is', '', $content );
+			// Strip ANY `<?` open tag. On hosts with `short_open_tag=1`, PHP parses
+			// `<?` followed by `$`, `(`, `"`, `//`, `/*`, `;`, or `xml` as an open
+			// tag. Block patterns are HTML/block markup, so there's no legitimate
+			// `<?xml` content to preserve.
+			$content = preg_replace( '/<\?/', '', $content );
+
+			// Strip legacy `<script language="php">…</script>` blocks. Match the
+			// entire block, including its inner content.
+			$content = preg_replace( '#<script\s+language\s*=\s*["\']?php["\']?[^>]*>.*?</script>#is', '', $content );
+		} while ( $content !== $previous_content );
 
 		return $content;
 	}

--- a/tests/test-theme-patterns.php
+++ b/tests/test-theme-patterns.php
@@ -178,6 +178,24 @@ class Test_Create_Block_Theme_Patterns extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_pattern_from_wp_block_stabilizes_overlapping_open_tags() {
+		$post    = $this->make_wp_block_post( '<p>safe</p><<??template data' );
+		$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+		$body    = substr( $pattern->content, strpos( $pattern->content, '?>' ) + 2 );
+
+		$this->assertStringNotContainsString( '<?', $body );
+		$this->assertStringContainsString( '<p>safe</p>', $body );
+	}
+
+	public function test_pattern_from_wp_block_stabilizes_after_legacy_script_removal() {
+		$post    = $this->make_wp_block_post( '<p>safe</p><<script language="php">bridge</script>?template data' );
+		$pattern = CBT_Theme_Patterns::pattern_from_wp_block( $post );
+		$body    = substr( $pattern->content, strpos( $pattern->content, '?>' ) + 2 );
+
+		$this->assertStringNotContainsString( '<?', $body );
+		$this->assertStringContainsString( '<p>safe</p>', $body );
+	}
+
 	public function test_pattern_from_wp_block_preserves_unrelated_script_tags() {
 		// `<script type="application/json">` and similar non-PHP scripts are legitimate
 		// in block markup and MUST NOT be stripped.


### PR DESCRIPTION
## Summary

Repeat pattern sanitization until the exported content is stable.

This keeps adjacent fragments from forming a new removable sequence after an earlier replacement.

## Test plan

- [x] `vendor/bin/phpunit -c phpunit.xml.dist --verbose --filter Test_Create_Block_Theme_Patterns`
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/create-theme/theme-patterns.php tests/test-theme-patterns.php`
- [x] Confirmed overlapping and legacy-script variants remain parse-clean while ordinary block markup is preserved.
